### PR TITLE
feat: argumentResolver 매핑용 빈 추가 및 테스트코드 반영

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/config/WebMvcConfig.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/config/WebMvcConfig.java
@@ -3,6 +3,7 @@ package com.wooteco.sokdak.config;
 
 import com.wooteco.sokdak.support.AuthInterceptor;
 import com.wooteco.sokdak.support.LoginArgumentResolver;
+import com.wooteco.sokdak.support.AuthInfoMapper;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,6 +42,11 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new LoginArgumentResolver());
+        resolvers.add(new LoginArgumentResolver(getMapMember()));
+    }
+
+    @Bean
+    public AuthInfoMapper getMapMember() {
+        return new AuthInfoMapper();
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/support/AuthInfoMapper.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/support/AuthInfoMapper.java
@@ -1,0 +1,13 @@
+package com.wooteco.sokdak.support;
+
+import com.wooteco.sokdak.auth.dto.AuthInfo;
+import javax.servlet.http.HttpSession;
+
+public class AuthInfoMapper {
+    public AuthInfoMapper() {
+    }
+
+    public AuthInfo getAuthInfo(HttpSession session) {
+        return (AuthInfo) session.getAttribute("member");
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/support/LoginArgumentResolver.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/support/LoginArgumentResolver.java
@@ -10,6 +10,11 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
+    private final AuthInfoMapper authInfoMapper;
+
+    public LoginArgumentResolver(AuthInfoMapper authInfoMapper) {
+        this.authInfoMapper = authInfoMapper;
+    }
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -19,13 +24,13 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+    public AuthInfo resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                    NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         HttpSession session = request.getSession(false);
         if (session == null) {
             return null;
         }
-        return session.getAttribute("member");
+        return authInfoMapper.getAuthInfo(session);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/controller/PostControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/controller/PostControllerTest.java
@@ -2,17 +2,21 @@ package com.wooteco.sokdak.post.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.spy;
 
 import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
 import com.wooteco.sokdak.post.dto.PostResponse;
 import com.wooteco.sokdak.post.exception.PostNotFoundException;
+import com.wooteco.sokdak.support.AuthInfoMapper;
 import com.wooteco.sokdak.util.ControllerTest;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
@@ -21,21 +25,31 @@ import org.springframework.restdocs.RestDocumentationExtension;
 class PostControllerTest extends ControllerTest {
 
     private static final String SESSION_ID = "mySessionId";
+    private static final AuthInfo AUTH_INFO = new AuthInfo(1L);
 
     @Autowired
     PostController postController;
+
+    @MockBean
+    private AuthInfoMapper authInfoMapper;
+
+    @BeforeEach
+    void setUpArgumentResolver() {
+        //해당 부분에서 ArgumentResolver 리턴값을 목 형태로 만듦
+        given(authInfoMapper.getAuthInfo(any()))
+                .willReturn(AUTH_INFO);
+    }
+
 
     @DisplayName("글 작성 요청을 받으면 새로운 게시글을 등록한다.")
     @Test
     void addPost() {
         NewPostRequest postRequest = new NewPostRequest("제목", "본문");
-        given(postService.addPost(any(), any()))
-                .willReturn(1L);
 
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .sessionId("mySessionId")
-                .sessionAttr("member", new AuthInfo(1L))
+                .sessionId(SESSION_ID)
+                .sessionAttr("member", AUTH_INFO)
                 .body(postRequest)
                 .when().post("/posts")
                 .then().log().all()
@@ -50,6 +64,7 @@ class PostControllerTest extends ControllerTest {
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .sessionId(SESSION_ID)
+                .sessionAttr("member", AUTH_INFO)
                 .body(postRequest)
                 .when().post("/posts")
                 .then().log().all()
@@ -64,6 +79,7 @@ class PostControllerTest extends ControllerTest {
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .sessionId(SESSION_ID)
+                .sessionAttr("member", AUTH_INFO)
                 .body(postRequest)
                 .when().post("/posts")
                 .then().log().all()
@@ -81,6 +97,7 @@ class PostControllerTest extends ControllerTest {
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .sessionId(SESSION_ID)
+                .sessionAttr("member", AUTH_INFO)
                 .when().get("/posts?size=3&page=0")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
@@ -96,6 +113,7 @@ class PostControllerTest extends ControllerTest {
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .sessionId(SESSION_ID)
+                .sessionAttr("member", AUTH_INFO)
                 .when().get("/posts/1")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
@@ -110,6 +128,7 @@ class PostControllerTest extends ControllerTest {
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .sessionId(SESSION_ID)
+                .sessionAttr("member", AUTH_INFO)
                 .when().get("/posts/9999")
                 .then().log().all()
                 .statusCode(HttpStatus.NOT_FOUND.value());


### PR DESCRIPTION
### 구현기능
`Object` -> `AuthInfo` 매핑 부분이 `Mock` 객체에서는 진행되지 않아 
일단 매핑용 빈(`AuthInfoMapper`)을 추가하고, 테스트 코드에서 `@MockBean`으로 설정함
(해당 방식은 ArgumentResolver를 목으로 만든 것으로, 통합테스트라고 볼 순 없음)

### 세부 구현기능
- [x] `Object` -> `AuthInfo` 매핑 부분 빈 등록
- [x] PostController 테스트
  - [x] `AuthInfoMapper`를 `@MockBean` 설정
  - [x] `AuthInfoMapper` 값 미리 세팅

### 관련 이슈
- 앞으로 `RestAssuredMockMvc`에서 세션 값 매핑이 이뤄질 때 마다 `sessionId()`, `sessionAttribute()`를 설정해주면 됨
- 컨트롤러 테스트 범위에 대해 논의 필요