### PR TITLE
fix: 게시글 삭제 시 해시태그 관련 오류 FIX #143

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -121,7 +121,8 @@ public class PostService {
         Post post = postRepository.findById(id)
                 .orElseThrow(PostNotFoundException::new);
         post.validateOwner(authInfo.getId());
+
+        postHashtagRepository.deleteAllByPostId(id);
         postRepository.delete(post);
-        postHashtagRepository.deleteAllByPostId(post.getId());
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
@@ -19,6 +19,7 @@ import com.wooteco.sokdak.post.dto.PostUpdateRequest;
 import com.wooteco.sokdak.post.dto.PostsElementResponse;
 import com.wooteco.sokdak.post.dto.PostsResponse;
 import com.wooteco.sokdak.post.exception.PostNotFoundException;
+import com.wooteco.sokdak.post.repository.HashtagRepository;
 import com.wooteco.sokdak.post.repository.PostHashtagRepository;
 import com.wooteco.sokdak.post.repository.PostRepository;
 import java.util.ArrayList;
@@ -50,6 +51,9 @@ class PostServiceTest {
 
     @Autowired
     private PostHashtagRepository postHashtagRepository;
+
+    @Autowired
+    private HashtagRepository hashtagRepository;
 
     private Post post;
 
@@ -207,6 +211,8 @@ class PostServiceTest {
     @DisplayName("게시글 삭제 기능")
     @Test
     void deletePost() {
+        Hashtag hashtag = hashtagRepository.save(new Hashtag("태그1"));
+        PostHashtag postHashtag = postHashtagRepository.save(new PostHashtag(post, hashtag));
         Long postId = postRepository.save(post).getId();
 
         postService.deletePost(postId, AUTH_INFO);


### PR DESCRIPTION
### 구현기능
게시글 삭제 시 해시태그 관련 오류 해결

### 세부 구현기능
- [x] 포스트를 먼저 지우고 해시태그를 지우고 있어 문제가 났습니다. 메소드 호출 순서를 바꿨습니다.

### 관련 이슈

관련해 메소드를 빼면 좋을 것 같습니다.
