### PR TITLE
fix: storybook routing 문제 해결

### DIFF
--- a/frontend/src/components/Header/index.stories.tsx
+++ b/frontend/src/components/Header/index.stories.tsx
@@ -1,9 +1,11 @@
 import Header from '.';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { withRouter } from 'storybook-addon-react-router-v6';
 
 export default {
   title: 'Components/Header',
   component: Header,
+  decorators: [withRouter],
 } as ComponentMeta<typeof Header>;
 
 const Template = (args: any) => <Header {...args} />;

--- a/frontend/src/pages/CreatePostPage/index.stories.tsx
+++ b/frontend/src/pages/CreatePostPage/index.stories.tsx
@@ -1,9 +1,11 @@
 import CreatePostPage from '.';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { withRouter } from 'storybook-addon-react-router-v6';
 
 export default {
   title: 'Pages/CreatePostPage',
   component: CreatePostPage,
+  decorators: [withRouter],
 } as ComponentMeta<typeof CreatePostPage>;
 
 const Template = (args: any) => <CreatePostPage {...args} />;


### PR DESCRIPTION
### 버그 설명

- router로 감싸진 페이지를 storybook에서 render하면 오류가 발생함.

### 버그 시나리오 재연

어떤 상황에서 버그가 발생했는지 시나리오를 적어주세요 :  

1. createPostPage, Header 관련된 컴포넌트 스토리로 이동한다.
2. 라우팅 관련 오류가 발생한다. 


### 기대 동작

- [x] 정상적으로 스토리가 렌더된다.

### 관련이슈

close #28 
