### PR TITLE
feat: 사용되지 않는 해시태그 삭제

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/repository/PostHashtagRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/repository/PostHashtagRepository.java
@@ -9,4 +9,6 @@ public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> 
     List<PostHashtag> findAllByPostId(Long id);
 
     void deleteAllByPostId(Long postId);
+
+    List<PostHashtag> findAllByHashtagId(Long id);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/repository/PostHashtagRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/repository/PostHashtagRepository.java
@@ -10,5 +10,5 @@ public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> 
 
     void deleteAllByPostId(Long postId);
 
-    List<PostHashtag> findAllByHashtagId(Long id);
+    boolean existsByHashtagId(Long id);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -142,7 +142,7 @@ public class PostService {
 
     private void deleteNoUsedHashtags(List<Hashtag> hashtags) {
         for (Hashtag hashtag : hashtags) {
-            if (postHashtagRepository.findAllByHashtagId(hashtag.getId()).isEmpty()) {
+            if (!postHashtagRepository.existsByHashtagId(hashtag.getId())) {
                 hashtagRepository.delete(hashtag);
             }
         }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -126,10 +126,25 @@ public class PostService {
                 .orElseThrow(PostNotFoundException::new);
         post.validateOwner(authInfo.getId());
 
+        List<Hashtag> hashtags = postHashtagRepository.findAllByPostId(id)
+                .stream()
+                .map(PostHashtag::getHashtag)
+                .collect(Collectors.toList());
+
         commentRepository.deleteAllByPostId(post.getId());
         likeRepository.deleteAllByPostId(post.getId());
         postHashtagRepository.deleteAllByPostId(id);
 
         postRepository.delete(post);
+
+        deleteNoUsedHashtags(hashtags);
+    }
+
+    private void deleteNoUsedHashtags(List<Hashtag> hashtags) {
+        for (Hashtag hashtag : hashtags) {
+            if (postHashtagRepository.findAllByHashtagId(hashtag.getId()).isEmpty()) {
+                hashtagRepository.delete(hashtag);
+            }
+        }
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/HashtagAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/HashtagAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.wooteco.sokdak.post.acceptance;
 
+import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpDeleteWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpGet;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPost;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPostWithAuthorization;
@@ -73,9 +74,7 @@ public class HashtagAcceptanceTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = httpDeleteWithAuthorization("/posts/" + postId, getToken());
 
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value())
-        );
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
     private String parsePostId(ExtractableResponse<Response> response) {

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/HashtagAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/HashtagAcceptanceTest.java
@@ -63,7 +63,19 @@ public class HashtagAcceptanceTest extends AcceptanceTest {
                         .ignoringFields("id")
                         .isEqualTo(List.of(new HashtagResponse(1L, "변경1"), new HashtagResponse(2L, "변경2")))
         );
+    }
 
+    @DisplayName("해시태그가 포함된 게시글이 정상적으로 삭제된다.")
+    @Test
+    void deletePostWithHashtags() {
+        String postId = parsePostId(
+                httpPostWithAuthorization(NEW_POST_REQUEST, "/posts", getToken()));
+
+        ExtractableResponse<Response> response = httpDeleteWithAuthorization("/posts/" + postId, getToken());
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value())
+        );
     }
 
     private String parsePostId(ExtractableResponse<Response> response) {

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
@@ -63,6 +63,9 @@ class PostServiceTest {
     private HashtagRepository hashtagRepository;
 
     private Post post;
+    private Hashtag tag1;
+    private Hashtag tag2;
+
 
     @BeforeEach
     public void setUp() {
@@ -73,6 +76,12 @@ class PostServiceTest {
                 .content("본문")
                 .member(member)
                 .likes(new ArrayList<>())
+                .build();
+        tag1 = Hashtag.builder()
+                .name("태그1")
+                .build();
+        tag2 = Hashtag.builder()
+                .name("태그2")
                 .build();
     }
 
@@ -241,23 +250,29 @@ class PostServiceTest {
         assertThat(deletePost).isEmpty();
     }
 
-    @DisplayName("해시태그가 있는 게시글 삭제 및 사용되지 않는 해시태그 삭제 기능")
+    @DisplayName("해시태그가 있는 게시글 삭제 시 더 이상 사용되지 않는 해시태그 삭제 기능")
     @Test
     void deletePostWithHashtag() {
-        Long postId = savePostWithHashtags(post, tag1, tag2);
+        Long postId = savePostWithHashtags(post, List.of(tag1, tag2));
+        Post post = Post.builder()
+                .title("제목2").
+                content("내용2")
+                .build();
+        savePostWithHashtags(post, List.of(tag1));
 
         postService.deletePost(postId, AUTH_INFO);
 
         assertAll(
                 () -> assertThat(postHashtagRepository.findAllByPostId(postId)).isEmpty(),
-                () -> assertThat(hashtagRepository.findByName("태그1").isEmpty() && hashtagRepository.findByName("태그2").isEmpty()).isTrue()
+                () -> assertThat(hashtagRepository.existsByName("태그1")).isTrue(),
+                () -> assertThat(!hashtagRepository.existsByName("태그2")).isTrue()
         );
     }
 
-    private Long savePostWithHashtags(Post post, Hashtag tag1, Hashtag tag2) {
+    private Long savePostWithHashtags(Post post, List<Hashtag> tags) {
         Long postId = postRepository.save(post).getId();
-        hashtagRepository.saveAll(List.of(tag1, tag2));
-        postHashtagRepository.saveAll(List.of(new PostHashtag(post, tag1),new PostHashtag(post, tag2)));
+        hashtagRepository.saveAll(tags);
+        tags.forEach(tag-> postHashtagRepository.save(new PostHashtag(post, tag)));
         return postId;
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
@@ -240,4 +240,24 @@ class PostServiceTest {
         Optional<Post> deletePost = postRepository.findById(post.getId());
         assertThat(deletePost).isEmpty();
     }
+
+    @DisplayName("해시태그가 있는 게시글 삭제 및 사용되지 않는 해시태그 삭제 기능")
+    @Test
+    void deletePostWithHashtag() {
+        Long postId = savePostWithHashtags(post, tag1, tag2);
+
+        postService.deletePost(postId, AUTH_INFO);
+
+        assertAll(
+                () -> assertThat(postHashtagRepository.findAllByPostId(postId)).isEmpty(),
+                () -> assertThat(hashtagRepository.findByName("태그1").isEmpty() && hashtagRepository.findByName("태그2").isEmpty()).isTrue()
+        );
+    }
+
+    private Long savePostWithHashtags(Post post, Hashtag tag1, Hashtag tag2) {
+        Long postId = postRepository.save(post).getId();
+        hashtagRepository.saveAll(List.of(tag1, tag2));
+        postHashtagRepository.saveAll(List.of(new PostHashtag(post, tag1),new PostHashtag(post, tag2)));
+        return postId;
+    }
 }


### PR DESCRIPTION
### 구현기능
한번만 쓰인 해시태그와 연결된 게시글이 삭제될 시,
해당 해시태그들이 Hashtag 테이블에서 삭제된다.

### 세부 구현기능
- [x] #161 

### 관련 이슈
해시태그 삭제는 특정 게시물 삭제 시마다,
게시물에 존재했던 해시태그들에 대해 이뤄진다.