### PR TITLE
fix: 좋아요 수에 따라 하트 svg 크기가 달라지지 않도록 수정

### DIFF
--- a/frontend/src/components/LikeButton/index.styles.ts
+++ b/frontend/src/components/LikeButton/index.styles.ts
@@ -4,11 +4,12 @@ export const Button = styled.button<{ isLiked: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 60px;
+  min-width: 50px;
   height: 30px;
   border-radius: 15px;
   border: 1px solid ${props => (props.isLiked ? props.theme.colors.pink_300 : props.theme.colors.gray_300)};
   gap: 4px;
-  color: ${props => (props.isLiked ? props.theme.colors.pink_300 : props.theme.colors.gray_300)};
   background-color: inherit;
+  font-size: 13px;
+  color: ${props => (props.isLiked ? props.theme.colors.pink_300 : props.theme.colors.gray_300)};
 `;

--- a/frontend/src/components/LikeButton/index.tsx
+++ b/frontend/src/components/LikeButton/index.tsx
@@ -3,6 +3,7 @@ import { HTMLAttributes } from 'react';
 import * as Styled from './index.styles';
 
 import HeartImg from '@/assets/images/heart.svg';
+import countFormatter from '@/utils/countFormatter';
 
 import { useTheme } from '@emotion/react';
 
@@ -18,7 +19,8 @@ const LikeButton = ({ isLiked, onClick, likeCount }: LikeButtonProps) => {
 
   return (
     <Styled.Button isLiked={isLiked} onClick={onClick}>
-      <HeartImg fill={fillColor} stroke={strokeColor} width="20px" height="20px" /> {likeCount}
+      <HeartImg fill={fillColor} stroke={strokeColor} width="16px" height="14px" />
+      {countFormatter(likeCount)}
     </Styled.Button>
   );
 };


### PR DESCRIPTION
### 설명

하트 svg 크기가 좋아요 수에 따라 달라지는 문제를 해결

### 세부 구현기능

- [x] `LikeButton`에 `min-width` 적용
- [x] countFormatter 적용

### 관련 이슈

close #138 
