### PR TITLE
fix: Storybook사용시 SnackBar 오류 해결

### DIFF
--- a/frontend/.storybook/preview-body.html
+++ b/frontend/.storybook/preview-body.html
@@ -1,0 +1,1 @@
+<div id="snackbar"></div>


### PR DESCRIPTION
### 버그 설명

Storybook 사용시 html파일에 snackbar id를 갖는 div 태그가 존재하지 않아 스토리북이 켜지지 않는 오류 발생

### 버그 시나리오 재연

어떤 상황에서 버그가 발생했는지 시나리오를 적어주세요 :  

1. npm run storybook을 한다.
2. Snackbar Template을 클릭한다.
3. 오류가 발생한다.

### 기대 동작

- [x] 정상적으로 Snackbar 렌더된다.

### 관련이슈

close #18 
