### PR TITLE
feat: 닉네임 포맷 확인 기능 추가

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/domain/Nickname.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/domain/Nickname.java
@@ -1,12 +1,20 @@
 package com.wooteco.sokdak.member.domain;
 
+import com.wooteco.sokdak.member.exception.InvalidNicknameException;
+import com.wooteco.sokdak.member.exception.InvalidUsernameException;
+import java.util.regex.Pattern;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.Getter;
+import org.hibernate.query.criteria.internal.expression.function.AggregationFunction.MAX;
 
 @Getter
 @Embeddable
 public class Nickname {
+
+    private static final Pattern PATTERN = Pattern.compile("^[0-9a-zA-Z가-힣]+(?:\\s+[0-9a-zA-Z가-힣]+)*$");
+    private static final int MIN_LENGTH = 1;
+    private static final int MAX_LENGTH = 16;
 
     @Column(name = "nickname")
     private String value;
@@ -15,6 +23,14 @@ public class Nickname {
     }
 
     public Nickname(String value) {
+        validate(value);
         this.value = value;
+    }
+
+    private void validate(String value) {
+        if (value.length() < MIN_LENGTH || value.length() > MAX_LENGTH
+        || !PATTERN.matcher(value).matches()) {
+            throw new InvalidNicknameException();
+        }
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/exception/InvalidNicknameException.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/exception/InvalidNicknameException.java
@@ -1,0 +1,12 @@
+package com.wooteco.sokdak.member.exception;
+
+import com.wooteco.sokdak.advice.BadRequestException;
+
+public class InvalidNicknameException extends BadRequestException {
+
+    private static final String MESSAGE = "잘못된 닉네임 형식입니다.";
+
+    public InvalidNicknameException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -7,7 +7,6 @@ import com.wooteco.sokdak.member.domain.Member;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/member/domain/member/NicknameTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/member/domain/member/NicknameTest.java
@@ -1,0 +1,20 @@
+package com.wooteco.sokdak.member.domain.member;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wooteco.sokdak.member.domain.Nickname;
+import com.wooteco.sokdak.member.exception.InvalidNicknameException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NicknameTest {
+
+    @DisplayName("유저의 닉네임은 숫자와 영문, 한글음절을 포함한 1자 이상 16자가 아니면 예외가 발생한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "ㄱㄴㄷ", "abdf123ㅏㅇ", "11112222333344445"})
+    void create_Exception_Format(String invalidUsername) {
+        assertThatThrownBy(() -> new Nickname(invalidUsername))
+                .isInstanceOf(InvalidNicknameException.class);
+    }
+}


### PR DESCRIPTION
### 구현기능
닉네임 포맷 확인 기능 추가

### 세부 구현기능
 - [ ] 정규표현식으로 영어 대소문자, 숫자, 한글음절, 그리고 단어사이 띄어쓰기 1개 허용하는 로직 구현
 - [ ] 1글자 이상 16글자 이하 확인하는 로직 구현
