### PR TITLE
fix: snackbar 관련 상수 export

### DIFF
--- a/frontend/src/constants/snackbar.ts
+++ b/frontend/src/constants/snackbar.ts
@@ -1,3 +1,5 @@
 const SNACKBAR_MESSAGE = {
   SUCCESS_WRITE_POST: '글 작성에 성공하였습니다.',
 };
+
+export default SNACKBAR_MESSAGE;

--- a/frontend/src/hooks/queries/post/useCreatePost.ts
+++ b/frontend/src/hooks/queries/post/useCreatePost.ts
@@ -6,6 +6,7 @@ import axios, { AxiosError, AxiosResponse } from 'axios';
 import SnackbarContext from '@/context/Snackbar';
 
 import QUERY_KEYS from '@/constants/queries';
+import SNACKBAR_MESSAGE from '@/constants/snackbar';
 
 const useCreatePost = (
   options?: UseMutationOptions<AxiosResponse<string, string>, AxiosError, Pick<Post, 'title' | 'content'>>,


### PR DESCRIPTION
### 버그 설명

`SNACKBAR_MESSAGE`가 export되어 있지 않아 `SNACKBAR_MESSAGE`를 찾을 수 없다는 에러가 발생한다. 

### 해결

`SNACKBAR_MESSAGE`를 export 해주고, 사용처에서 import 해줌

### 관련이슈 

close #75 

