### PR TITLE
fix: 게시글의 시간 기준 내림차순이 되지 않았던 문제 해결

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -37,7 +37,7 @@ public class PostService {
     }
 
     public PostsResponse findPosts(Pageable pageable) {
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort());
         Slice<Post> posts = postRepository.findSliceBy(pageRequest);
         List<PostResponse> postResponses = posts.getContent()
                 .stream()

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -8,7 +8,6 @@ import com.wooteco.sokdak.post.exception.PostNotFoundException;
 import com.wooteco.sokdak.post.repository.PostRepository;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -37,8 +36,7 @@ public class PostService {
     }
 
     public PostsResponse findPosts(Pageable pageable) {
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort());
-        Slice<Post> posts = postRepository.findSliceBy(pageRequest);
+        Slice<Post> posts = postRepository.findSliceBy(pageable);
         List<PostResponse> postResponses = posts.getContent()
                 .stream()
                 .map(PostResponse::from)


### PR DESCRIPTION
### 버그 설명
Sort 기준을 넘겨주지 않아서 정렬이 되지 않았습니다.

### 버그 시나리오 재연
1. 첫번째 글 등록
2. 두번째 글 등록
3. 게시글 목록 조회
4. 첫번째 글, 두번째 글 순으로 조회됨

### 기대 동작
- [x] 두번째 글, 첫번째 글 순으로 조회됨(최신순)
