### PR TITLE
refactor: API 명세 변경에 따라 필드 포맷 수정

### DIFF
--- a/frontend/src/components/PostListItem/index.stories.tsx
+++ b/frontend/src/components/PostListItem/index.stories.tsx
@@ -11,9 +11,6 @@ const Template: ComponentStory<typeof PostListItem> = args => <PostListItem {...
 export const PostListItemTemplate = Template.bind({});
 PostListItemTemplate.args = {
   title: '오늘 날씨 좋네요!',
-  localDate: {
-    date: '2022-07-05',
-    time: '15:00',
-  },
   content: '안녕?',
+  createdAt: new Date().toISOString(),
 };

--- a/frontend/src/components/PostListItem/index.tsx
+++ b/frontend/src/components/PostListItem/index.tsx
@@ -9,12 +9,12 @@ interface PostListItemProps extends Omit<Post, 'id'> {
 }
 
 const PostListItem = forwardRef<HTMLDivElement, PostListItemProps>(
-  ({ title, localDate, content, handleClick }: PostListItemProps, ref) => {
+  ({ title, content, createdAt, handleClick }: PostListItemProps, ref) => {
     return (
       <Styled.Container onClick={handleClick} ref={ref}>
         <Styled.TitleContainer>
           <Styled.Title>{title}</Styled.Title>
-          <Styled.Date>{timeConverter(localDate)}</Styled.Date>
+          <Styled.Date>{timeConverter(createdAt)}</Styled.Date>
         </Styled.TitleContainer>
         <Styled.ContentContainer>
           <Styled.Content>{content}</Styled.Content>

--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -2,91 +2,61 @@ export const postList: Post[] = [
   {
     id: 1,
     title: '오늘 날씨 맑네요',
-    localDate: {
-      date: '2022-06-05',
-      time: '15:30',
-    },
+    createdAt: '2022-07-13T19:55:31.016376300',
     content: '날씨는 참 좋네요.',
   },
   {
     id: 2,
     title: '오늘 날씨 좋네요',
-    localDate: {
-      date: '2022-07-05',
-      time: '15:30',
-    },
+    createdAt: '2022-07-12T19:55:31.016376300',
     content: '어항에 있는 것 같아요.',
   },
   {
     id: 3,
     title: '오늘 날씨 싫어요',
-    localDate: {
-      date: '2022-07-05',
-      time: '15:30',
-    },
+    createdAt: '2022-07-11T19:55:31.016376300',
     content: '싫어? 아냐 나 괜찮아',
   },
   {
     id: 4,
     title: '오늘 날씨 별로예요',
-    localDate: {
-      date: '2022-07-05',
-      time: '15:30',
-    },
+    createdAt: '2022-07-10T19:55:31.016376300',
     content: '어항에 있는 것 같아요',
   },
   {
     id: 5,
     title: '조시 : 미안하다 진짜',
-    localDate: {
-      date: '2022-07-05',
-      time: '15:30',
-    },
+    createdAt: '2022-07-09T19:55:31.016376300',
     content: '미안하다 진짜봇',
   },
   {
     id: 6,
     title: '크리스 : 갑자기 이런 생각이 드네?',
-    localDate: {
-      date: '2022-06-05',
-      time: '15:30',
-    },
+    createdAt: '2022-07-08T19:55:31.016376300',
     content: '생각멈춰',
   },
   {
     id: 7,
     title: '이스트 : 아채 싫엉',
-    localDate: {
-      date: '2022-07-05',
-      time: '15:30',
-    },
+    createdAt: '2022-07-07T19:55:31.016376300',
     content: '베이비 이스트',
   },
   {
     id: 8,
     title: '토르 : 사진 찰칵 찰칵',
-    localDate: {
-      date: '2022-07-05',
-      time: '15:30',
-    },
+    createdAt: '2022-07-06T19:55:31.016376300',
     content: '단백질 벌컥 벌컥',
   },
   {
     id: 9,
     title: '헌치 : 악상이 떠오른다.',
-    localDate: {
-      date: '2022-07-05',
-      time: '15:30',
-    },
+    createdAt: '2022-07-05T19:55:31.016376300',
     content: '알고리즘 냠냠',
   },
   {
     id: 10,
     title: '동키콩 : 수학 1등급',
-    localDate: {
-      date: '2022-07-05',
-      time: '15:30',
-    },
+    createdAt: '2022-07-04T19:55:31.016376300',
     content: '특 : 페이지 계산 못함',
   },
 ];

--- a/frontend/src/mocks/handlers/posts/index.ts
+++ b/frontend/src/mocks/handlers/posts/index.ts
@@ -8,12 +8,9 @@ const postHandlers = [
     const id = postList.length + 1;
     const newPost: Post = {
       id,
-      localDate: {
-        date: '2022-07-01',
-        time: '16:32',
-      },
       title,
       content,
+      createdAt: new Date().toISOString(),
     };
 
     postList.push(newPost);

--- a/frontend/src/pages/MainPage/index.tsx
+++ b/frontend/src/pages/MainPage/index.tsx
@@ -48,11 +48,11 @@ const MainPage = () => {
   return (
     <Layout>
       <Styled.PostListContainer>
-        {data?.pages.map(({ id, title, localDate, content }, index) => (
+        {data?.pages.map(({ id, title, content, createdAt }, index) => (
           <PostListItem
             title={title}
-            localDate={localDate}
             content={content}
+            createdAt={createdAt}
             key={id}
             handleClick={e => handleClickPostItem(id)}
             ref={index === data.pages.length - 1 ? scrollRef : null}

--- a/frontend/src/pages/PostPage/index.tsx
+++ b/frontend/src/pages/PostPage/index.tsx
@@ -36,7 +36,7 @@ const PostPage = () => {
     );
   }
 
-  const { content, title, localDate } = data!;
+  const { content, title, createdAt } = data!;
 
   return (
     <Layout>
@@ -45,7 +45,7 @@ const PostPage = () => {
           <Styled.TitleContainer>
             <Styled.Title>{title}</Styled.Title>
           </Styled.TitleContainer>
-          <Styled.Date>{timeConverter(localDate)}</Styled.Date>
+          <Styled.Date>{timeConverter(createdAt)}</Styled.Date>
         </Styled.HeadContainer>
 
         <Styled.ContentContainer>

--- a/frontend/src/types/post.d.ts
+++ b/frontend/src/types/post.d.ts
@@ -1,9 +1,6 @@
 interface Post {
   id: number;
   title: string;
-  localDate: {
-    date: string;
-    time: string;
-  };
   content: string;
+  createdAt: string;
 }

--- a/frontend/src/utils/timeConverter.ts
+++ b/frontend/src/utils/timeConverter.ts
@@ -4,8 +4,8 @@ const options = {
   day: 'numeric',
 } as const;
 
-const timeConverter = (localDate: { date: string; time: string }): string => {
-  const postDate = new Date(localDate.date + 'T' + localDate.time);
+const timeConverter = (createdAt: string): string => {
+  const postDate = new Date(createdAt);
   const sec = (Date.now() - +postDate) / 1000;
   const date = Math.floor(sec / 60 / 60 / 24);
   const hour = Math.floor(sec / 60 / 60);


### PR DESCRIPTION
### 설명

API 명세 변경 사항에 따라

```json
// before
{	
  "posts": [
      {
	 "id": 1,
	 "title": "제목",
	 "content": "본문1",
	 "localDate": {
		"date": "2022-07-01",
		"time": "16:32"
	 }
      },
   ]
}

// after
{	
  "posts": [
      {
	 "id": 1,
	 "title": "제목",
	 "content": "본문1",
	 "createdAt": "2019-01-01T12:30:00.000Z"
      },
   ]
}

```

관련된 로직 수정 

### 개선한 부분

- [x] `timeConverter` 유틸 로직 변경 
- [x] 필드 이름을 `localDate`에서 `createdAt`으로 변경

### 관련 이슈 

close #60 