### PR TITLE
feat: 해시태그 기능 1차 리팩토링 #160

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/HashtagConverter.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/HashtagConverter.java
@@ -1,0 +1,30 @@
+package com.wooteco.sokdak.post.domain;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HashtagConverter {
+
+    private HashtagConverter(){
+    }
+
+    public List<Hashtag> PostHashtagsToHashtags(List<PostHashtag> postHashtags) {
+        return postHashtags.stream()
+                .map(PostHashtag::getHashtag)
+                .collect(Collectors.toList());
+    }
+
+    public List<Hashtag> NamesToHashtags(List<String> names) {
+        return names.stream()
+                .map(name -> Hashtag.builder().name(name).build())
+                .collect(Collectors.toList());
+    }
+
+    public List<PostHashtag> HashtagsToPostHashtags(List<Hashtag> hashtags, Post post) {
+        return hashtags.stream()
+                .map(hashtag -> PostHashtag.builder().hashtag(hashtag).post(post).build())
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/controller/PostControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/controller/PostControllerTest.java
@@ -92,7 +92,7 @@ class PostControllerTest extends ControllerTest {
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
-    @DisplayName("게시글 제목이 없는 경우 400을 반환한다.")
+    @DisplayName("게시글 내용이 없는 경우 400을 반환한다.")
     @Test
     void addPost_Exception_NoContent() {
         NewPostRequest postRequest = new NewPostRequest("제목", null, Collections.emptyList());
@@ -170,6 +170,7 @@ class PostControllerTest extends ControllerTest {
                 .likeCount(0)
                 .like(false)
                 .modified(false)
+                .hashtagResponses(List.of(new HashtagResponse(1L, "gogo")))
                 .authorized(false)
                 .build();
         doReturn(postResponse)

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
@@ -74,12 +74,10 @@ class PostServiceTest {
                 .member(member)
                 .likes(new ArrayList<>())
                 .build();
-        tag1 = Hashtag
-                .builder()
+        tag1 = Hashtag.builder()
                 .name("태그1")
                 .build();
-        tag2 = Hashtag
-                .builder()
+        tag2 = Hashtag.builder()
                 .name("태그2")
                 .build();
     }
@@ -239,20 +237,20 @@ class PostServiceTest {
         assertThat(hashtags).containsOnly("태그1", "태그2");
     }
 
-    @DisplayName("게시글에 해시태그를 삭제하는 수정 기능")
+    @DisplayName("게시글에 일부 해시태그를 삭제하는 수정 기능")
     @Test
     void updatePostWithDeletingHashtag() {
-        Long postId = savePostWithHashtags(post, tag1, tag2);
+        Long postId = savePostWithHashtags(post, List.of(tag1, tag2));
 
         PostUpdateRequest postUpdateRequest = new PostUpdateRequest("변경된 제목", "변경된 본문", List.of("태그1"));
         postService.updatePost(postId, postUpdateRequest, AUTH_INFO);
 
-        List<String> hashtags = postHashtagRepository.findAllByPostId(postId)
+        List<String> hashtagNames = postHashtagRepository.findAllByPostId(postId)
                 .stream()
                 .map(PostHashtag::getHashtag)
                 .map(Hashtag::getName)
                 .collect(Collectors.toList());
-        assertThat(hashtags).containsOnly("태그1");
+        assertThat(hashtagNames).containsOnly("태그1");
     }
 
     @DisplayName("게시글 삭제 기능")
@@ -301,7 +299,7 @@ class PostServiceTest {
     private Long savePostWithHashtags(Post post, List<Hashtag> tags) {
         Long postId = postRepository.save(post).getId();
         hashtagRepository.saveAll(tags);
-        tags.forEach(tag-> postHashtagRepository.save(new PostHashtag(post, tag)));
+        tags.forEach(tag-> postHashtagRepository.save(PostHashtag.builder().post(post).hashtag(tag).build()));
         return postId;
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
@@ -7,9 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
 import com.wooteco.sokdak.auth.dto.AuthInfo;
-import com.wooteco.sokdak.comment.dto.CommentResponse;
 import com.wooteco.sokdak.comment.dto.NewCommentRequest;
-import com.wooteco.sokdak.comment.repository.CommentRepository;
 import com.wooteco.sokdak.comment.service.CommentService;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.exception.MemberNotFoundException;
@@ -66,7 +64,6 @@ class PostServiceTest {
     private Hashtag tag1;
     private Hashtag tag2;
 
-
     @BeforeEach
     public void setUp() {
         Member member = memberRepository.findById(1L)
@@ -77,10 +74,12 @@ class PostServiceTest {
                 .member(member)
                 .likes(new ArrayList<>())
                 .build();
-        tag1 = Hashtag.builder()
+        tag1 = Hashtag
+                .builder()
                 .name("태그1")
                 .build();
-        tag2 = Hashtag.builder()
+        tag2 = Hashtag
+                .builder()
                 .name("태그2")
                 .build();
     }
@@ -224,12 +223,42 @@ class PostServiceTest {
         );
     }
 
+    @DisplayName("게시글에 해시태그를 추가하는 수정 기능")
+    @Test
+    void updatePostWithAddingHashtag() {
+        Long postId = postRepository.save(post).getId();
+        PostUpdateRequest postUpdateRequest = new PostUpdateRequest("변경된 제목", "변경된 본문", List.of("태그1", "태그2"));
+
+        postService.updatePost(postId, postUpdateRequest, AUTH_INFO);
+
+        List<String> hashtags = postHashtagRepository.findAllByPostId(postId)
+                .stream()
+                .map(PostHashtag::getHashtag)
+                .map(Hashtag::getName)
+                .collect(Collectors.toList());
+        assertThat(hashtags).containsOnly("태그1", "태그2");
+    }
+
+    @DisplayName("게시글에 해시태그를 삭제하는 수정 기능")
+    @Test
+    void updatePostWithDeletingHashtag() {
+        Long postId = savePostWithHashtags(post, tag1, tag2);
+
+        PostUpdateRequest postUpdateRequest = new PostUpdateRequest("변경된 제목", "변경된 본문", List.of("태그1"));
+        postService.updatePost(postId, postUpdateRequest, AUTH_INFO);
+
+        List<String> hashtags = postHashtagRepository.findAllByPostId(postId)
+                .stream()
+                .map(PostHashtag::getHashtag)
+                .map(Hashtag::getName)
+                .collect(Collectors.toList());
+        assertThat(hashtags).containsOnly("태그1");
+    }
+
     @DisplayName("게시글 삭제 기능")
     @Test
     void deletePost() {
-        Hashtag hashtag = hashtagRepository.save(new Hashtag("태그1"));
-        PostHashtag postHashtag = postHashtagRepository.save(new PostHashtag(post, hashtag));
-        Long postId = postRepository.save(post).getId();
+        Long postId = savePostWithHashtags(post, List.of(tag1, tag2));
 
         postService.deletePost(postId, AUTH_INFO);
 


### PR DESCRIPTION
### 구현기능
해시태그 기능 관련 1차 리팩토링 진행

### 세부 구현기능
- [x] 새로 만든 해시태그 관련 유틸(HashtagConverter)으로 PostService 코드 일부 이동
- [x] 컨트롤러, 서비스 테스트 코드 작성
resolved: #160 

### 관련 이슈
- 해시태그 유틸을 `@Component` 등록함
- 아직 해시태그 관련 패키지 이동을 진행하지 않은 pr