### PR TITLE
feat: 게시물 삭제 기능 구현 

### DIFF
--- a/frontend/.storybook/preview-body.html
+++ b/frontend/.storybook/preview-body.html
@@ -1,1 +1,2 @@
+<div id="confirm-modal"></div>
 <div id="snackbar"></div>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,6 +7,7 @@
     <title>속닥속닥</title>
   </head>
   <body>
+    <div id="confirm-modal"></div>
     <div id="snackbar"></div>
     <div id="root"></div>
   </body>

--- a/frontend/src/components/ConfirmModal/index.stories.tsx
+++ b/frontend/src/components/ConfirmModal/index.stories.tsx
@@ -1,0 +1,23 @@
+import { useReducer } from 'react';
+
+import ConfirmModal from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Components/ConfirmModal',
+  component: ConfirmModal,
+} as ComponentMeta<typeof ConfirmModal>;
+
+const Template: ComponentStory<typeof ConfirmModal> = args => {
+  const [isConfirmModalOpen, handleConfirmModal] = useReducer(state => !state, true);
+
+  return (
+    <>{isConfirmModalOpen && <ConfirmModal {...args} handleCancel={handleConfirmModal} handleConfirm={() => {}} />}</>
+  );
+};
+
+export const ConfirmModalTemplate: ComponentStory<typeof ConfirmModal> = Template.bind({});
+ConfirmModalTemplate.args = {
+  title: '삭제',
+  notice: '해당 글을 삭제하시겠습니까?',
+};

--- a/frontend/src/components/ConfirmModal/index.styles.ts
+++ b/frontend/src/components/ConfirmModal/index.styles.ts
@@ -1,0 +1,68 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const Modal = styled.div`
+  width: 260px;
+  height: 140px;
+  background: #ffffff;
+  box-shadow: 0px 1px 7px rgba(0, 0, 0, 0.25);
+  border-radius: 4px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  z-index: 20;
+`;
+
+export const Dimmer = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: black;
+  opacity: 0.2;
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  z-index: 10;
+`;
+
+export const Title = styled.p`
+  font-weight: 700;
+  font-size: 18px;
+`;
+
+export const Notice = styled.p`
+  font-weight: 400;
+  font-size: 13px;
+  color: ${props => props.theme.colors.gray_200};
+`;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const button = () => css`
+  width: 58px;
+  height: 28px;
+  border-radius: 4px;
+  font-size: 10px;
+  margin-left: 10px;
+`;
+
+export const ConfirmButton = styled.button`
+  ${button}
+
+  background: ${props => props.theme.colors.sub};
+  color: white;
+`;
+
+export const CancelButton = styled.button`
+  ${button}
+
+  background: white;
+  color: ${props => props.theme.colors.sub};
+`;

--- a/frontend/src/components/ConfirmModal/index.tsx
+++ b/frontend/src/components/ConfirmModal/index.tsx
@@ -1,0 +1,33 @@
+import ReactDOM from 'react-dom';
+
+import * as Styled from './index.styles';
+
+interface ConfirmModalProps {
+  title: string;
+  notice: string;
+  handleCancel: () => void;
+  handleConfirm: () => void;
+}
+
+const ConfirmModal = ({ title, notice, handleCancel, handleConfirm }: ConfirmModalProps) => {
+  return (
+    <>
+      {ReactDOM.createPortal(
+        <>
+          <Styled.Modal>
+            <Styled.Title>{title}</Styled.Title>
+            <Styled.Notice>{notice}</Styled.Notice>
+            <Styled.ButtonContainer>
+              <Styled.CancelButton onClick={handleCancel}>취소</Styled.CancelButton>
+              <Styled.ConfirmButton onClick={handleConfirm}>확인</Styled.ConfirmButton>
+            </Styled.ButtonContainer>
+          </Styled.Modal>
+          <Styled.Dimmer onClick={handleCancel}></Styled.Dimmer>
+        </>,
+        document.getElementById('confirm-modal')!,
+      )}
+    </>
+  );
+};
+
+export default ConfirmModal;

--- a/frontend/src/constants/snackbar.ts
+++ b/frontend/src/constants/snackbar.ts
@@ -1,6 +1,7 @@
 const SNACKBAR_MESSAGE = {
   SUCCESS_WRITE_POST: '글 작성에 성공하였습니다.',
   SUCCESS_UPDATE_POST: '글 수정에 성공하였습니다.',
+  SUCCESS_DELETE_POST: '해당 게시물이 삭제되었습니다.',
 };
 
 export default SNACKBAR_MESSAGE;

--- a/frontend/src/hooks/queries/post/useDeletePost.ts
+++ b/frontend/src/hooks/queries/post/useDeletePost.ts
@@ -1,0 +1,33 @@
+import { useContext } from 'react';
+import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
+
+import axios, { AxiosError, AxiosResponse } from 'axios';
+
+import SnackbarContext from '@/context/Snackbar';
+
+import QUERY_KEYS from '@/constants/queries';
+import SNACKBAR_MESSAGE from '@/constants/snackbar';
+
+const useDeletePost = (options?: UseMutationOptions<AxiosResponse, AxiosError, string>) => {
+  const queryClient = useQueryClient();
+  const { showSnackbar } = useContext(SnackbarContext);
+
+  return useMutation(
+    id => {
+      return axios.delete(`/posts/${id}`);
+    },
+    {
+      ...options,
+      onSuccess: (data, variables, context) => {
+        queryClient.resetQueries(QUERY_KEYS.POSTS);
+        showSnackbar(SNACKBAR_MESSAGE.SUCCESS_DELETE_POST);
+
+        if (options && options.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+      },
+    },
+  );
+};
+
+export default useDeletePost;

--- a/frontend/src/mocks/handlers/posts/index.ts
+++ b/frontend/src/mocks/handlers/posts/index.ts
@@ -64,6 +64,24 @@ const postHandlers = [
 
     return res(ctx.status(204));
   }),
+
+  rest.delete('/posts/:id', (req, res, ctx) => {
+    const params = req.params;
+    const id = Number(params.id);
+
+    const isTargetPostExist = postList.some(post => post.id === id);
+
+    if (!isTargetPostExist) {
+      return res(ctx.status(400), ctx.json({ message: '해당 글이 존재하지 않습니다.' }));
+    }
+
+    postList.splice(
+      postList.findIndex(post => post.id === id),
+      1,
+    );
+
+    return res(ctx.status(204));
+  }),
 ];
 
 export default postHandlers;

--- a/frontend/src/pages/PostPage/index.tsx
+++ b/frontend/src/pages/PostPage/index.tsx
@@ -1,8 +1,11 @@
+import { useReducer } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import Layout from '@/components/@styled/Layout';
+import ConfirmModal from '@/components/ConfirmModal';
 import Spinner from '@/components/Spinner';
 
+import useDeletePost from '@/hooks/queries/post/useDeletePost';
 import usePost from '@/hooks/queries/post/usePost';
 
 import * as Styled from './index.styles';
@@ -12,8 +15,16 @@ import timeConverter from '@/utils/timeConverter';
 
 const PostPage = () => {
   const navigate = useNavigate();
+
   const { id } = useParams();
   const { data, isLoading, isError } = usePost({ storeCode: id! });
+  const [isConfirmModalOpen, handleConfirmModal] = useReducer(state => !state, false);
+  const { mutate: deletePost } = useDeletePost({
+    onSuccess: () => {
+      handleConfirmModal();
+      navigate(-1);
+    },
+  });
 
   if (isLoading) {
     return (
@@ -51,7 +62,7 @@ const PostPage = () => {
             <Styled.UpdateButton onClick={() => navigate(PATH.UPDATE_POST, { state: { id, title, content } })}>
               수정
             </Styled.UpdateButton>
-            <Styled.DeleteButton>삭제</Styled.DeleteButton>
+            <Styled.DeleteButton onClick={handleConfirmModal}>삭제</Styled.DeleteButton>
           </Styled.PostController>
           <Styled.PostInfo>
             <Styled.Author>익명</Styled.Author>
@@ -66,6 +77,15 @@ const PostPage = () => {
           <Styled.ListButton to={PATH.HOME}>글 목록</Styled.ListButton>
         </Styled.ListButtonContainer>
       </Styled.Container>
+
+      {isConfirmModalOpen && (
+        <ConfirmModal
+          title="삭제"
+          notice="해당 글을 삭제하시겠습니까?"
+          handleCancel={handleConfirmModal}
+          handleConfirm={() => deletePost(id!)}
+        />
+      )}
     </Layout>
   );
 };


### PR DESCRIPTION
### 구현기능

작성된 글을 삭제할 수 있는 기능을 구현한다.

### 세부 구현기능

- [x] 글 상세보기 페이지에 `삭제`버튼을 추가한다. 
- [x] 사용자가 상세보기 페이지에서 `삭제`버튼을 눌렀을 때 적절한 안내를 통해 실수를 예방한다. 
- [x] 삭제 API를 msw mocking으로 구현한다. 

### 관련 이슈

close #73 
