### PR TITLE
feat: 게시물 수정 기능 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import CreatePostPage from './pages/CreatePostPage';
 import MainPage from './pages/MainPage';
 import NotFoundPage from './pages/NotFoundPage';
 import PostPage from './pages/PostPage';
+import UpdatePostPage from './pages/UpdatePostPage';
 
 import Snackbar from './components/Snackbar';
 import Header from '@/components/Header';
@@ -23,6 +24,7 @@ const App = () => {
         <Route path={PATH.HOME} element={<MainPage />} />
         <Route path={PATH.CREATE_POST} element={<CreatePostPage />} />
         <Route path={`${PATH.POST}/:id`} element={<PostPage />} />
+        <Route path={PATH.UPDATE_POST} element={<UpdatePostPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
       {isVisible && <Snackbar message={message} />}

--- a/frontend/src/components/PostForm/index.stories.tsx
+++ b/frontend/src/components/PostForm/index.stories.tsx
@@ -1,0 +1,16 @@
+import PostForm from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Components/PostForm',
+  component: PostForm,
+} as ComponentMeta<typeof PostForm>;
+
+const Template: ComponentStory<typeof PostForm> = args => <PostForm {...args} />;
+
+export const PostFormTemplate = Template.bind({});
+PostFormTemplate.args = {
+  heading: '글 작성',
+  submitType: '글 작성하기',
+  handlePost: () => {},
+};

--- a/frontend/src/components/PostForm/index.styles.ts
+++ b/frontend/src/components/PostForm/index.styles.ts
@@ -1,0 +1,84 @@
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const Container = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  padding: 0 13px;
+  box-sizing: border-box;
+`;
+
+export const Heading = styled.h1`
+  font-family: 'BMHANNAPro';
+  font-size: 27px;
+  margin: 40px 0;
+`;
+
+export const huduldul = keyframes`
+  0% {
+    transform: translateX(-10px)
+  } 
+  20% {
+    transform: translateX(10px)
+  }
+  40% {
+    transform: translateX(-10px)
+  }
+  60% {
+    transform: translateX(10px)
+  }
+  100% {
+    transform: translateX(0px)
+  }
+`;
+
+interface InputProps {
+  isValid: boolean;
+  isAnimationActive: boolean;
+}
+
+export const TitleInput = styled.input<InputProps>`
+  font-family: 'BMHANNAAir';
+  border-bottom: 1px solid ${props => (props.isValid ? props.theme.colors.sub : props.theme.colors.red_100)};
+
+  width: 100%;
+  padding: 10px;
+  font-size: 20px;
+  animation: ${props => (props.isAnimationActive ? huduldul : null)} 0.5s;
+
+  :valid {
+    border-bottom: 1px solid ${props => props.theme.colors.sub};
+  }
+`;
+
+export const ContentInput = styled.textarea<InputProps>`
+  width: 100%;
+  height: 290px;
+  padding: 10px;
+  font-size: 14px;
+  margin: 20px 0;
+  animation: ${props => (props.isAnimationActive ? huduldul : null)} 0.5s;
+
+  ::placeholder {
+    color: ${props => (props.isValid ? 'gray' : props.theme.colors.red_100)};
+  }
+
+  :valid {
+    ::placeholder {
+      color: grey;
+    }
+  }
+`;
+
+export const SubmitButton = styled.button`
+  font-family: 'BMHANNAAir';
+  background-color: ${props => props.theme.colors.sub};
+  color: white;
+  border-radius: 15px;
+  font-size: 17px;
+  width: 100%;
+  height: 55px;
+  cursor: pointer;
+`;

--- a/frontend/src/components/PostForm/index.tsx
+++ b/frontend/src/components/PostForm/index.tsx
@@ -1,0 +1,75 @@
+import { useContext, useState } from 'react';
+
+import SnackbarContext from '@/context/Snackbar';
+
+import * as Styled from './index.styles';
+
+interface PostFormProps {
+  heading: string;
+  submitType: string;
+  prevTitle?: string;
+  prevContent?: string;
+  handlePost: (post: Pick<Post, 'title' | 'content'>) => void;
+}
+
+const PostForm = ({ heading, submitType, prevTitle = '', prevContent = '', handlePost }: PostFormProps) => {
+  const { isVisible, showSnackbar } = useContext(SnackbarContext);
+
+  const [title, setTitle] = useState(prevTitle);
+  const [content, setContent] = useState(prevContent);
+
+  const [isValidTitle, setIsValidTitle] = useState(true);
+  const [isValidContent, setIsValidContent] = useState(true);
+  const [isAnimationActive, setIsAnimationActive] = useState(false);
+  const [isContentAnimationActive, setIsContentAnimationActive] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    handlePost({ title, content });
+  };
+
+  return (
+    <Styled.Container
+      onSubmit={handleSubmit}
+      onInvalid={(e: React.FormEvent<HTMLFormElement> & { target: HTMLInputElement }) => {
+        if (isVisible) return;
+        showSnackbar(e.target.placeholder);
+      }}
+    >
+      <Styled.Heading>{heading}</Styled.Heading>
+      <Styled.TitleInput
+        placeholder="제목을 입력해주세요."
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+        maxLength={50}
+        onInvalid={e => {
+          e.preventDefault();
+          setIsValidTitle(false);
+          setIsAnimationActive(true);
+        }}
+        onAnimationEnd={() => setIsAnimationActive(false)}
+        isValid={isValidTitle}
+        isAnimationActive={isAnimationActive}
+        required
+      />
+      <Styled.ContentInput
+        placeholder="내용을 작성해주세요."
+        value={content}
+        onChange={e => setContent(e.target.value)}
+        maxLength={5000}
+        onInvalid={e => {
+          e.preventDefault();
+          setIsValidContent(false);
+          setIsContentAnimationActive(true);
+        }}
+        onAnimationEnd={() => setIsContentAnimationActive(false)}
+        isValid={isValidContent}
+        isAnimationActive={isContentAnimationActive}
+        required
+      />
+      <Styled.SubmitButton>{submitType}</Styled.SubmitButton>
+    </Styled.Container>
+  );
+};
+
+export default PostForm;

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -2,6 +2,7 @@ const PATH = {
   HOME: '/',
   POST: '/post',
   CREATE_POST: '/post/write',
+  UPDATE_POST: '/post/update',
 };
 
 export default PATH;

--- a/frontend/src/constants/snackbar.ts
+++ b/frontend/src/constants/snackbar.ts
@@ -1,5 +1,6 @@
 const SNACKBAR_MESSAGE = {
   SUCCESS_WRITE_POST: '글 작성에 성공하였습니다.',
+  SUCCESS_UPDATE_POST: '글 수정에 성공하였습니다.',
 };
 
 export default SNACKBAR_MESSAGE;

--- a/frontend/src/hooks/queries/post/useUpdatePost.ts
+++ b/frontend/src/hooks/queries/post/useUpdatePost.ts
@@ -1,0 +1,41 @@
+import { useContext } from 'react';
+import { useQueryClient, useMutation, UseMutationOptions } from 'react-query';
+
+import axios, { AxiosError, AxiosResponse } from 'axios';
+
+import SnackbarContext from '@/context/Snackbar';
+
+import QUERY_KEYS from '@/constants/queries';
+import SNACKBAR_MESSAGE from '@/constants/snackbar';
+
+const useUpdatePost = ({
+  id,
+  options,
+}: {
+  id: string | number;
+  options?: UseMutationOptions<AxiosResponse, AxiosError, Pick<Post, 'title' | 'content'>>;
+}) => {
+  const queryClient = useQueryClient();
+  const { showSnackbar } = useContext(SnackbarContext);
+
+  return useMutation(
+    ({ title, content }: Pick<Post, 'title' | 'content'>): Promise<AxiosResponse> =>
+      axios.put(`/posts/${id}`, {
+        title,
+        content,
+      }),
+    {
+      ...options,
+      onSuccess: (data, variables, context) => {
+        queryClient.resetQueries(QUERY_KEYS.POSTS);
+        showSnackbar(SNACKBAR_MESSAGE.SUCCESS_UPDATE_POST);
+
+        if (options && options.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+      },
+    },
+  );
+};
+
+export default useUpdatePost;

--- a/frontend/src/mocks/handlers/posts/index.ts
+++ b/frontend/src/mocks/handlers/posts/index.ts
@@ -41,6 +41,29 @@ const postHandlers = [
       }),
     );
   }),
+
+  rest.put<Pick<Post, 'title' | 'content'>>('/posts/:id', (req, res, ctx) => {
+    const params = req.params;
+    const id = Number(params.id);
+    const { title, content } = req.body;
+
+    const isTargetPostExist = postList.some(post => post.id === id);
+
+    if (!isTargetPostExist) {
+      return res(ctx.status(400), ctx.json({ message: '해당 글이 존재하지 않습니다.' }));
+    }
+
+    if (!title || !content) {
+      return res(ctx.status(400), ctx.json({ message: '제목 혹은 본문이 없습니다.' }));
+    }
+
+    const targetPost = postList.find(post => post.id === id)!;
+
+    targetPost.title = title;
+    targetPost.content = content;
+
+    return res(ctx.status(204));
+  }),
 ];
 
 export default postHandlers;

--- a/frontend/src/pages/CreatePostPage/index.styles.ts
+++ b/frontend/src/pages/CreatePostPage/index.styles.ts
@@ -1,14 +1,4 @@
-import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
-
-export const PostForm = styled.form`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  padding: 0 13px;
-  box-sizing: border-box;
-`;
 
 export const SpinnerContainer = styled.div`
   width: 100%;
@@ -16,73 +6,4 @@ export const SpinnerContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-`;
-
-export const Heading = styled.h1`
-  font-family: 'BMHANNAPro';
-  font-size: 27px;
-  margin: 40px 0;
-`;
-
-export const huduldul = keyframes`
-  0%{
-    transform:translateX(-10px)
-  }20%{
-    transform:translateX(10px)
-  }40%{
-    transform:translateX(-10px)
-  }60%{
-    transform:translateX(10px)
-  }100%{
-    transform:translateX(0px)
-  }
-`;
-
-interface InputProps {
-  isValid: boolean;
-  isAnimationActive: boolean;
-}
-
-export const TitleInput = styled.input<InputProps>`
-  font-family: 'BMHANNAAir';
-  border-bottom: 1px solid ${props => (props.isValid ? props.theme.colors.sub : props.theme.colors.red_100)};
-
-  width: 100%;
-  padding: 10px;
-  font-size: 20px;
-  animation: ${props => (props.isAnimationActive ? huduldul : null)} 0.5s;
-
-  :valid {
-    border-bottom: 1px solid ${props => props.theme.colors.sub};
-  }
-`;
-
-export const ContentInput = styled.textarea<InputProps>`
-  width: 100%;
-  height: 290px;
-  padding: 10px;
-  font-size: 14px;
-  margin: 20px 0;
-  animation: ${props => (props.isAnimationActive ? huduldul : null)} 0.5s;
-
-  ::placeholder {
-    color: ${props => (props.isValid ? 'gray' : props.theme.colors.red_100)};
-  }
-
-  :valid {
-    ::placeholder {
-      color: grey;
-    }
-  }
-`;
-
-export const PostButton = styled.button`
-  font-family: 'BMHANNAAir';
-  background-color: ${props => props.theme.colors.sub};
-  color: white;
-  border-radius: 15px;
-  font-size: 17px;
-  width: 100%;
-  height: 55px;
-  cursor: pointer;
 `;

--- a/frontend/src/pages/CreatePostPage/index.tsx
+++ b/frontend/src/pages/CreatePostPage/index.tsx
@@ -1,10 +1,8 @@
-import { useContext, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Layout from '@/components/@styled/Layout';
+import PostForm from '@/components/PostForm';
 import Spinner from '@/components/Spinner';
-
-import SnackbarContext from '@/context/Snackbar';
 
 import useCreatePost from '@/hooks/queries/post/useCreatePost';
 
@@ -13,17 +11,7 @@ import * as Styled from './index.styles';
 import PATH from '@/constants/path';
 
 const CreatePostPage = () => {
-  const [isValidTitle, setIsValidTitle] = useState(true);
-  const [isValidContent, setIsValidContent] = useState(true);
-  const [isAnimationActive, setIsAnimationActive] = useState(false);
-  const [isContentAnimationActive, setIsContentAnimationActive] = useState(false);
-
-  const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
-  const { isVisible, showSnackbar } = useContext(SnackbarContext);
-
   const { mutate: registerPost, isLoading } = useCreatePost({
     onSuccess: () => {
       navigate(PATH.HOME);
@@ -40,58 +28,9 @@ const CreatePostPage = () => {
     );
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    registerPost({ title, content });
-  };
-
   return (
     <Layout>
-      <Styled.PostForm
-        onSubmit={handleSubmit}
-        onInvalid={(e: React.FormEvent<HTMLFormElement> & { target: HTMLInputElement }) => {
-          if (isVisible) return;
-          showSnackbar(e.target.placeholder);
-        }}
-      >
-        <Styled.Heading>글 작성</Styled.Heading>
-        <Styled.TitleInput
-          placeholder="제목을 입력해주세요."
-          value={title}
-          onChange={e => setTitle(e.target.value)}
-          maxLength={50}
-          onInvalid={e => {
-            e.preventDefault();
-            setIsValidTitle(false);
-            setIsAnimationActive(true);
-          }}
-          onAnimationEnd={() => {
-            setIsAnimationActive(false);
-          }}
-          isValid={isValidTitle}
-          isAnimationActive={isAnimationActive}
-          ref={inputRef}
-          required
-        />
-        <Styled.ContentInput
-          placeholder="내용을 작성해주세요."
-          value={content}
-          onChange={e => setContent(e.target.value)}
-          maxLength={5000}
-          onInvalid={e => {
-            e.preventDefault();
-            setIsValidContent(false);
-            setIsContentAnimationActive(true);
-          }}
-          onAnimationEnd={() => {
-            setIsContentAnimationActive(false);
-          }}
-          isValid={isValidContent}
-          isAnimationActive={isContentAnimationActive}
-          required
-        />
-        <Styled.PostButton>글 작성하기</Styled.PostButton>
-      </Styled.PostForm>
+      <PostForm heading="글 작성" submitType="글 작성하기" handlePost={registerPost} />
     </Layout>
   );
 };

--- a/frontend/src/pages/PostPage/index.styles.ts
+++ b/frontend/src/pages/PostPage/index.styles.ts
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 
+import { css, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const Container = styled.div`
@@ -9,35 +10,16 @@ export const Container = styled.div`
   align-items: center;
 `;
 
-export const SpinnerContainer = styled.div`
-  position: fixed;
-  top: 20%;
-  left: 50%;
-  transform: translateY(-50%);
-  transform: translateX(-50%);
-`;
-
-export const ErrorContainer = styled.div`
-  width: 100%;
-  height: 500px;
-  font-family: 'BMHANNAPro';
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 3em;
-`;
-
 export const HeadContainer = styled.div`
   width: 100%;
+  min-height: 70px;
   display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
+  flex-direction: column;
   margin-bottom: 60px;
 `;
 
 export const TitleContainer = styled.div`
-  width: 240px;
+  width: 100%;
   word-wrap: break-word;
 `;
 
@@ -45,6 +27,43 @@ export const Title = styled.p`
   font-size: 24px;
   font-family: 'BMHANNAPro';
   word-break: keep-all;
+  line-height: 30px;
+`;
+
+export const PostController = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin: 0 -5px;
+`;
+
+const controllerButton = (props: { theme: Theme }) => css`
+  font-size: 10px;
+  background-color: transparent;
+  color: ${props.theme.colors.gray_200};
+  width: fit-content;
+  padding: 5px;
+`;
+
+export const UpdateButton = styled.button`
+  ${controllerButton}
+`;
+
+export const DeleteButton = styled.button`
+  ${controllerButton}
+
+  color: ${props => props.theme.colors.red_200};
+`;
+
+export const PostInfo = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 10px;
+  margin: 0 -10px;
+`;
+
+export const Author = styled.span`
+  font-size: 14px;
+  font-family: 'BMHANNAPro';
 `;
 
 export const Date = styled.span`
@@ -84,4 +103,23 @@ export const ListButton = styled(Link)`
   display: flex;
   align-items: center;
   justify-content: center;
+`;
+
+export const SpinnerContainer = styled.div`
+  position: fixed;
+  top: 20%;
+  left: 50%;
+  transform: translateY(-50%);
+  transform: translateX(-50%);
+`;
+
+export const ErrorContainer = styled.div`
+  width: 100%;
+  height: 500px;
+  font-family: 'BMHANNAPro';
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 3em;
 `;

--- a/frontend/src/pages/PostPage/index.tsx
+++ b/frontend/src/pages/PostPage/index.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import Layout from '@/components/@styled/Layout';
 import Spinner from '@/components/Spinner';
@@ -11,6 +11,7 @@ import PATH from '@/constants/path';
 import timeConverter from '@/utils/timeConverter';
 
 const PostPage = () => {
+  const navigate = useNavigate();
   const { id } = useParams();
   const { data, isLoading, isError } = usePost({ storeCode: id! });
 
@@ -46,7 +47,16 @@ const PostPage = () => {
           <Styled.TitleContainer>
             <Styled.Title>{title}</Styled.Title>
           </Styled.TitleContainer>
-          <Styled.Date>{timeConverter(createdAt)}</Styled.Date>
+          <Styled.PostController>
+            <Styled.UpdateButton onClick={() => navigate(PATH.UPDATE_POST, { state: { id, title, content } })}>
+              수정
+            </Styled.UpdateButton>
+            <Styled.DeleteButton>삭제</Styled.DeleteButton>
+          </Styled.PostController>
+          <Styled.PostInfo>
+            <Styled.Author>익명</Styled.Author>
+            <Styled.Date>{timeConverter(createdAt)}</Styled.Date>
+          </Styled.PostInfo>
         </Styled.HeadContainer>
 
         <Styled.ContentContainer>

--- a/frontend/src/pages/UpdatePostPage/index.stories.tsx
+++ b/frontend/src/pages/UpdatePostPage/index.stories.tsx
@@ -1,0 +1,15 @@
+import { withRouter } from 'storybook-addon-react-router-v6';
+
+import UpdatePostPage from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Pages/UpdatePostPage',
+  component: UpdatePostPage,
+  decorators: [withRouter],
+} as ComponentMeta<typeof UpdatePostPage>;
+
+const Template = () => <UpdatePostPage />;
+
+export const UpdatePostPageTemplate: ComponentStory<typeof UpdatePostPage> = Template.bind({});
+UpdatePostPageTemplate.args = {};

--- a/frontend/src/pages/UpdatePostPage/index.stories.tsx
+++ b/frontend/src/pages/UpdatePostPage/index.stories.tsx
@@ -1,4 +1,4 @@
-import { withRouter } from 'storybook-addon-react-router-v6';
+import { MemoryRouter as Router, Routes, Route } from 'react-router-dom';
 
 import UpdatePostPage from '.';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
@@ -6,10 +6,20 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 export default {
   title: 'Pages/UpdatePostPage',
   component: UpdatePostPage,
-  decorators: [withRouter],
 } as ComponentMeta<typeof UpdatePostPage>;
 
-const Template = () => <UpdatePostPage />;
+const Template = () => (
+  <Router
+    initialEntries={[
+      '/post/update',
+      { pathname: '/post/update', state: { id: 1, title: '수정할 글 제목', content: '수정할 글 내용' } },
+    ]}
+  >
+    <Routes>
+      <Route path="/post/update" element={<UpdatePostPage />} />
+    </Routes>
+  </Router>
+);
 
 export const UpdatePostPageTemplate: ComponentStory<typeof UpdatePostPage> = Template.bind({});
 UpdatePostPageTemplate.args = {};

--- a/frontend/src/pages/UpdatePostPage/index.styles.ts
+++ b/frontend/src/pages/UpdatePostPage/index.styles.ts
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+export const SpinnerContainer = styled.div`
+  width: 100%;
+  height: 500px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/frontend/src/pages/UpdatePostPage/index.tsx
+++ b/frontend/src/pages/UpdatePostPage/index.tsx
@@ -1,11 +1,43 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import Layout from '@/components/@styled/Layout';
 import PostForm from '@/components/PostForm';
+import Spinner from '@/components/Spinner';
+
+import useUpdatePost from '@/hooks/queries/post/useUpdatePost';
+
+import * as Styled from './index.styles';
+
+import NotFoundPage from '../NotFoundPage';
 
 const UpdatePostPage = () => {
   const location = useLocation();
-  const { title, content } = location.state as Pick<Post, 'content' | 'title'>;
+  const navigate = useNavigate();
+
+  if (!location.state) {
+    return <NotFoundPage />;
+  }
+
+  const { id, title, content } = location.state as Omit<Post, 'createdAt'>;
+
+  const { mutate: updatePost, isLoading } = useUpdatePost({
+    id,
+    options: {
+      onSuccess: () => {
+        navigate(-1);
+      },
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <Layout>
+        <Styled.SpinnerContainer>
+          <Spinner />
+        </Styled.SpinnerContainer>
+      </Layout>
+    );
+  }
 
   return (
     <Layout>
@@ -14,7 +46,7 @@ const UpdatePostPage = () => {
         submitType="글 수정하기"
         prevTitle={title}
         prevContent={content}
-        handlePost={() => {}}
+        handlePost={updatePost}
       />
     </Layout>
   );

--- a/frontend/src/pages/UpdatePostPage/index.tsx
+++ b/frontend/src/pages/UpdatePostPage/index.tsx
@@ -1,0 +1,23 @@
+import { useLocation } from 'react-router-dom';
+
+import Layout from '@/components/@styled/Layout';
+import PostForm from '@/components/PostForm';
+
+const UpdatePostPage = () => {
+  const location = useLocation();
+  const { title, content } = location.state as Pick<Post, 'content' | 'title'>;
+
+  return (
+    <Layout>
+      <PostForm
+        heading="글 수정"
+        submitType="글 수정하기"
+        prevTitle={title}
+        prevContent={content}
+        handlePost={() => {}}
+      />
+    </Layout>
+  );
+};
+
+export default UpdatePostPage;

--- a/frontend/src/style/GlobalStyle.tsx
+++ b/frontend/src/style/GlobalStyle.tsx
@@ -50,7 +50,9 @@ const style = css`
   }
 
   button {
+    font-family: 'Noto Sans KR', sans-serif;
     border: none;
+    cursor: pointer;
   }
 `;
 

--- a/frontend/src/style/theme.ts
+++ b/frontend/src/style/theme.ts
@@ -6,6 +6,7 @@ const theme = {
     gray_200: '#808080',
     gray_300: 'rgba(0, 0, 0, 0.55)',
     red_100: '#F3ABA4',
+    red_200: '#CC4949',
   },
 };
 

--- a/frontend/src/types/style.d.ts
+++ b/frontend/src/types/style.d.ts
@@ -9,6 +9,7 @@ declare module '@emotion/react' {
       gray_200: string;
       gray_300: string;
       red_100: string;
+      red_200: string;
     };
   }
 }


### PR DESCRIPTION

### 구현기능

작성된 글을 수정할 수 있는 기능을 구현한다.

### 세부 구현기능

- [x] 글 수정 페이지를 구현한다. 
- [x] 수정 API를 msw mocking으로 구현한다.
- [x] 글 상세보기 페이지에 `수정` 버튼을 추가한다. 

### 관련 이슈

close #72 

### 설명

1. [feat: PostForm 컴포넌트 구현](https://github.com/woowacourse-teams/2022-sokdak/commit/b8c30214aef5dae7123427c6f41dac38ca04aa44)
  a. 글 작성 페이지와 글 수정 페이지가 공통적으로 사용할 수 있도록 `PostForm` 컴포넌트 구현
2. [feat: PostForm 컴포넌트를 CreatePostPage에 활용](https://github.com/woowacourse-teams/2022-sokdak/commit/4f52c07e2353a390ba32de102331794dff57d1d0)
  a. 구현한 PostForm 컴포넌트를 CreatePostPage에 적용
3. [feat: 게시물을 수정하는 페이지인 UpdatePostPage 컴포넌트 구현](https://github.com/woowacourse-teams/2022-sokdak/commit/629eacc4042f08f8b72cf2309286dfffa155a8a7) 
  a. 글 수정 페이지(UpdatePostPage)의 UI만 구현
4. [feat: 수정 API msw mocking 구현](https://github.com/woowacourse-teams/2022-sokdak/commit/e26d518700513ca96a414b3ca76269cbc97ea099)
5. [feat: 수정 API를 위한 custom hook 구현](https://github.com/woowacourse-teams/2022-sokdak/commit/e04c3e496b6b3ae58a1902b780ab8a3ef3333138)
  a. `useCreatePost`와 거의 동일 
6. [feat: PostPage에 수정, 삭제 버튼 추가](https://github.com/woowacourse-teams/2022-sokdak/commit/5dc6aabff24047b88d113d979e6169b359a82746)
7. [feat: UpdatePostPage를 routes에 추가](https://github.com/woowacourse-teams/2022-sokdak/commit/5cda8f7df34e0579d9c3a57d73464a34fac005d2)
8. [feat: UpdatePostPage storybook에 예시 추가](https://github.com/woowacourse-teams/2022-sokdak/commit/b5188e881353d19bcb9117ea8900c61fa8409bbb)

