### PR TITLE
fix: 테스트 격리 문제 해결 FIX #188

### DIFF
--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/AcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/AcceptanceTest.java
@@ -1,15 +1,18 @@
 package com.wooteco.sokdak.util;
 
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.jdbc.Sql;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@Sql(
+        scripts = {"classpath:truncate.sql"},
+        executionPhase = BEFORE_TEST_METHOD)
 public class AcceptanceTest {
 
     @LocalServerPort

--- a/backend/sokdak/src/test/resources/application.yml
+++ b/backend/sokdak/src/test/resources/application.yml
@@ -1,0 +1,48 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:db?serverTimezone=Asia/Seoul;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
+    show-sql: true
+
+  h2:
+    console:
+      enabled: true
+
+  mail:
+    host: smtp.gmail.com
+    username: sokdakX2@gmail.com
+    password: ljngmlufjlbushhy
+    port: 587
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+security:
+  jwt:
+    token:
+      secret-key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno
+      expire-length: 3600000
+
+logging:
+  level:
+    org:
+      hibernate:
+        type: trace
+
+server:
+  servlet:
+    session:
+      cookie:
+        http-only: false

--- a/backend/sokdak/src/test/resources/truncate.sql
+++ b/backend/sokdak/src/test/resources/truncate.sql
@@ -1,0 +1,19 @@
+SET FOREIGN_KEY_CHECKS = 0;
+TRUNCATE TABLE post_hashtag;
+TRUNCATE TABLE likes;
+TRUNCATE TABLE comment;
+TRUNCATE TABLE hashtag;
+TRUNCATE TABLE post;
+TRUNCATE TABLE auth_code;
+TRUNCATE TABLE ticket;
+TRUNCATE TABLE member;
+SET FOREIGN_KEY_CHECKS = 1;
+
+insert into member (username, nickname, password) values ('chris', 'chrisNickname', '6297d64078fc9abcfe37d0e2c910d4798bb4c04502d7dd1207f558860c2b382e');
+insert into ticket (serial_number, used) values ('21f46568bf6002c23843d198af30bb2bc8123695bd3d12ce86e0fc35bc5d3279', false);
+insert into ticket (serial_number, used) values ('5810c81b6f78b1bcf62b53035d879e1309750ab60d1b4b601dfbc368005645cb', false);
+insert into ticket (serial_number, used) values ('694f51c40e1910a86b3f4a655ac874a0511402a6ac347b1cadccf7b9e3678fac', false);
+insert into ticket (serial_number, used) values ('a3280648524742e7c891fb472ea3541d4bf73276e01f15b3e73eeba4d0085424', false);
+insert into ticket (serial_number, used) values ('774dd927c9c846f2bb21b02fd139d266f7f6fd9d4a0d829e4e6553b8fcd9b53b', false);
+insert into ticket (serial_number, used) values ('ce89c8413662dffc17a4644ddf0386432404cd943b18eeee45740be5c35ef03b', false);
+insert into ticket (serial_number, used) values ('49d3b5b2d51e0f03cd1c0b85e2312dbd740023856ce16a725a3617f58b91da1c', false);


### PR DESCRIPTION
### 구현기능
`AcceptanceTest`에서 `@DirtiesContext` 초기화 문제 해결을 위해 `@Sql`문 사용
`truncate.sql`로 초기화

### 관련 이슈
resolved: #188 