### PR TITLE
feat: 글 상세보기 페이지에서 해쉬태그 표시

### DIFF
--- a/frontend/src/components/HashTag/index.styles.ts
+++ b/frontend/src/components/HashTag/index.styles.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-export const Container = styled.div`
+export const Container = styled.div<{ onClick: React.MouseEventHandler<HTMLDivElement> | undefined }>`
   min-width: fit-content;
   height: 23px;
   border: 1px solid ${props => props.theme.colors.sub};
@@ -11,5 +11,5 @@ export const Container = styled.div`
   padding: 6px;
   box-sizing: border-box;
   user-select: none;
-  cursor: pointer;
+  cursor: ${props => (!!props.onClick ? 'pointer' : null)};
 `;

--- a/frontend/src/components/HashTag/index.tsx
+++ b/frontend/src/components/HashTag/index.tsx
@@ -1,9 +1,8 @@
 import * as Styled from './index.styles';
 
 interface HashTagProps {
-  id?: number;
   name: string;
-  handleTagClick?: () => void;
+  handleTagClick?: React.MouseEventHandler<HTMLDivElement>;
 }
 
 const HashTag = ({ name, handleTagClick }: HashTagProps) => {

--- a/frontend/src/components/PostForm/index.styles.ts
+++ b/frontend/src/components/PostForm/index.styles.ts
@@ -102,7 +102,7 @@ export const appear = keyframes`
 export const TagTooltip = styled.div`
   position: absolute;
   background-color: black;
-  opacity: 0.6;
+  opacity: 0.75;
   width: 115px;
   height: 60px;
   top: -67px;

--- a/frontend/src/components/Snackbar/index.styles.ts
+++ b/frontend/src/components/Snackbar/index.styles.ts
@@ -16,6 +16,7 @@ export const Container = styled.div`
   transform: translateX(-50%);
   -webkit-animation: fadein 0.5s, fadeout 0.5s 1.2s;
   animation: fadein 0.5s, fadeout 0.5s 1.2s;
+  z-index: 500;
 
   @-webkit-keyframes fadein {
     from {

--- a/frontend/src/pages/PostPage/index.styles.ts
+++ b/frontend/src/pages/PostPage/index.styles.ts
@@ -78,11 +78,22 @@ export const ContentContainer = styled.div`
   min-height: 420px;
   border-bottom: 1px solid ${props => props.theme.colors.sub};
   margin-bottom: 25px;
-  padding-bottom: 20px;
 `;
 
 export const Content = styled.p`
+  min-height: 370px;
   line-height: 25px;
+`;
+
+export const TagContainer = styled.div`
+  min-height: 50px;
+  float: left;
+  display: flex;
+  box-sizing: border-box;
+  flex-wrap: wrap;
+  gap: 5px;
+  row-gap: 10px;
+  padding: 15px 0;
 `;
 
 export const ListButtonContainer = styled.div`

--- a/frontend/src/pages/PostPage/index.tsx
+++ b/frontend/src/pages/PostPage/index.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import CommentList from './components/CommentList';
 import Layout from '@/components/@styled/Layout';
 import ConfirmModal from '@/components/ConfirmModal';
+import HashTag from '@/components/HashTag';
 import LikeButton from '@/components/LikeButton';
 import Spinner from '@/components/Spinner';
 
@@ -102,6 +103,11 @@ const PostPage = () => {
 
         <Styled.ContentContainer>
           <Styled.Content>{content}</Styled.Content>
+          <Styled.TagContainer>
+            {hashtags.map(({ name }) => (
+              <HashTag key={name} name={name} />
+            ))}
+          </Styled.TagContainer>
         </Styled.ContentContainer>
         <CommentList id={id!} />
       </Styled.Container>


### PR DESCRIPTION
### 구현기능

글 상세보기 페이지에서 해당 글에 달려있는 태그를 표시한다.

### 세부 구현기능

### 관련 이슈

close #128 