### PR TITLE
fix: 좋아요/댓글 있는 경우 게시글 삭제 안되는 버그 수정

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/repository/CommentRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/repository/CommentRepository.java
@@ -15,4 +15,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<String> findNicknamesByPostId(@Param("postId") Long postId);
 
     List<Comment> findAllByPostId(Long postId);
+
+    void deleteAllByPostId(Long id);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/repository/LikeRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/repository/LikeRepository.java
@@ -11,4 +11,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     int countByPostId(Long postId);
 
     boolean existsByMemberIdAndPostId(Long memberId, Long postId);
+
+    void deleteAllByPostId(Long id);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -43,10 +43,10 @@ public class Post {
     @Embedded
     private Content content;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "post")
     private List<Like> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post", orphanRemoval = true)
+    @OneToMany(mappedBy = "post")
     private List<Comment> comments = new ArrayList<>();
 
     @CreatedDate

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -7,6 +7,7 @@ import com.wooteco.sokdak.member.domain.Member;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -42,10 +43,10 @@ public class Post {
     @Embedded
     private Content content;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private List<Like> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
     @CreatedDate

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -1,6 +1,7 @@
 package com.wooteco.sokdak.post.service;
 
 import com.wooteco.sokdak.auth.dto.AuthInfo;
+import com.wooteco.sokdak.comment.repository.CommentRepository;
 import com.wooteco.sokdak.like.repository.LikeRepository;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.exception.MemberNotFoundException;
@@ -32,15 +33,18 @@ public class PostService {
     private final MemberRepository memberRepository;
     private final HashtagRepository hashtagRepository;
     private final PostHashtagRepository postHashtagRepository;
+    private final CommentRepository commentRepository;
     private final LikeRepository likeRepository;
 
 
     public PostService(PostRepository postRepository, MemberRepository memberRepository,
                        HashtagRepository hashtagRepository,
                        PostHashtagRepository postHashtagRepository,
+                       CommentRepository commentRepository,
                        LikeRepository likeRepository) {
         this.postRepository = postRepository;
         this.memberRepository = memberRepository;
+        this.commentRepository = commentRepository;
         this.likeRepository = likeRepository;
         this.hashtagRepository = hashtagRepository;
         this.postHashtagRepository = postHashtagRepository;
@@ -121,6 +125,9 @@ public class PostService {
         Post post = postRepository.findById(id)
                 .orElseThrow(PostNotFoundException::new);
         post.validateOwner(authInfo.getId());
+
+        commentRepository.deleteAllByPostId(post.getId());
+        likeRepository.deleteAllByPostId(post.getId());
         postRepository.delete(post);
         postHashtagRepository.deleteAllByPostId(post.getId());
     }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
@@ -7,6 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
 import com.wooteco.sokdak.auth.dto.AuthInfo;
+import com.wooteco.sokdak.comment.dto.CommentResponse;
+import com.wooteco.sokdak.comment.dto.NewCommentRequest;
+import com.wooteco.sokdak.comment.repository.CommentRepository;
+import com.wooteco.sokdak.comment.service.CommentService;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.exception.MemberNotFoundException;
 import com.wooteco.sokdak.member.repository.MemberRepository;
@@ -50,6 +54,9 @@ class PostServiceTest {
 
     @Autowired
     private PostHashtagRepository postHashtagRepository;
+
+    @Autowired
+    private CommentService commentService;
 
     private Post post;
 
@@ -213,5 +220,18 @@ class PostServiceTest {
 
         Optional<Post> foundPost = postRepository.findById(postId);
         assertThat(foundPost).isEmpty();
+    }
+
+    @DisplayName("댓글이 있는 게시글 삭제")
+    @Test
+    void deletePostWithComment() {
+        Long savedPostId = postRepository.save(post).getId();
+        NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", true);
+        Long commentId = commentService.addComment(post.getId(), newCommentRequest, AUTH_INFO);
+
+        postService.deletePost(post.getId(), AUTH_INFO);
+
+        Optional<Post> deletePost = postRepository.findById(post.getId());
+        assertThat(deletePost).isEmpty();
     }
 }


### PR DESCRIPTION
### 구현기능
좋아요/댓글 있는 경우 게시글 삭제 안되는 버그 수정

### 세부 구현기능
- post를 삭제하기 전에 댓글/좋아요를 삭제하고 삭제하도록 구현

### 관련 이슈
- post에서 Cascade remove 옵션을 줬는데 동작하지 않음
- 이번 스프린트 이후 수정해야함