### PR TITLE
feat: PostListItem 컴포넌트 구현

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -18,7 +18,6 @@ export const parameters = {
   controls: {
     matchers: {
       color: /(background|color)$/i,
-      date: /Date$/,
     },
   },
 };

--- a/frontend/src/components/PostListItem/index.stories.tsx
+++ b/frontend/src/components/PostListItem/index.stories.tsx
@@ -1,4 +1,4 @@
-import PostListItem from '.';
+import PostListItem, { PostListItemProp } from '.';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 export default {
@@ -6,7 +6,14 @@ export default {
   component: PostListItem,
 } as ComponentMeta<typeof PostListItem>;
 
-const Template = (args: any) => <PostListItem {...args} />;
+const Template = (args: PostListItemProp) => <PostListItem {...args} />;
 
 export const PostListItemTemplate: ComponentStory<typeof PostListItem> = Template.bind({});
-PostListItemTemplate.args = {};
+PostListItemTemplate.args = {
+  title: '오늘 날씨 좋네요!',
+  localDate: {
+    date: '2022-07-05',
+    time: '15:00',
+  },
+  content: '안녕?',
+};

--- a/frontend/src/components/PostListItem/index.styles.ts
+++ b/frontend/src/components/PostListItem/index.styles.ts
@@ -20,6 +20,11 @@ export const TitleContainer = styled.div`
 export const Title = styled.p`
   font-size: 24px;
   font-family: 'BMHANNAPro';
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 270px;
+  white-space: nowrap;
 `;
 
 export const Date = styled.span`
@@ -31,6 +36,7 @@ export const ContentContainer = styled.div`
   padding: 1em;
   border-radius: 5px;
   background-color: ${props => props.theme.colors.gray_100};
+  height: 110px;
 `;
 
 export const Content = styled.p`

--- a/frontend/src/components/PostListItem/index.tsx
+++ b/frontend/src/components/PostListItem/index.tsx
@@ -1,20 +1,24 @@
 import * as Styled from './index.styles';
+import timeConverter from '@/utils/timeConverter';
 
-const PostListItem = () => {
+export interface PostListItemProp {
+  title: string;
+  localDate: {
+    date: string;
+    time: string;
+  };
+  content: string;
+}
+
+const PostListItem = ({ title, localDate, content }: PostListItemProp) => {
   return (
     <Styled.Container>
       <Styled.TitleContainer>
-        <Styled.Title>오늘 날씨 맑네여.</Styled.Title>
-        <Styled.Date>20분전</Styled.Date>
+        <Styled.Title>{title}</Styled.Title>
+        <Styled.Date>{timeConverter(localDate)}</Styled.Date>
       </Styled.TitleContainer>
       <Styled.ContentContainer>
-        <Styled.Content>
-          안녕?안녕?안녕?안녕?
-          <br />
-          안녕?안녕?안녕?안녕?안녕?
-          <br />
-          안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?안녕?
-        </Styled.Content>
+        <Styled.Content>{content}</Styled.Content>
       </Styled.ContentContainer>
     </Styled.Container>
   );

--- a/frontend/src/utils/timeConverter.ts
+++ b/frontend/src/utils/timeConverter.ts
@@ -1,0 +1,21 @@
+const options = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+} as const;
+
+const timeConverter = (localDate: { date: string; time: string }): string => {
+  const postDate = new Date(localDate.date + 'T' + localDate.time);
+  const sec = (Date.now() - +postDate) / 1000;
+  const date = Math.floor(sec / 60 / 60 / 24);
+  const hour = Math.floor(sec / 60 / 60);
+  const min = Math.floor(sec / 60);
+
+  if (date > 5) return new Intl.DateTimeFormat('ko-KR', options).format(postDate);
+  if (hour >= 24) return date + '일 전';
+  if (min >= 60) return hour + '시간 전';
+  if (sec >= 60) return min + '분 전';
+  return '방금 전';
+};
+
+export default timeConverter;


### PR DESCRIPTION
### 구현기능

<img width="458" alt="스크린샷 2022-07-05 오후 4 01 07" src="https://user-images.githubusercontent.com/52737532/177268975-6b4e9e5e-316c-4cfa-92cf-ffc1dffb017e.png">


- PostListItem 컴포넌트 기능을 구현한다.

### 세부 구현기능

- [x]  글에 대한 제목, 내용, 작성 시간을 인자로 받아 보여준다. 
- [x] API response에 따라 작성 시간을 표기한다. 
 
```
- 0분 전 => 방금 전
- 1분 전~59분 전 
- 1시간 전~23시간 전
- 1일 전~ 5일 전
- 위를 제외한 이전 시간대는 날짜로 표기 (2022년 07월 05일)
```

### 관련이슈

close #13 

