### PR TITLE
feat: 회원과 게시물 연관관계 매핑

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/advice/ControllerAdvice.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/advice/ControllerAdvice.java
@@ -28,6 +28,11 @@ public class ControllerAdvice {
         return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
     }
 
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponse(e.getMessage()));
+    }
+
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorResponse> handleRuntimeException() {
         return ResponseEntity.internalServerError().body(new ErrorResponse("서버에 알 수 없는 문제가 발생했습니다."));

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/advice/ForbiddenException.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/advice/ForbiddenException.java
@@ -1,0 +1,8 @@
+package com.wooteco.sokdak.advice;
+
+public class ForbiddenException extends BusinessException {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/exception/AuthenticationException.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/exception/AuthenticationException.java
@@ -1,0 +1,12 @@
+package com.wooteco.sokdak.auth.exception;
+
+import com.wooteco.sokdak.advice.ForbiddenException;
+
+public class AuthenticationException extends ForbiddenException {
+
+    private static final String MESSAGE = "권한이 없습니다.";
+
+    public AuthenticationException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/domain/Member.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/domain/Member.java
@@ -28,7 +28,8 @@ public class Member {
     }
 
     @Builder
-    public Member(String username, String password, String nickname) {
+    public Member(Long id, String username, String password, String nickname) {
+        this.id = id;
         this.username = new Username(username);
         this.password = password;
         this.nickname = new Nickname(nickname);

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/exception/MemberNotFoundException.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/exception/MemberNotFoundException.java
@@ -1,0 +1,12 @@
+package com.wooteco.sokdak.member.exception;
+
+import com.wooteco.sokdak.advice.NotFoundException;
+
+public class MemberNotFoundException extends NotFoundException {
+
+    private static final String MESSAGE = "멤버가 존재하지 않습니다.";
+
+    public MemberNotFoundException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/controller/PostController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/controller/PostController.java
@@ -4,7 +4,7 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 
 import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
-import com.wooteco.sokdak.post.dto.PostResponse;
+import com.wooteco.sokdak.post.dto.PostDetailResponse;
 import com.wooteco.sokdak.post.dto.PostUpdateRequest;
 import com.wooteco.sokdak.post.dto.PostsResponse;
 import com.wooteco.sokdak.post.service.PostService;
@@ -34,8 +34,8 @@ public class PostController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<PostResponse> findPost(@PathVariable Long id) {
-        PostResponse postResponse = postService.findPost(id);
+    public ResponseEntity<PostDetailResponse> findPost(@PathVariable Long id, @Login AuthInfo authInfo) {
+        PostDetailResponse postResponse = postService.findPost(id, authInfo);
         return ResponseEntity.ok(postResponse);
     }
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/controller/PostController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/controller/PostController.java
@@ -2,11 +2,13 @@ package com.wooteco.sokdak.post.controller;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
+import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
 import com.wooteco.sokdak.post.dto.PostResponse;
 import com.wooteco.sokdak.post.dto.PostUpdateRequest;
 import com.wooteco.sokdak.post.dto.PostsResponse;
 import com.wooteco.sokdak.post.service.PostService;
+import com.wooteco.sokdak.support.Login;
 import java.net.URI;
 import javax.validation.Valid;
 import org.springframework.data.domain.Pageable;
@@ -38,8 +40,8 @@ public class PostController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> addPost(@Valid @RequestBody NewPostRequest newPostRequest) {
-        Long postId = postService.addPost(newPostRequest);
+    public ResponseEntity<Void> addPost(@Valid @RequestBody NewPostRequest newPostRequest, @Login AuthInfo authInfo) {
+        Long postId = postService.addPost(newPostRequest, authInfo);
         return ResponseEntity.created(URI.create("/posts/" + postId)).build();
     }
 
@@ -52,14 +54,15 @@ public class PostController {
 
     @PutMapping("/{id}")
     public ResponseEntity<Void> updatePost(@PathVariable Long id,
-                                           @Valid @RequestBody PostUpdateRequest postUpdateRequest) {
-        postService.updatePost(id, postUpdateRequest);
+                                           @Valid @RequestBody PostUpdateRequest postUpdateRequest,
+                                           @Login AuthInfo authInfo) {
+        postService.updatePost(id, postUpdateRequest, authInfo);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletePost(@PathVariable Long id) {
-        postService.deletePost(id);
+    public ResponseEntity<Void> deletePost(@PathVariable Long id, @Login AuthInfo authInfo) {
+        postService.deletePost(id, authInfo);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -14,6 +14,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.Builder;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -37,6 +38,9 @@ public class Post {
 
     @CreatedDate
     private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
 
     protected Post() {
     }
@@ -68,6 +72,10 @@ public class Post {
         return member;
     }
 
+    public boolean isModified() {
+        return !createdAt.equals(modifiedAt);
+    }
+
     public void updateTitle(String title, Long accessMemberId) {
         validateOwner(accessMemberId);
         this.title = new Title(title);
@@ -82,5 +90,12 @@ public class Post {
         if (accessMemberId != member.getId()) {
             throw new AuthenticationException();
         }
+    }
+
+    public boolean isAuthenticated(Long accessMemberId) {
+        if (accessMemberId == null) {
+            return false;
+        }
+        return member.getId().equals(accessMemberId);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -1,5 +1,6 @@
 package com.wooteco.sokdak.post.domain;
 
+import com.wooteco.sokdak.auth.exception.AuthenticationException;
 import com.wooteco.sokdak.member.domain.Member;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
@@ -67,11 +68,19 @@ public class Post {
         return member;
     }
 
-    public void updateTitle(String title) {
+    public void updateTitle(String title, Long accessMemberId) {
+        validateOwner(accessMemberId);
         this.title = new Title(title);
     }
 
-    public void updateContent(String content) {
+    public void updateContent(String content, Long accessMemberId) {
+        validateOwner(accessMemberId);
         this.content = new Content(content);
+    }
+
+    public void validateOwner(Long accessMemberId) {
+        if (accessMemberId != member.getId()) {
+            throw new AuthenticationException();
+        }
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostsElementResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostsElementResponse.java
@@ -5,25 +5,28 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
-public class PostResponse {
+public class PostsElementResponse {
 
     private final Long id;
     private final String title;
     private final String content;
     private final LocalDateTime createdAt;
+    private final boolean modified;
 
-    public PostResponse(Long id, String title, String content, LocalDateTime createdAt) {
+    public PostsElementResponse(Long id, String title, String content, LocalDateTime createdAt, boolean modified) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.createdAt = createdAt;
+        this.modified = modified;
     }
 
-    public static PostResponse from(Post post) {
-        return new PostResponse(
+    public static PostsElementResponse from(Post post) {
+        return new PostsElementResponse(
                 post.getId(),
                 post.getTitle(),
                 post.getContent(),
-                post.getCreatedAt());
+                post.getCreatedAt(),
+                post.isModified());
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostsResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostsResponse.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 @Getter
 public class PostsResponse {
 
-    private final List<PostResponse> posts;
+    private final List<PostsElementResponse> posts;
     private final boolean lastPage;
 
-    public PostsResponse(List<PostResponse> posts, boolean lastPage) {
+    public PostsResponse(List<PostsElementResponse> posts, boolean lastPage) {
         this.posts = posts;
         this.lastPage = lastPage;
     }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -6,8 +6,9 @@ import com.wooteco.sokdak.member.exception.MemberNotFoundException;
 import com.wooteco.sokdak.member.repository.MemberRepository;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
-import com.wooteco.sokdak.post.dto.PostResponse;
+import com.wooteco.sokdak.post.dto.PostDetailResponse;
 import com.wooteco.sokdak.post.dto.PostUpdateRequest;
+import com.wooteco.sokdak.post.dto.PostsElementResponse;
 import com.wooteco.sokdak.post.dto.PostsResponse;
 import com.wooteco.sokdak.post.exception.PostNotFoundException;
 import com.wooteco.sokdak.post.repository.PostRepository;
@@ -42,19 +43,20 @@ public class PostService {
         return postRepository.save(post).getId();
     }
 
-    public PostResponse findPost(Long postId) {
+    public PostDetailResponse findPost(Long postId, AuthInfo authInfo) {
+        System.out.println(authInfo);
         Post foundPost = postRepository.findById(postId)
                 .orElseThrow(PostNotFoundException::new);
-        return PostResponse.from(foundPost);
+        return PostDetailResponse.of(foundPost, foundPost.isAuthenticated(authInfo.getId()));
     }
 
     public PostsResponse findPosts(Pageable pageable) {
         Slice<Post> posts = postRepository.findSliceBy(pageable);
-        List<PostResponse> postResponses = posts.getContent()
+        List<PostsElementResponse> postsElementResponses = posts.getContent()
                 .stream()
-                .map(PostResponse::from)
+                .map(PostsElementResponse::from)
                 .collect(Collectors.toUnmodifiableList());
-        return new PostsResponse(postResponses, posts.isLast());
+        return new PostsResponse(postsElementResponses, posts.isLast());
     }
 
     @Transactional

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -48,7 +48,6 @@ public class PostService {
         return PostResponse.from(foundPost);
     }
 
-
     public PostsResponse findPosts(Pageable pageable) {
         Slice<Post> posts = postRepository.findSliceBy(pageable);
         List<PostResponse> postResponses = posts.getContent()

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/support/AuthInfoMapper.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/support/AuthInfoMapper.java
@@ -4,6 +4,7 @@ import com.wooteco.sokdak.auth.dto.AuthInfo;
 import javax.servlet.http.HttpSession;
 
 public class AuthInfoMapper {
+
     public AuthInfoMapper() {
     }
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/support/LoginArgumentResolver.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/support/LoginArgumentResolver.java
@@ -10,6 +10,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
+
     private final AuthInfoMapper authInfoMapper;
 
     public LoginArgumentResolver(AuthInfoMapper authInfoMapper) {
@@ -29,7 +30,7 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         HttpSession session = request.getSession(false);
         if (session == null) {
-            return null;
+            return new AuthInfo(null);
         }
         return authInfoMapper.getAuthInfo(session);
     }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
@@ -15,8 +15,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.wooteco.sokdak.auth.dto.LoginRequest;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
-import com.wooteco.sokdak.post.dto.PostResponse;
+import com.wooteco.sokdak.post.dto.PostDetailResponse;
 import com.wooteco.sokdak.post.dto.PostUpdateRequest;
+import com.wooteco.sokdak.post.dto.PostsElementResponse;
 import com.wooteco.sokdak.post.dto.PostsResponse;
 import com.wooteco.sokdak.util.AcceptanceTest;
 import io.restassured.response.ExtractableResponse;
@@ -76,12 +77,12 @@ class PostAcceptanceTest extends AcceptanceTest {
                 httpPostWithAuthorization(NEW_POST_REQUEST, "/posts", getSessionId()));
 
         ExtractableResponse<Response> response = httpGet("/posts/" + postId);
-        PostResponse postResponse = response.jsonPath().getObject(".", PostResponse.class);
+        PostDetailResponse postDetailResponse = response.jsonPath().getObject(".", PostDetailResponse.class);
 
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(postResponse.getTitle()).isEqualTo(NEW_POST_REQUEST.getTitle()),
-                () -> assertThat(postResponse.getContent()).isEqualTo(NEW_POST_REQUEST.getContent())
+                () -> assertThat(postDetailResponse.getTitle()).isEqualTo(NEW_POST_REQUEST.getTitle()),
+                () -> assertThat(postDetailResponse.getContent()).isEqualTo(NEW_POST_REQUEST.getContent())
         );
     }
 
@@ -120,11 +121,12 @@ class PostAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response =
                 httpPutWithAuthorization(postUpdateRequest, "/posts/" + postId, getSessionId());
 
-        PostResponse postResponse = httpGet("/posts/" + postId).jsonPath().getObject(".", PostResponse.class);
+        PostDetailResponse postDetailResponse = httpGet("/posts/" + postId).jsonPath()
+                .getObject(".", PostDetailResponse.class);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
-                () -> assertThat(postResponse.getTitle()).isEqualTo(UPDATED_POST_TITLE),
-                () -> assertThat(postResponse.getContent()).isEqualTo(UPDATED_POST_CONTENT)
+                () -> assertThat(postDetailResponse.getTitle()).isEqualTo(UPDATED_POST_TITLE),
+                () -> assertThat(postDetailResponse.getContent()).isEqualTo(UPDATED_POST_CONTENT)
         );
     }
 
@@ -159,7 +161,7 @@ class PostAcceptanceTest extends AcceptanceTest {
                 .getObject(".", PostsResponse.class)
                 .getPosts()
                 .stream()
-                .map(PostResponse::getTitle)
+                .map(PostsElementResponse::getTitle)
                 .collect(Collectors.toList());
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
@@ -1,5 +1,9 @@
 package com.wooteco.sokdak.post.acceptance;
 
+import static com.wooteco.sokdak.post.util.PostFixture.UPDATED_POST_CONTENT;
+import static com.wooteco.sokdak.post.util.PostFixture.UPDATED_POST_TITLE;
+import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_CONTENT;
+import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_TITLE;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.getExceptionMessage;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpDeleteWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpGet;
@@ -26,7 +30,7 @@ import org.springframework.http.HttpStatus;
 @DisplayName("게시글 관련 인수테스트")
 class PostAcceptanceTest extends AcceptanceTest {
 
-    private static final NewPostRequest NEW_POST_REQUEST = new NewPostRequest("제목", "본문");
+    private static final NewPostRequest NEW_POST_REQUEST = new NewPostRequest(VALID_POST_TITLE, VALID_POST_CONTENT);
 
     @DisplayName("새로운 게시글을 작성할 수 있다.")
     @Test
@@ -84,7 +88,7 @@ class PostAcceptanceTest extends AcceptanceTest {
     @DisplayName("게시글 제목이 없는 경우 글 작성을 할 수 없다.")
     @Test
     void addPost_Exception_NoTitle() {
-        NewPostRequest newPostRequestWithoutTitle = new NewPostRequest(null, "본문");
+        NewPostRequest newPostRequestWithoutTitle = new NewPostRequest(null, VALID_POST_CONTENT);
         ExtractableResponse<Response> response =
                 httpPostWithAuthorization(newPostRequestWithoutTitle, "/posts", getSessionId());
 
@@ -112,15 +116,15 @@ class PostAcceptanceTest extends AcceptanceTest {
         String postId = parsePostId(
                 httpPostWithAuthorization(NEW_POST_REQUEST, "/posts", getSessionId()));
 
-        PostUpdateRequest postUpdateRequest = new PostUpdateRequest("변경된 제목", "변경된 본문");
+        PostUpdateRequest postUpdateRequest = new PostUpdateRequest(UPDATED_POST_TITLE, UPDATED_POST_CONTENT);
         ExtractableResponse<Response> response =
                 httpPutWithAuthorization(postUpdateRequest, "/posts/" + postId, getSessionId());
 
         PostResponse postResponse = httpGet("/posts/" + postId).jsonPath().getObject(".", PostResponse.class);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
-                () -> assertThat(postResponse.getTitle()).isEqualTo("변경된 제목"),
-                () -> assertThat(postResponse.getContent()).isEqualTo("변경된 본문")
+                () -> assertThat(postResponse.getTitle()).isEqualTo(UPDATED_POST_TITLE),
+                () -> assertThat(postResponse.getContent()).isEqualTo(UPDATED_POST_CONTENT)
         );
     }
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/controller/PostControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/controller/PostControllerTest.java
@@ -1,10 +1,9 @@
 package com.wooteco.sokdak.post.controller;
 
+import static com.wooteco.sokdak.util.fixture.MemberFixture.AUTH_INFO;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.spy;
 
-import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
 import com.wooteco.sokdak.post.dto.PostResponse;
 import com.wooteco.sokdak.post.exception.PostNotFoundException;
@@ -25,7 +24,6 @@ import org.springframework.restdocs.RestDocumentationExtension;
 class PostControllerTest extends ControllerTest {
 
     private static final String SESSION_ID = "mySessionId";
-    private static final AuthInfo AUTH_INFO = new AuthInfo(1L);
 
     @Autowired
     PostController postController;
@@ -35,11 +33,9 @@ class PostControllerTest extends ControllerTest {
 
     @BeforeEach
     void setUpArgumentResolver() {
-        //해당 부분에서 ArgumentResolver 리턴값을 목 형태로 만듦
         given(authInfoMapper.getAuthInfo(any()))
                 .willReturn(AUTH_INFO);
     }
-
 
     @DisplayName("글 작성 요청을 받으면 새로운 게시글을 등록한다.")
     @Test

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
@@ -4,7 +4,9 @@ import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_NICKNAME;
 import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_PASSWORD;
 import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.wooteco.sokdak.auth.exception.AuthenticationException;
 import com.wooteco.sokdak.member.domain.Member;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -37,11 +39,29 @@ class PostTest {
         assertThat(post.getTitle()).isEqualTo("변경된 제목");
     }
 
+    @DisplayName("권한이 없는 게시글의 제목을 수정하려할 시 예외 발생")
+    @Test
+    void updateTitle_Exception_ForbiddenId() {
+        Long forbiddenMemberId = 2L;
+
+        assertThatThrownBy(() -> post.updateTitle("변경된 제목", forbiddenMemberId))
+                .isInstanceOf(AuthenticationException.class);
+    }
+
     @DisplayName("게시글 본문 수정")
     @Test
     void updateContent() {
         post.updateContent("변경된 본문", 1L);
 
         assertThat(post.getContent()).isEqualTo("변경된 본문");
+    }
+
+    @DisplayName("권한이 없는 게시글의 본문을 수정하려할 시 예외 발생")
+    @Test
+    void updateContent_Exception_ForbiddenId() {
+        Long forbiddenMemberId = 2L;
+
+        assertThatThrownBy(() -> post.updateContent("변경된 본문", forbiddenMemberId))
+                .isInstanceOf(AuthenticationException.class);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
@@ -11,6 +11,8 @@ import com.wooteco.sokdak.member.domain.Member;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class PostTest {
 
@@ -63,5 +65,14 @@ class PostTest {
 
         assertThatThrownBy(() -> post.updateContent("변경된 본문", forbiddenMemberId))
                 .isInstanceOf(AuthenticationException.class);
+    }
+
+    @DisplayName("게시글의 회원 정보가 일치하는지 반환")
+    @ParameterizedTest
+    @CsvSource({"1, true", "2, false"})
+    void isAuthenticated(Long accessMemberId, boolean expected) {
+        boolean actual = post.isAuthenticated(accessMemberId);
+
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
@@ -1,21 +1,38 @@
 package com.wooteco.sokdak.post.domain;
 
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_NICKNAME;
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_PASSWORD;
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.wooteco.sokdak.member.domain.Member;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class PostTest {
 
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        Member member = Member.builder()
+                .id(1L)
+                .username(VALID_USERNAME)
+                .password(VALID_PASSWORD)
+                .nickname(VALID_NICKNAME)
+                .build();
+        post = Post.builder()
+                .title("제목")
+                .content("본문")
+                .member(member)
+                .build();
+    }
+
     @DisplayName("게시글 제목 수정")
     @Test
     void updateTitle() {
-        Post post = Post.builder()
-                .title("제목")
-                .content("본문")
-                .build();
-
-        post.updateTitle("변경된 제목");
+        post.updateTitle("변경된 제목", 1L);
 
         assertThat(post.getTitle()).isEqualTo("변경된 제목");
     }
@@ -23,12 +40,7 @@ class PostTest {
     @DisplayName("게시글 본문 수정")
     @Test
     void updateContent() {
-        Post post = Post.builder()
-                .title("제목")
-                .content("본문")
-                .build();
-
-        post.updateContent("변경된 본문");
+        post.updateContent("변경된 본문", 1L);
 
         assertThat(post.getContent()).isEqualTo("변경된 본문");
     }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/util/PostFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/util/PostFixture.java
@@ -1,0 +1,13 @@
+package com.wooteco.sokdak.post.util;
+
+public class PostFixture {
+
+    public static final String VALID_POST_TITLE = "제목";
+    public static final String VALID_POST_CONTENT = "본문";
+
+    public static final String UPDATED_POST_TITLE = "변경된 제목";
+    public static final String UPDATED_POST_CONTENT = "변경된 본문";
+
+    public static final String INVALID_POST_TITLE = "A".repeat(51);
+    public static final String INVALID_POST_CONTENT = "A".repeat(5001);
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/MemberFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/MemberFixture.java
@@ -1,5 +1,6 @@
 package com.wooteco.sokdak.util.fixture;
 
+import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.auth.dto.LoginRequest;
 
 public class MemberFixture {
@@ -7,9 +8,13 @@ public class MemberFixture {
     public static final String VALID_USERNAME = "chris";
     public static final String VALID_PASSWORD = "Abcd123!@";
     public static final String VALID_ENCRYPTED_PASSWORD = "6297d64078fc9abcfe37d0e2c910d4798bb4c04502d7dd1207f558860c2b382e";
+    public static final String VALID_NICKNAME = "josh";
+
     public static final String INVALID_USERNAME = "invalidUsername";
     public static final String INVALID_PASSWORD = "invalidPassword1!";
 
     public static final LoginRequest VALID_LOGIN_REQUEST = new LoginRequest(VALID_USERNAME, VALID_PASSWORD);
     public static final LoginRequest INVALID_LOGIN_REQUEST = new LoginRequest(INVALID_USERNAME, INVALID_PASSWORD);
+
+    public static final AuthInfo AUTH_INFO = new AuthInfo(1L);
 }


### PR DESCRIPTION
### 구현기능
- [x] 회원과 게시물 연관관계 매핑

### 세부 구현기능
- [x] 게시물과 회원 단방향 연관관계 매핑
- [x] 게시물 수정, 삭제시 회원 정보 검증
- [x] 로그인 상태, 로그아웃 상태 모두 게시글을 조회할 수 있는 기능 구현
