### PR TITLE
feat:MainPage 글목록 API 연결

### DIFF
--- a/frontend/src/components/PostListItem/index.tsx
+++ b/frontend/src/components/PostListItem/index.tsx
@@ -1,23 +1,25 @@
 import * as Styled from './index.styles';
 import timeConverter from '@/utils/timeConverter';
-import { MouseEventHandler } from 'react';
+import { forwardRef, MouseEventHandler } from 'react';
 
 export interface PostListItemProp extends Omit<Post, 'id'> {
   handleClick: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 }
 
-const PostListItem = ({ title, localDate, content, handleClick }: PostListItemProp) => {
-  return (
-    <Styled.Container onClick={handleClick}>
-      <Styled.TitleContainer>
-        <Styled.Title>{title}</Styled.Title>
-        <Styled.Date>{timeConverter(localDate)}</Styled.Date>
-      </Styled.TitleContainer>
-      <Styled.ContentContainer>
-        <Styled.Content>{content}</Styled.Content>
-      </Styled.ContentContainer>
-    </Styled.Container>
-  );
-};
+const PostListItem = forwardRef<HTMLDivElement, PostListItemProp>(
+  ({ title, localDate, content, handleClick }: PostListItemProp, ref) => {
+    return (
+      <Styled.Container onClick={handleClick} ref={ref}>
+        <Styled.TitleContainer>
+          <Styled.Title>{title}</Styled.Title>
+          <Styled.Date>{timeConverter(localDate)}</Styled.Date>
+        </Styled.TitleContainer>
+        <Styled.ContentContainer>
+          <Styled.Content>{content}</Styled.Content>
+        </Styled.ContentContainer>
+      </Styled.Container>
+    );
+  },
+);
 
 export default PostListItem;

--- a/frontend/src/mocks/handlers/posts/index.ts
+++ b/frontend/src/mocks/handlers/posts/index.ts
@@ -33,14 +33,13 @@ const postHandlers = [
   rest.get('/posts', (req, res, ctx) => {
     const size = Number(req.url.searchParams.get('size')!);
     const page = Number(req.url.searchParams.get('page')!);
-    const prevPage = page - 1;
-    const posts = postList.slice(prevPage * size, prevPage * size + size);
+    const posts = postList.slice(page * size, page * size + size);
 
     return res(
       ctx.status(200),
       ctx.json({
         posts,
-        isLastPage: postList.length - size * prevPage - posts.length === 0 && posts.length !== 0,
+        isLastPage: postList.length - size * page - posts.length === 0 && posts.length !== 0,
       }),
     );
   }),

--- a/frontend/src/pages/CreatePostPage/index.tsx
+++ b/frontend/src/pages/CreatePostPage/index.tsx
@@ -22,7 +22,7 @@ const CreatePostPage = () => {
   const { mutate: registerPost, isLoading } = useMutation(createPost, {
     onSuccess: () => {
       queryClient.invalidateQueries();
-      queryClient.invalidateQueries('post-get');
+      queryClient.invalidateQueries('posts-getByPage');
     },
   });
 

--- a/frontend/src/pages/MainPage/index.tsx
+++ b/frontend/src/pages/MainPage/index.tsx
@@ -3,10 +3,27 @@ import PostListItem from '@/components/PostListItem';
 import FAB from '@/components/FAB';
 import { useNavigate } from 'react-router-dom';
 import Layout from '@/components/@styled/Layout';
-import { postList } from '@/dummy';
+import axios from 'axios';
+import { useRef, useState, useEffect } from 'react';
+import { useInfiniteQuery } from 'react-query';
+import Spinner from '@/components/Spinner';
 
 const MainPage = () => {
   const navigate = useNavigate();
+  const scrollRef = useRef(null);
+  const [postList, setPostList] = useState<Post[]>([]);
+  const io = new IntersectionObserver(
+    (entries, io) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          io.unobserve(entry.target);
+          fetchNextPage();
+        }
+      });
+    },
+    { threshold: 0.7 },
+  );
+
   const handleClickFAB = () => {
     navigate('/post/write');
   };
@@ -15,18 +32,52 @@ const MainPage = () => {
     navigate(`post/${id}`);
   };
 
+  const getPosts = async ({ pageParam = 0 }) => {
+    const { data } = await axios.get(`/posts?size=5&page=${pageParam}`);
+
+    return {
+      ...data,
+      nextPage: pageParam + 1,
+    };
+  };
+
+  const { isLoading, data, fetchNextPage } = useInfiniteQuery('posts-getByPage', getPosts, {
+    enabled: false,
+    getNextPageParam: lastPage => (lastPage.isLastPage ? undefined : lastPage.nextPage),
+  });
+
+  useEffect(() => {
+    if (!data) {
+      fetchNextPage();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (data) {
+      setPostList(data.pages.reduce((prev, { posts }) => prev.concat(posts), []));
+    }
+  }, [data]);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      io.observe(scrollRef.current);
+    }
+  }, [postList]);
+
   return (
     <Layout>
       <Styled.PostListContainer>
-        {postList.map(({ id, title, localDate, content }: Post) => (
+        {postList.map(({ id, title, localDate, content }: Post, index) => (
           <PostListItem
             title={title}
             localDate={localDate}
             content={content}
             key={id}
             handleClick={e => handleClickPostItem(id)}
+            ref={index === postList.length - 1 ? scrollRef : null}
           />
         ))}
+        {isLoading && <Spinner />}
       </Styled.PostListContainer>
       <FAB handleClick={handleClickFAB} />
     </Layout>


### PR DESCRIPTION
### 구현기능

- MainPage내의 글 목록 불러오기를 모킹한 API와 연결한다.

### 세부 구현기능
 - [x] 글 목록에 대하여 InfiniteScroll을 활용하여 데이터를 로드한다.
 - [x] react-query를 활용하여 데이터를 캐싱한다.
 - [x] 스피너를 활용하여 로딩 이미지를 보여준다.

### 관련 이슈
close #39 