### PR TITLE
chore: production용 webpack 설정

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start:MSW": "eslint . && env-cmd -f ./env/.env.mocking webpack serve --open --config ./webpack/webpack.dev.js",
     "start": "eslint . && env-cmd -f ./env/.env.local webpack serve --open --config ./webpack/webpack.dev.js",
-    "build": "webpack --config ./webpack/webpack.prod.js",
+    "build": "env-cmd -f ./env/.env.production webpack --config ./webpack/webpack.prod.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/frontend/webpack/webpack.config.js
+++ b/frontend/webpack/webpack.config.js
@@ -2,7 +2,6 @@ const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const Dotenv = require('dotenv-webpack');
 require('dotenv').config();
@@ -45,7 +44,7 @@ module.exports = {
             ],
             '@babel/typescript',
           ],
-          plugins: ['@emotion', 'react-refresh/babel'].filter(Boolean),
+          plugins: ['@emotion'].filter(Boolean),
         },
       },
       {
@@ -64,7 +63,6 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, '../public/index.html'),
     }),
-    new ReactRefreshWebpackPlugin(),
   ],
   devtool: 'source-map',
 };

--- a/frontend/webpack/webpack.dev.js
+++ b/frontend/webpack/webpack.dev.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 const common = require('./webpack.config');
 const { DefinePlugin } = require('webpack');
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
 require('dotenv').config();
 
@@ -12,6 +13,7 @@ module.exports = merge(common, {
       'process.env.API_URL': JSON.stringify(process.env.API_URL),
       'process.env.MODE': JSON.stringify(process.env.MODE),
     }),
+    new ReactRefreshWebpackPlugin(),
   ],
   devServer: {
     port: 3000,


### PR DESCRIPTION
### 설명

webpack 설정을 변경한다. 

### 세부 기능 요구사항

- [x] production 용 webpack에는 `react-refresh`가 plugin되어 있으면 안되므로 삭제 
- [x] build시 production 환경변수를 참조하도록 변경

### 관련이슈 

close #107 
