### PR TITLE
fix: storybook에 routing이 적용 안되는 문제 해결

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -2,7 +2,12 @@ const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
-  addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-interactions'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+    'storybook-addon-react-router-v6',
+  ],
   framework: '@storybook/react',
   core: {
     builder: '@storybook/builder-webpack5',

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,6 +46,7 @@
         "prettier": "^2.7.1",
         "react-refresh": "^0.14.0",
         "react-router-dom": "^6.3.0",
+        "storybook-addon-react-router-v6": "^0.1.10",
         "ts-loader": "^9.3.1",
         "tsconfig-paths-webpack-plugin": "^3.5.2",
         "type-fest": "^2.15.1",
@@ -22367,6 +22368,34 @@
       "integrity": "sha512-CMtO2Uneg3SAz/d6fZ/6qbqqQHi2ynq6/KzMD/26gTkiEShCcpqFfTHgOxsE0egAq6SX3FmN4CeSqn8BzXQkJg==",
       "dev": true
     },
+    "node_modules/storybook-addon-react-router-v6": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/storybook-addon-react-router-v6/-/storybook-addon-react-router-v6-0.1.10.tgz",
+      "integrity": "sha512-eeJUdtELmck3VlUISCgX/3oEwY+/7wzqa4+5BOiYbkp4BKZIEwaQbiSdsmmXzWQLG5zRRNEbgk6dA3tZwV060w==",
+      "dev": true,
+      "dependencies": {
+        "react-inspector": "^5.1.1"
+      },
+      "peerDependencies": {
+        "@storybook/addons": "^6.4.0",
+        "@storybook/api": "^6.4.0",
+        "@storybook/components": "^6.4.0",
+        "@storybook/core-events": "^6.4.0",
+        "@storybook/theming": "^6.4.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-router": "^6.3.0",
+        "react-router-dom": "^6.3.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -42280,6 +42309,15 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.13.2.tgz",
       "integrity": "sha512-CMtO2Uneg3SAz/d6fZ/6qbqqQHi2ynq6/KzMD/26gTkiEShCcpqFfTHgOxsE0egAq6SX3FmN4CeSqn8BzXQkJg==",
       "dev": true
+    },
+    "storybook-addon-react-router-v6": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/storybook-addon-react-router-v6/-/storybook-addon-react-router-v6-0.1.10.tgz",
+      "integrity": "sha512-eeJUdtELmck3VlUISCgX/3oEwY+/7wzqa4+5BOiYbkp4BKZIEwaQbiSdsmmXzWQLG5zRRNEbgk6dA3tZwV060w==",
+      "dev": true,
+      "requires": {
+        "react-inspector": "^5.1.1"
+      }
     },
     "stream-browserify": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -106,6 +106,7 @@
     "prettier": "^2.7.1",
     "react-refresh": "^0.14.0",
     "react-router-dom": "^6.3.0",
+    "storybook-addon-react-router-v6": "^0.1.10",
     "ts-loader": "^9.3.1",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "type-fest": "^2.15.1",

--- a/frontend/src/components/Snackbar/index.stories.tsx
+++ b/frontend/src/components/Snackbar/index.stories.tsx
@@ -9,4 +9,6 @@ export default {
 const Template = (args: any) => <Snackbar {...args} />;
 
 export const SnackbarTemplate: ComponentStory<typeof Snackbar> = Template.bind({});
-SnackbarTemplate.args = {};
+SnackbarTemplate.args = {
+  message: '글 작성이 완료되었습니다.',
+};

--- a/frontend/src/pages/MainPage/index.stories.tsx
+++ b/frontend/src/pages/MainPage/index.stories.tsx
@@ -1,9 +1,11 @@
 import MainPage from '.';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { withRouter } from 'storybook-addon-react-router-v6';
 
 export default {
   title: 'Pages/MainPage',
   component: MainPage,
+  decorators: [withRouter],
 } as ComponentMeta<typeof MainPage>;
 
 const Template = (args: any) => <MainPage {...args} />;


### PR DESCRIPTION
### 버그 설명

- router로 감싸진 페이지를 storybook에서 render하면 오류가 발생함.

### 버그 시나리오 재연

어떤 상황에서 버그가 발생했는지 시나리오를 적어주세요 :  

1. page관련된 컴포넌트 스토리로 이동한다.
2. 오류가 발생한다. 


### 기대 동작

- [x] 정상적으로 스토리가 렌더된다.

### 관련이슈

close #24 