### PR TITLE
refactor: API 로직 hook으로 분리

### DIFF
--- a/frontend/src/constants/queries.ts
+++ b/frontend/src/constants/queries.ts
@@ -1,0 +1,6 @@
+const QUERY_KEYS = {
+  POST: 'post',
+  POSTS: 'posts',
+};
+
+export default QUERY_KEYS;

--- a/frontend/src/hooks/queries/post/useCreatePost.ts
+++ b/frontend/src/hooks/queries/post/useCreatePost.ts
@@ -1,0 +1,36 @@
+import { useContext } from 'react';
+import { useQueryClient, useMutation, UseMutationOptions } from 'react-query';
+
+import axios, { AxiosError, AxiosResponse } from 'axios';
+
+import SnackbarContext from '@/context/Snackbar';
+
+import QUERY_KEYS from '@/constants/queries';
+
+const useCreatePost = (
+  options?: UseMutationOptions<AxiosResponse<string, string>, AxiosError, Pick<Post, 'title' | 'content'>>,
+) => {
+  const queryClient = useQueryClient();
+  const { showSnackbar } = useContext(SnackbarContext);
+
+  return useMutation(
+    ({ title, content }: { title: string; content: string }): Promise<AxiosResponse<string, string>> =>
+      axios.post('/posts', {
+        title,
+        content,
+      }),
+    {
+      ...options,
+      onSuccess: (data, variables, context) => {
+        queryClient.resetQueries(QUERY_KEYS.POSTS);
+        showSnackbar('글 작성에 성공하였습니다.');
+
+        if (options && options.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+      },
+    },
+  );
+};
+
+export default useCreatePost;

--- a/frontend/src/hooks/queries/post/usePost.ts
+++ b/frontend/src/hooks/queries/post/usePost.ts
@@ -1,0 +1,19 @@
+import { useQuery, QueryKey, UseQueryOptions } from 'react-query';
+
+import axios, { AxiosError, AxiosResponse } from 'axios';
+
+import QUERY_KEYS from '@/constants/queries';
+
+const usePost = ({
+  storeCode,
+  options,
+}: {
+  storeCode: QueryKey;
+  options?: UseQueryOptions<AxiosResponse<Post>, AxiosError, Post, QueryKey[]>;
+}) =>
+  useQuery([QUERY_KEYS.POST, storeCode], ({ queryKey: [_, id] }) => axios.get(`/posts/${id}`), {
+    select: data => data.data,
+    ...options,
+  });
+
+export default usePost;

--- a/frontend/src/hooks/queries/post/usePosts.ts
+++ b/frontend/src/hooks/queries/post/usePosts.ts
@@ -1,0 +1,37 @@
+import { useInfiniteQuery, QueryKey, UseInfiniteQueryOptions } from 'react-query';
+
+import axios, { AxiosResponse, AxiosError } from 'axios';
+
+import QUERY_KEYS from '@/constants/queries';
+
+const usePosts = ({
+  storeCode,
+  options,
+}: {
+  storeCode: QueryKey;
+  options?: UseInfiniteQueryOptions<
+    AxiosResponse<{ posts: Post; lastPage: boolean }>,
+    AxiosError,
+    Post,
+    AxiosResponse<{ posts: Post; lastPage: boolean }>,
+    QueryKey[]
+  >;
+}) =>
+  useInfiniteQuery(
+    [QUERY_KEYS.POSTS, storeCode],
+    ({ pageParam = 0, queryKey: [_, size] }) => axios.get(`/posts?size=${size}&page=${pageParam}`),
+    {
+      select: data => {
+        const posts: Post[] = data.pages.reduce((pre, { data }) => pre.concat(data.posts), [] as Post[]);
+        return {
+          pages: posts,
+          pageParams: [...data.pageParams, data.pageParams.length],
+        };
+      },
+      enabled: false,
+      getNextPageParam: (lastPage, allPages) => (lastPage.data.lastPage ? undefined : allPages.length),
+      ...options,
+    },
+  );
+
+export default usePosts;

--- a/frontend/src/hooks/queries/post/usePosts.ts
+++ b/frontend/src/hooks/queries/post/usePosts.ts
@@ -21,13 +21,10 @@ const usePosts = ({
     [QUERY_KEYS.POSTS, storeCode],
     ({ pageParam = 0, queryKey: [_, size] }) => axios.get(`/posts?size=${size}&page=${pageParam}`),
     {
-      select: data => {
-        const posts: Post[] = data.pages.reduce((pre, { data }) => pre.concat(data.posts), [] as Post[]);
-        return {
-          pages: posts,
-          pageParams: [...data.pageParams, data.pageParams.length],
-        };
-      },
+      select: data => ({
+        pages: data.pages.flatMap((x: any) => x.data.posts),
+        pageParams: [...data.pageParams, data.pageParams.length],
+      }),
       enabled: false,
       getNextPageParam: (lastPage, allPages) => (lastPage.data.lastPage ? undefined : allPages.length),
       ...options,

--- a/frontend/src/pages/CreatePostPage/index.tsx
+++ b/frontend/src/pages/CreatePostPage/index.tsx
@@ -1,13 +1,12 @@
 import { useContext, useRef, useState } from 'react';
-import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
-
-import axios from 'axios';
 
 import Layout from '@/components/@styled/Layout';
 import Spinner from '@/components/Spinner';
 
 import SnackbarContext from '@/context/Snackbar';
+
+import useCreatePost from '@/hooks/queries/post/useCreatePost';
 
 import * as Styled from './index.styles';
 
@@ -18,21 +17,13 @@ const CreatePostPage = () => {
   const [isContentAnimationActive, setIsContentAnimationActive] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
-  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const { isVisible, showSnackbar } = useContext(SnackbarContext);
-  const createPost = () =>
-    axios.post('/posts', {
-      title,
-      content,
-    });
 
-  const { mutate: registerPost, isLoading } = useMutation(createPost, {
+  const { mutate: registerPost, isLoading } = useCreatePost({
     onSuccess: () => {
-      queryClient.resetQueries('posts-getByPage');
-      showSnackbar('글 작성에 성공하였습니다.');
       navigate('/');
     },
   });
@@ -49,7 +40,7 @@ const CreatePostPage = () => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    registerPost();
+    registerPost({ title, content });
   };
 
   return (

--- a/frontend/src/pages/PostPage/index.tsx
+++ b/frontend/src/pages/PostPage/index.tsx
@@ -1,10 +1,9 @@
-import { useQuery } from 'react-query';
 import { useParams } from 'react-router-dom';
-
-import axios from 'axios';
 
 import Layout from '@/components/@styled/Layout';
 import Spinner from '@/components/Spinner';
+
+import usePost from '@/hooks/queries/post/usePost';
 
 import * as Styled from './index.styles';
 
@@ -12,8 +11,7 @@ import timeConverter from '@/utils/timeConverter';
 
 const PostPage = () => {
   const { id } = useParams();
-  const getPost = () => axios.get(`/posts/${id}`).then(res => res.data);
-  const { data, isLoading, isError } = useQuery('post-get', getPost, {});
+  const { data, isLoading, isError } = usePost({ storeCode: id! });
 
   if (isLoading) {
     return (
@@ -38,7 +36,7 @@ const PostPage = () => {
     );
   }
 
-  const { content, title, localDate } = data;
+  const { content, title, localDate } = data!;
 
   return (
     <Layout>


### PR DESCRIPTION
### 설명

- API 관련 로직을 custom hook으로 분리한다.

### 개선한 부분

- [x] `usePost`, `usePosts`, `useCreatePost` custom hook 생성을 통해 API 관련 로직을 페이지 컴포넌트와 분리 

### 장점

- query key 관리를 쉽게 할 수 있다.
- query의 default option을 설정할 수 있다.

### 관련이슈

close #57 