### PR TITLE
fix: devtool이 source-map을 인식하지 못하는 문제 해결

### DIFF
--- a/frontend/webpack/webpack.config.js
+++ b/frontend/webpack/webpack.config.js
@@ -66,4 +66,5 @@ module.exports = {
     }),
     new ReactRefreshWebpackPlugin(),
   ],
+  devtool: 'source-map',
 };


### PR DESCRIPTION
### 버그 설명

콘솔을 열면 아래와 같이 에러가 출력된다.

```
devtools failed to load source map
```

### 버그 시나리오 재연

어떤 상황에서 버그가 발생했는지 시나리오를 적어주세요 :  

1. 서버를 실행한다. 
2. 콘솔을 연다.
3. `devtools failed to load source map` 에러가 발생한다. 

### 해결

```js 
// webpack.config.js

devtool : 'source-map'
```

을 추가함으로써 해결했다. 
