### PR TITLE
feat: PostPage 구현

### DIFF
--- a/frontend/src/components/PostListItem/index.styles.ts
+++ b/frontend/src/components/PostListItem/index.styles.ts
@@ -9,6 +9,7 @@ export const Container = styled.div`
   box-shadow: 0px 1px 7px rgba(0, 0, 0, 0.13);
   border-radius: 5px;
   gap: 14px;
+  cursor: pointer;
 `;
 
 export const TitleContainer = styled.div`

--- a/frontend/src/components/PostListItem/index.tsx
+++ b/frontend/src/components/PostListItem/index.tsx
@@ -1,18 +1,14 @@
 import * as Styled from './index.styles';
 import timeConverter from '@/utils/timeConverter';
+import { MouseEventHandler } from 'react';
 
-export interface PostListItemProp {
-  title: string;
-  localDate: {
-    date: string;
-    time: string;
-  };
-  content: string;
+export interface PostListItemProp extends Omit<Post, 'id'> {
+  handleClick: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 }
 
-const PostListItem = ({ title, localDate, content }: PostListItemProp) => {
+const PostListItem = ({ title, localDate, content, handleClick }: PostListItemProp) => {
   return (
-    <Styled.Container>
+    <Styled.Container onClick={handleClick}>
       <Styled.TitleContainer>
         <Styled.Title>{title}</Styled.Title>
         <Styled.Date>{timeConverter(localDate)}</Styled.Date>

--- a/frontend/src/pages/MainPage/index.tsx
+++ b/frontend/src/pages/MainPage/index.tsx
@@ -11,11 +11,21 @@ const MainPage = () => {
     navigate('/post/write');
   };
 
+  const handleClickPostItem = (id: number) => {
+    navigate(`post/${id}`);
+  };
+
   return (
     <Layout>
       <Styled.PostListContainer>
         {postList.map(({ id, title, localDate, content }: Post) => (
-          <PostListItem title={title} localDate={localDate} content={content} key={id} />
+          <PostListItem
+            title={title}
+            localDate={localDate}
+            content={content}
+            key={id}
+            handleClick={e => handleClickPostItem(id)}
+          />
         ))}
       </Styled.PostListContainer>
       <FAB handleClick={handleClickFAB} />

--- a/frontend/src/pages/PostPage/index.stories.tsx
+++ b/frontend/src/pages/PostPage/index.stories.tsx
@@ -1,9 +1,11 @@
 import PostPage from '.';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { withRouter } from 'storybook-addon-react-router-v6';
 
 export default {
   title: 'Pages/PostPage',
   component: PostPage,
+  decorators: [withRouter],
 } as ComponentMeta<typeof PostPage>;
 
 const Template = (args: any) => <PostPage {...args} />;

--- a/frontend/src/pages/PostPage/index.styles.ts
+++ b/frontend/src/pages/PostPage/index.styles.ts
@@ -1,3 +1,61 @@
 import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
 
-export const Container = styled.div``;
+export const Container = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const TitleContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 100px;
+`;
+
+export const Title = styled.p`
+  font-size: 24px;
+  font-family: 'BMHANNAPro';
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 270px;
+  white-space: nowrap;
+`;
+
+export const Date = styled.span`
+  font-size: 10px;
+  color: ${props => props.theme.colors.gray_200};
+`;
+
+export const ContentContainer = styled.div`
+  min-height: 420px;
+  border-bottom: 1px solid ${props => props.theme.colors.sub};
+  margin-bottom: 25px;
+`;
+
+export const Content = styled.p`
+  line-height: 25px;
+`;
+
+export const ListButtonContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+`;
+
+export const ListButton = styled(Link)`
+  font-family: 'BMHANNAAir';
+  background-color: ${props => props.theme.colors.sub};
+  color: white;
+  border-radius: 15px;
+  font-size: 17px;
+  width: 100px;
+  height: 55px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/frontend/src/pages/PostPage/index.styles.ts
+++ b/frontend/src/pages/PostPage/index.styles.ts
@@ -13,7 +13,7 @@ export const TitleContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  margin-bottom: 100px;
+  margin-bottom: 60px;
 `;
 
 export const Title = styled.p`
@@ -34,6 +34,7 @@ export const ContentContainer = styled.div`
   min-height: 420px;
   border-bottom: 1px solid ${props => props.theme.colors.sub};
   margin-bottom: 25px;
+  padding-bottom: 20px;
 `;
 
 export const Content = styled.p`

--- a/frontend/src/pages/PostPage/index.tsx
+++ b/frontend/src/pages/PostPage/index.tsx
@@ -1,7 +1,25 @@
+import Layout from '@/components/@styled/Layout';
 import * as Styled from './index.styles';
 
 const PostPage = () => {
-  return <Styled.Container>PostPage</Styled.Container>;
+  return (
+    <Layout>
+      <Styled.Container>
+        <Styled.TitleContainer>
+          <Styled.Title>속닥속닥</Styled.Title>
+          <Styled.Date>2022년 6월 22일</Styled.Date>
+        </Styled.TitleContainer>
+        <Styled.ContentContainer>
+          <Styled.Content>
+            안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.안녕하세요.
+          </Styled.Content>
+        </Styled.ContentContainer>
+        <Styled.ListButtonContainer>
+          <Styled.ListButton to="/">글 목록</Styled.ListButton>
+        </Styled.ListButtonContainer>
+      </Styled.Container>
+    </Layout>
+  );
 };
 
 export default PostPage;


### PR DESCRIPTION
### 구현기능

- PostPage에 대한 UI를 구현한다.

<img width="412" alt="스크린샷 2022-07-06 오전 11 50 13" src="https://user-images.githubusercontent.com/65863017/177457583-5b280b2f-8582-4a6a-bded-fe4e1e31b256.png">

### 세부 구현기능

- [x] figma에 맞는 UI 구현
- [x] MainPage의 PostListItem 클릭시 /post/id로 이동 

### 관련 이슈

#30 