### PR TITLE
feat: 페이지 라우팅 기능 구현 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,6 +45,7 @@
         "html-webpack-plugin": "^5.5.0",
         "prettier": "^2.7.1",
         "react-refresh": "^0.14.0",
+        "react-router-dom": "^6.3.0",
         "ts-loader": "^9.3.1",
         "tsconfig-paths-webpack-plugin": "^3.5.2",
         "type-fest": "^2.15.1",
@@ -16210,6 +16211,15 @@
         "node": "*"
       }
     },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -20431,6 +20441,32 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "dev": true,
+      "dependencies": {
+        "history": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "dev": true,
+      "dependencies": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-syntax-highlighter": {
@@ -37456,6 +37492,15 @@
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "dev": true
     },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -40684,6 +40729,25 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
+    },
+    "react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "dev": true,
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "dev": true,
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      }
     },
     "react-syntax-highlighter": {
       "version": "15.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,6 +105,7 @@
     "html-webpack-plugin": "^5.5.0",
     "prettier": "^2.7.1",
     "react-refresh": "^0.14.0",
+    "react-router-dom": "^6.3.0",
     "ts-loader": "^9.3.1",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "type-fest": "^2.15.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,26 @@
+import Header from '@/components/Header';
+import { useContext } from 'react';
+import Snackbar from './components/Snackbar';
+import SnackbarContext from './context/Snackbar';
+import { Route, Routes } from 'react-router-dom';
+import MainPage from './pages/MainPage';
+import PostPage from './pages/PostPage';
+import CreatePostPage from './pages/CreatePostPage';
+
 const App = () => {
-  return <div>App</div>;
+  const { isVisible, message } = useContext(SnackbarContext);
+
+  return (
+    <div>
+      <Header />
+      <Routes>
+        <Route path="/" element={<MainPage />} />
+        <Route path="/post/write" element={<CreatePostPage />} />
+        <Route path="/post/:id" element={<PostPage />} />
+      </Routes>
+      {isVisible && <Snackbar message={message} />}
+    </div>
+  );
 };
 
 export default App;

--- a/frontend/src/components/Header/index.styles.ts
+++ b/frontend/src/components/Header/index.styles.ts
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
 
 export const Container = styled.header`
   width: 100%;
@@ -7,7 +8,7 @@ export const Container = styled.header`
   justify-content: space-between;
 `;
 
-export const LeftSide = styled.div`
+export const LeftSide = styled(Link)`
   display: flex;
   align-items: center;
   gap: 8px;

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -5,7 +5,7 @@ import * as Styled from './index.styles';
 const Header = () => {
   return (
     <Styled.Container>
-      <Styled.LeftSide>
+      <Styled.LeftSide to="/">
         <Logo width={35} height={35} />
         <Styled.Title>속닥속닥</Styled.Title>
       </Styled.LeftSide>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,6 +5,7 @@ import App from './App';
 import { SnackBarContextProvider } from './context/Snackbar';
 import GlobalStyle from './style/GlobalStyle';
 import theme from './style/theme';
+import { BrowserRouter } from 'react-router-dom';
 
 const rootNode = document.getElementById('root') as Element;
 
@@ -12,7 +13,9 @@ ReactDOM.createRoot(rootNode).render(
   <React.StrictMode>
     <SnackBarContextProvider>
       <ThemeProvider theme={theme}>
-        <App />
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
         <GlobalStyle />
       </ThemeProvider>
     </SnackBarContextProvider>

--- a/frontend/src/pages/CreatePostPage/index.stories.tsx
+++ b/frontend/src/pages/CreatePostPage/index.stories.tsx
@@ -1,0 +1,12 @@
+import CreatePostPage from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Pages/CreatePostPage',
+  component: CreatePostPage,
+} as ComponentMeta<typeof CreatePostPage>;
+
+const Template = (args: any) => <CreatePostPage {...args} />;
+
+export const CreatePostPageTemplate: ComponentStory<typeof CreatePostPage> = Template.bind({});
+CreatePostPageTemplate.args = {};

--- a/frontend/src/pages/CreatePostPage/index.styles.ts
+++ b/frontend/src/pages/CreatePostPage/index.styles.ts
@@ -1,0 +1,3 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div``;

--- a/frontend/src/pages/CreatePostPage/index.tsx
+++ b/frontend/src/pages/CreatePostPage/index.tsx
@@ -1,0 +1,7 @@
+import * as Styled from './index.styles';
+
+const CreatePostPage = () => {
+  return <div>CreatePostPage</div>;
+};
+
+export default CreatePostPage;

--- a/frontend/src/pages/MainPage/index.stories.tsx
+++ b/frontend/src/pages/MainPage/index.stories.tsx
@@ -1,0 +1,12 @@
+import MainPage from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Pages/MainPage',
+  component: MainPage,
+} as ComponentMeta<typeof MainPage>;
+
+const Template = (args: any) => <MainPage {...args} />;
+
+export const MainPageTemplate: ComponentStory<typeof MainPage> = Template.bind({});
+MainPageTemplate.args = {};

--- a/frontend/src/pages/MainPage/index.styles.ts
+++ b/frontend/src/pages/MainPage/index.styles.ts
@@ -1,0 +1,3 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div``;

--- a/frontend/src/pages/MainPage/index.tsx
+++ b/frontend/src/pages/MainPage/index.tsx
@@ -1,0 +1,7 @@
+import * as Styled from './index.styles';
+
+const MainPage = () => {
+  return <div>MainPage</div>;
+};
+
+export default MainPage;

--- a/frontend/src/pages/PostPage/index.stories.tsx
+++ b/frontend/src/pages/PostPage/index.stories.tsx
@@ -1,0 +1,12 @@
+import PostPage from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Pages/PostPage',
+  component: PostPage,
+} as ComponentMeta<typeof PostPage>;
+
+const Template = (args: any) => <PostPage {...args} />;
+
+export const PostPageTemplate: ComponentStory<typeof PostPage> = Template.bind({});
+PostPageTemplate.args = {};

--- a/frontend/src/pages/PostPage/index.styles.ts
+++ b/frontend/src/pages/PostPage/index.styles.ts
@@ -1,0 +1,3 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div``;

--- a/frontend/src/pages/PostPage/index.tsx
+++ b/frontend/src/pages/PostPage/index.tsx
@@ -1,0 +1,7 @@
+import * as Styled from './index.styles';
+
+const PostPage = () => {
+  return <Styled.Container>PostPage</Styled.Container>;
+};
+
+export default PostPage;

--- a/frontend/src/style/GlobalStyle.tsx
+++ b/frontend/src/style/GlobalStyle.tsx
@@ -17,6 +17,11 @@ const style = css`
     font-weight: normal;
     font-style: normal;
   }
+
+  a {
+    text-decoration: none;
+    color: black;
+  }
 `;
 
 const GlobalStyle = () => {


### PR DESCRIPTION
### 구현기능

- 페이지 라우팅 기능을 구현한다.

### 세부 구현기능

- [x] react-router-dom을 사용하여 라우팅 기능을 구현한다.
- [x] 글작성, 메인, 글상세보기 이상 세 페이지 간의 페이지 이동 기능을 구현한다.
- [x] 헤더의 로고 클릭시 메인페이지로 이동한다. 

### 관련 이슈

close #20 
