### PR TITLE
feat: MainPage 구현

### DIFF
--- a/frontend/src/components/@styled/Layout/index.tsx
+++ b/frontend/src/components/@styled/Layout/index.tsx
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+const Layout = styled.section`
+  width: 100%;
+  padding: 18px;
+  box-sizing: border-box;
+`;
+
+export default Layout;

--- a/frontend/src/components/FAB/index.styles.ts
+++ b/frontend/src/components/FAB/index.styles.ts
@@ -7,11 +7,16 @@ export const Container = styled.div`
   background-color: ${props => props.theme.colors.sub};
   color: white;
   filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+
   display: flex;
   align-items: center;
   justify-content: center;
+
   font-weight: 500;
   font-size: 30px;
   user-select: none;
   cursor: pointer;
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
 `;

--- a/frontend/src/components/FAB/index.tsx
+++ b/frontend/src/components/FAB/index.tsx
@@ -1,7 +1,11 @@
 import * as Styled from './index.styles';
 
-const FAB = () => {
-  return <Styled.Container>+</Styled.Container>;
+interface FABProps {
+  handleClick: () => void;
+}
+
+const FAB = ({ handleClick }: FABProps) => {
+  return <Styled.Container onClick={handleClick}>+</Styled.Container>;
 };
 
 export default FAB;

--- a/frontend/src/components/Header/index.styles.ts
+++ b/frontend/src/components/Header/index.styles.ts
@@ -6,6 +6,9 @@ export const Container = styled.header`
   height: 50px;
   display: flex;
   justify-content: space-between;
+  padding: 0 20px;
+  margin: 15px 0;
+  box-sizing: border-box;
 `;
 
 export const LeftSide = styled(Link)`

--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -1,0 +1,47 @@
+export const postList: Post[] = [
+  {
+    id: 1,
+    title: '오늘 날씨 맑네요',
+    localDate: {
+      date: '2022-07-05',
+      time: '15:30',
+    },
+    content: '날씨는 참 좋네요.',
+  },
+  {
+    id: 2,
+    title: '오늘 날씨 좋네요',
+    localDate: {
+      date: '2022-07-05',
+      time: '15:30',
+    },
+    content: '어항에 있는 것 같아요.',
+  },
+  {
+    id: 3,
+    title: '오늘 날씨 싫어요',
+    localDate: {
+      date: '2022-07-05',
+      time: '15:30',
+    },
+    content: '싫어? 아냐 나 괜찮아',
+  },
+  {
+    id: 4,
+    title: '오늘 날씨 별로예요',
+    localDate: {
+      date: '2022-07-05',
+      time: '15:30',
+    },
+    content: '어항에 있는 것 같아요',
+  },
+  {
+    id: 5,
+    title: '조시 : 미안하다 진짜',
+    localDate: {
+      date: '2022-07-05',
+      time: '15:30',
+    },
+    content: '미안하다 진짜봇',
+  },
+];

--- a/frontend/src/pages/MainPage/index.styles.ts
+++ b/frontend/src/pages/MainPage/index.styles.ts
@@ -1,3 +1,8 @@
 import styled from '@emotion/styled';
 
-export const Container = styled.div``;
+export const PostListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2em;
+`;

--- a/frontend/src/pages/MainPage/index.tsx
+++ b/frontend/src/pages/MainPage/index.tsx
@@ -1,7 +1,26 @@
 import * as Styled from './index.styles';
+import PostListItem from '@/components/PostListItem';
+import FAB from '@/components/FAB';
+import { useNavigate } from 'react-router-dom';
+import Layout from '@/components/@styled/Layout';
+import { postList } from '@/dummy';
 
 const MainPage = () => {
-  return <div>MainPage</div>;
+  const navigate = useNavigate();
+  const handleClickFAB = () => {
+    navigate('/post/write');
+  };
+
+  return (
+    <Layout>
+      <Styled.PostListContainer>
+        {postList.map(({ id, title, localDate, content }: Post) => (
+          <PostListItem title={title} localDate={localDate} content={content} key={id} />
+        ))}
+      </Styled.PostListContainer>
+      <FAB handleClick={handleClickFAB} />
+    </Layout>
+  );
 };
 
 export default MainPage;

--- a/frontend/src/style.d.ts
+++ b/frontend/src/style.d.ts
@@ -1,7 +1,7 @@
 import '@emotion/react';
 
 declare module '@emotion/react' {
-  export interface Theme {
+  interface Theme {
     colors: {
       main: string;
       sub: string;

--- a/frontend/src/types/post.d.ts
+++ b/frontend/src/types/post.d.ts
@@ -1,0 +1,13 @@
+export {};
+
+declare global {
+  interface Post {
+    id: number;
+    title: string;
+    localDate: {
+      date: string;
+      time: string;
+    };
+    content: string;
+  }
+}


### PR DESCRIPTION
### 구현기능

- 메인 페이지를 구현한다. 

### 세부 구현기능

- [x] 글의 목록을 보여준다.
- [x] 하단의 글 작성 버튼을 클릭하면 글 작성 페이지로 이동한다.
- [x] 글 목록 dummy data를 추가한다.
- [x] Layout 컴포넌트 구현

### 관련 이슈

close #22 
