### PR TITLE
feat: 해시태그로 검색 기능 구현 #172

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/controller/HashtagController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/controller/HashtagController.java
@@ -1,4 +1,31 @@
 package com.wooteco.sokdak.hashtag.controller;
 
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import com.wooteco.sokdak.hashtag.service.HashtagService;
+import com.wooteco.sokdak.post.dto.PostsResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping
 public class HashtagController {
+
+    private final HashtagService hashtagService;
+
+    public HashtagController(HashtagService hashtagService) {
+        this.hashtagService = hashtagService;
+    }
+
+    @GetMapping(path = "/posts", params = {"hashtag", "size", "page"})
+    public ResponseEntity<PostsResponse> findPostsWithHashtags(@RequestParam String hashtag,
+                                                               @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
+        PostsResponse postsResponse = hashtagService.findPostsWithHashtag(hashtag, pageable);
+        return ResponseEntity.ok(postsResponse);
+    }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/controller/HashtagController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/controller/HashtagController.java
@@ -23,8 +23,8 @@ public class HashtagController {
     }
 
     @GetMapping(path = "/posts", params = {"hashtag", "size", "page"})
-    public ResponseEntity<PostsResponse> findPostsWithHashtags(@RequestParam String hashtag,
-                                                               @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
+    public ResponseEntity<PostsResponse> findPostsWithHashtag(@RequestParam String hashtag,
+                                                              @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
         PostsResponse postsResponse = hashtagService.findPostsWithHashtag(hashtag, pageable);
         return ResponseEntity.ok(postsResponse);
     }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/repository/HashtagRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/repository/HashtagRepository.java
@@ -5,8 +5,8 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
     boolean existsByName(String name);
 
     Optional<Hashtag> findByName(String name);
-
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/repository/PostHashtagRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/repository/PostHashtagRepository.java
@@ -1,8 +1,12 @@
 package com.wooteco.sokdak.hashtag.repository;
 
 import com.wooteco.sokdak.hashtag.domain.PostHashtag;
+import com.wooteco.sokdak.post.domain.Post;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
 
@@ -11,4 +15,7 @@ public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> 
     void deleteAllByPostId(Long postId);
 
     boolean existsByHashtagId(Long id);
+
+    @Query(value = "SELECT p FROM Post p INNER JOIN PostHashtag ph ON p=ph.post and ph.hashtag.id = :hashtagId")
+    Slice<Post> findAllByHashtagId(Long hashtagId, Pageable pageable);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/service/HashtagService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/service/HashtagService.java
@@ -2,11 +2,16 @@ package com.wooteco.sokdak.hashtag.service;
 
 import com.wooteco.sokdak.hashtag.domain.Hashtag;
 import com.wooteco.sokdak.hashtag.domain.Hashtags;
+import com.wooteco.sokdak.hashtag.exception.HashtagNotFoundException;
 import com.wooteco.sokdak.hashtag.repository.HashtagRepository;
 import com.wooteco.sokdak.hashtag.repository.PostHashtagRepository;
 import com.wooteco.sokdak.post.domain.Post;
+import com.wooteco.sokdak.post.dto.PostsElementResponse;
+import com.wooteco.sokdak.post.dto.PostsResponse;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,5 +58,18 @@ public class HashtagService {
                 hashtagRepository.delete(hashtag);
             }
         }
+    }
+
+    public PostsResponse findPostsWithHashtag(String name, Pageable pageable) {
+        Hashtag hashtag = hashtagRepository.findByName(name)
+                .orElseThrow(HashtagNotFoundException::new);
+        Slice<Post> posts = postHashtagRepository.findAllByHashtagId(hashtag.getId(), pageable);
+
+        List<PostsElementResponse> postsElementResponses = posts.getContent()
+                .stream()
+                .map(PostsElementResponse::from)
+                .collect(Collectors.toList());
+        boolean last = posts.isLast();
+        return new PostsResponse(postsElementResponses, last);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/service/HashtagService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/service/HashtagService.java
@@ -64,12 +64,6 @@ public class HashtagService {
         Hashtag hashtag = hashtagRepository.findByName(name)
                 .orElseThrow(HashtagNotFoundException::new);
         Slice<Post> posts = postHashtagRepository.findAllByHashtagId(hashtag.getId(), pageable);
-
-        List<PostsElementResponse> postsElementResponses = posts.getContent()
-                .stream()
-                .map(PostsElementResponse::from)
-                .collect(Collectors.toList());
-        boolean last = posts.isLast();
-        return new PostsResponse(postsElementResponses, last);
+        return PostsResponse.ofSlice(posts);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/service/HashtagService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/service/HashtagService.java
@@ -26,10 +26,15 @@ public class HashtagService {
     @Transactional
     public void saveHashtag(List<String> names, Post savedPost) {
         Hashtags hashtags = new Hashtags(names.stream()
-                .map(name -> hashtagRepository.findByName(name)
-                        .orElse(hashtagRepository.save(Hashtag.builder().name(name).build())))
+                .map(this::saveOrFind)
                 .collect(Collectors.toList()));
         postHashtagRepository.saveAll(hashtags.getPostHashtags(savedPost));
+    }
+
+    private Hashtag saveOrFind(String name) {
+        return hashtagRepository
+                .findByName(name)
+                .orElseGet(() -> hashtagRepository.save(Hashtag.builder().name(name).build()));
     }
 
     public Hashtags findHashtagsByPostId(Long postId) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -1,7 +1,6 @@
 package com.wooteco.sokdak.post.domain;
 
 import com.wooteco.sokdak.auth.exception.AuthenticationException;
-import com.wooteco.sokdak.board.domain.PostBoard;
 import com.wooteco.sokdak.comment.domain.Comment;
 import com.wooteco.sokdak.hashtag.domain.PostHashtag;
 import com.wooteco.sokdak.like.domain.Like;
@@ -126,10 +125,16 @@ public class Post {
     }
 
     public int getLikeCount() {
+        if (likes == null) {
+            return 0;
+        }
         return likes.size();
     }
 
     public int getCommentCount() {
+        if (comments == null) {
+            return 0;
+        }
         return comments.size();
     }
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostsResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostsResponse.java
@@ -1,7 +1,10 @@
 package com.wooteco.sokdak.post.dto;
 
+import com.wooteco.sokdak.post.domain.Post;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Getter;
+import org.springframework.data.domain.Slice;
 
 @Getter
 public class PostsResponse {
@@ -12,5 +15,13 @@ public class PostsResponse {
     public PostsResponse(List<PostsElementResponse> posts, boolean lastPage) {
         this.posts = posts;
         this.lastPage = lastPage;
+    }
+
+    public static PostsResponse ofSlice(Slice<Post> postSlice) {
+        List<PostsElementResponse> postsElementResponses = postSlice.getContent()
+                .stream()
+                .map(PostsElementResponse::from)
+                .collect(Collectors.toList());
+        return new PostsResponse(postsElementResponses, postSlice.isLast());
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/board/service/BoardServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/board/service/BoardServiceTest.java
@@ -4,6 +4,8 @@ import static com.wooteco.sokdak.util.fixture.BoardFixture.BOARD_REQUEST_1;
 import static com.wooteco.sokdak.util.fixture.BoardFixture.BOARD_REQUEST_2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
 import com.wooteco.sokdak.board.domain.Board;
 import com.wooteco.sokdak.board.dto.BoardsResponse;
@@ -13,9 +15,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@Sql(
+        scripts = {"classpath:truncate.sql"},
+        executionPhase = BEFORE_TEST_METHOD)
 @Transactional
 class BoardServiceTest {
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/acceptance/HashtagAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/acceptance/HashtagAcceptanceTest.java
@@ -1,4 +1,4 @@
-package com.wooteco.sokdak.post.acceptance;
+package com.wooteco.sokdak.hashtag.acceptance;
 
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpDeleteWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpGet;

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/acceptance/HashtagAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/acceptance/HashtagAcceptanceTest.java
@@ -10,20 +10,31 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.wooteco.sokdak.auth.dto.LoginRequest;
+import com.wooteco.sokdak.hashtag.domain.Hashtag;
+import com.wooteco.sokdak.hashtag.domain.Hashtags;
 import com.wooteco.sokdak.hashtag.dto.HashtagResponse;
+import com.wooteco.sokdak.hashtag.repository.HashtagRepository;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
 import com.wooteco.sokdak.post.dto.PostDetailResponse;
 import com.wooteco.sokdak.post.dto.PostUpdateRequest;
+import com.wooteco.sokdak.post.dto.PostsElementResponse;
+import com.wooteco.sokdak.post.dto.PostsResponse;
 import com.wooteco.sokdak.util.AcceptanceTest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 @DisplayName("해시태그 관련 인수테스트")
 public class HashtagAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private HashtagRepository hashtagRepository;
 
     private static final NewPostRequest NEW_POST_REQUEST = new NewPostRequest("제목", "본문", List.of("태그1", "태그2"));
 
@@ -74,7 +85,32 @@ public class HashtagAcceptanceTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = httpDeleteWithAuthorization("/posts/" + postId, getToken());
 
+
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    @DisplayName("해시태그로 검색하면 해당 해시태그가 포함된 게시물들을 조회한다.")
+    @Test
+    void searchWithHashtag() {
+        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", List.of("태그1"));
+        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", List.of("태그2"));
+        NewPostRequest postRequest3 = new NewPostRequest("제목3", "본문3", List.of("태그1","태그2"));
+
+        httpPostWithAuthorization(postRequest1, "/posts", getToken());
+        httpPostWithAuthorization(postRequest2, "/posts", getToken());
+        httpPostWithAuthorization(postRequest3, "/posts", getToken());
+
+        ExtractableResponse<Response> response = httpGet("/posts?hashtag=태그1&size=10&page=0");
+        List<String> postNames = parsePostTitles(response);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(postNames).containsExactly("제목3","제목1")
+        );
+    }
+
+    private String getToken() {
+        LoginRequest loginRequest = new LoginRequest("chris", "Abcd123!@");
+        return httpPost(loginRequest, "/login").header(AUTHORIZATION);
     }
 
     private String parsePostId(ExtractableResponse<Response> response) {
@@ -82,8 +118,12 @@ public class HashtagAcceptanceTest extends AcceptanceTest {
                 .split("/posts/")[1];
     }
 
-    private String getToken() {
-        LoginRequest loginRequest = new LoginRequest("chris", "Abcd123!@");
-        return httpPost(loginRequest, "/login").header(AUTHORIZATION);
+    private List<String> parsePostTitles(ExtractableResponse<Response> response) {
+        return response.jsonPath()
+                .getObject(".", PostsResponse.class)
+                .getPosts()
+                .stream()
+                .map(PostsElementResponse::getTitle)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/acceptance/HashtagAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/acceptance/HashtagAcceptanceTest.java
@@ -100,10 +100,11 @@ public class HashtagAcceptanceTest extends AcceptanceTest {
         httpPostWithAuthorization(postRequest2, "/posts", getToken());
         httpPostWithAuthorization(postRequest3, "/posts", getToken());
 
-        ExtractableResponse<Response> response = httpGet("/posts?hashtag=태그1&size=10&page=0");
+        ExtractableResponse<Response> response = httpGet("/posts?hashtag=태그1&size=3&page=0");
         List<String> postNames = parsePostTitles(response);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(postNames).hasSize(2),
                 () -> assertThat(postNames).containsExactly("제목3","제목1")
         );
     }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/controller/HashtagControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/controller/HashtagControllerTest.java
@@ -1,0 +1,82 @@
+package com.wooteco.sokdak.hashtag.controller;
+
+import static com.wooteco.sokdak.util.fixture.MemberFixture.AUTH_INFO;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+
+import com.wooteco.sokdak.hashtag.exception.HashtagNotFoundException;
+import com.wooteco.sokdak.post.dto.PostsElementResponse;
+import com.wooteco.sokdak.post.dto.PostsResponse;
+import com.wooteco.sokdak.util.ControllerTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class HashtagControllerTest extends ControllerTest {
+
+    @BeforeEach
+    void setUpArgumentResolver() {
+        doReturn(true)
+                .when(authInterceptor)
+                .preHandle(any(), any(), any());
+        doReturn(AUTH_INFO)
+                .when(authenticationPrincipalArgumentResolver)
+                .resolveArgument(any(), any(), any(), any());
+    }
+
+    @DisplayName("해시태그로 검색 시 200 반환")
+    @Test
+    void findPostsWithHashtag() {
+        PostsElementResponse postsElementResponse1 = PostsElementResponse.builder()
+                .id(3L)
+                .title("제목")
+                .content("내용")
+                .createdAt(LocalDateTime.MIN)
+                .modified(false)
+                .commentCount(2)
+                .likeCount(5)
+                .build();
+        PostsElementResponse postsElementResponse2 = PostsElementResponse.builder()
+                .id(2L)
+                .title("제목2")
+                .content("내용2")
+                .createdAt(LocalDateTime.MAX)
+                .modified(false)
+                .commentCount(4)
+                .likeCount(10)
+                .build();
+
+        doReturn(new PostsResponse(List.of(postsElementResponse1, postsElementResponse2), true))
+                .when(hashtagService)
+                .findPostsWithHashtag(matches("속닥"), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/posts?hashtag=속닥&size=5&page=0")
+                .then().log().all()
+                .apply(document("hashtag/search/success"))
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @DisplayName("해시태그로 검색 시 없는 해시태그이면 404 반환")
+    @Test
+    void findPostsWithHashtags_Exception_NoHashtag() {
+        doThrow(new HashtagNotFoundException())
+                .when(hashtagService)
+                .findPostsWithHashtag(matches("없는태그"), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/posts?hashtag=없는태그&size=5&page=0")
+                .then().log().all()
+                .apply(document("hashtag/search/success"))
+                .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/repository/PostHashtagRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/repository/PostHashtagRepositoryTest.java
@@ -1,0 +1,84 @@
+package com.wooteco.sokdak.hashtag.repository;
+
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_ENCRYPTED_PASSWORD;
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_USERNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import com.wooteco.sokdak.config.JPAConfig;
+import com.wooteco.sokdak.hashtag.domain.Hashtag;
+import com.wooteco.sokdak.hashtag.domain.PostHashtag;
+import com.wooteco.sokdak.member.domain.Member;
+import com.wooteco.sokdak.member.repository.MemberRepository;
+import com.wooteco.sokdak.post.domain.Post;
+import com.wooteco.sokdak.post.repository.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+@DataJpaTest
+@Import(JPAConfig.class)
+class PostHashtagRepositoryTest {
+
+    @Autowired
+    private PostHashtagRepository postHashtagRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PostRepository postRepository;
+    @Autowired
+    private HashtagRepository hashtagRepository;
+
+    private final Hashtag tag1 = Hashtag.builder().name("태그1").build();
+    private final Hashtag tag2 = Hashtag.builder().name("태그2").build();
+
+    @BeforeEach
+    void setUp() {
+        Member member = memberRepository
+                .findByUsernameValueAndPassword(VALID_USERNAME, VALID_ENCRYPTED_PASSWORD)
+                .orElseThrow();
+
+        Post post1 = Post.builder()
+                .title("제목1")
+                .content("본문1")
+                .member(member)
+                .build();
+        Post post2 = Post.builder()
+                .title("제목2")
+                .content("본문2")
+                .member(member)
+                .build();
+        Post post3 = Post.builder()
+                .title("제목3")
+                .content("본문3")
+                .member(member)
+                .build();
+        postRepository.save(post1);
+        postRepository.save(post2);
+        postRepository.save(post3);
+
+        hashtagRepository.save(tag1);
+        hashtagRepository.save(tag2);
+
+        postHashtagRepository.save(PostHashtag.builder().post(post1).hashtag(tag1).build());
+        postHashtagRepository.save(PostHashtag.builder().post(post1).hashtag(tag2).build());
+        postHashtagRepository.save(PostHashtag.builder().post(post2).hashtag(tag1).build());
+        postHashtagRepository.save(PostHashtag.builder().post(post3).hashtag(tag2).build());
+    }
+
+    @Test
+    void findAllByHashtagId() {
+        Pageable pageable = PageRequest.of(0, 3, DESC, "createdAt");
+
+        Slice<Post> posts = postHashtagRepository.findAllByHashtagId(tag1.getId(), pageable);
+        for (Post post : posts.getContent()) {
+            System.err.println(post.getTitle());
+        }
+        assertThat(posts.getNumberOfElements()).isEqualTo(2);
+    }
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/repository/PostHashtagRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/repository/PostHashtagRepositoryTest.java
@@ -76,9 +76,6 @@ class PostHashtagRepositoryTest {
         Pageable pageable = PageRequest.of(0, 3, DESC, "createdAt");
 
         Slice<Post> posts = postHashtagRepository.findAllByHashtagId(tag1.getId(), pageable);
-        for (Post post : posts.getContent()) {
-            System.err.println(post.getTitle());
-        }
         assertThat(posts.getNumberOfElements()).isEqualTo(2);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/service/HashtagServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/service/HashtagServiceTest.java
@@ -2,10 +2,15 @@ package com.wooteco.sokdak.hashtag.service;
 
 import static com.wooteco.sokdak.util.fixture.MemberFixture.AUTH_INFO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.data.domain.Sort.Direction.DESC;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
 import com.wooteco.sokdak.hashtag.domain.Hashtag;
+import com.wooteco.sokdak.hashtag.domain.Hashtags;
 import com.wooteco.sokdak.hashtag.domain.PostHashtag;
+import com.wooteco.sokdak.hashtag.exception.HashtagNotFoundException;
 import com.wooteco.sokdak.hashtag.repository.HashtagRepository;
 import com.wooteco.sokdak.hashtag.repository.PostHashtagRepository;
 import com.wooteco.sokdak.member.domain.Member;
@@ -14,6 +19,8 @@ import com.wooteco.sokdak.member.repository.MemberRepository;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
 import com.wooteco.sokdak.post.dto.PostUpdateRequest;
+import com.wooteco.sokdak.post.dto.PostsElementResponse;
+import com.wooteco.sokdak.post.dto.PostsResponse;
 import com.wooteco.sokdak.post.repository.PostRepository;
 import com.wooteco.sokdak.post.service.PostService;
 import java.util.ArrayList;
@@ -24,28 +31,35 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@Sql(
+        scripts = {"classpath:truncate.sql"},
+        executionPhase = BEFORE_TEST_METHOD)
 @Transactional
 class HashtagServiceTest {
 
     @Autowired
     private PostService postService;
+    @Autowired
+    private HashtagService hashtagService;
 
     @Autowired
     private MemberRepository memberRepository;
-
     @Autowired
     private PostRepository postRepository;
-
     @Autowired
     private PostHashtagRepository postHashtagRepository;
-
     @Autowired
     private HashtagRepository hashtagRepository;
 
     private Post post;
+    private Post post2;
+    private Post post3;
     private Hashtag tag1;
     private Hashtag tag2;
 
@@ -56,6 +70,18 @@ class HashtagServiceTest {
         post = Post.builder()
                 .title("제목")
                 .content("본문")
+                .member(member)
+                .likes(new ArrayList<>())
+                .build();
+        post2 = Post.builder()
+                .title("제목2")
+                .content("내용")
+                .member(member)
+                .likes(new ArrayList<>())
+                .build();
+        post3 = Post.builder()
+                .title("제목3")
+                .content("내용")
                 .member(member)
                 .likes(new ArrayList<>())
                 .build();
@@ -70,18 +96,16 @@ class HashtagServiceTest {
     @DisplayName("해시태그가 포함된 게시글 작성 기능")
     @Test
     void addPostWithHashtag() {
-        final List<String> expected = List.of("태그1", "태그2");
-        NewPostRequest newPostRequest = new NewPostRequest("제목", "본문", expected);
+        NewPostRequest newPostRequest = new NewPostRequest("제목", "본문", List.of("태그1", "태그2"));
 
         Long postId = postService.addPost(newPostRequest, AUTH_INFO);
-        List<PostHashtag> postHashtags = postHashtagRepository.findAllByPostId(postId);
 
-        final List<String> hashtags = postHashtags
+        final List<String> hashtags = postHashtagRepository.findAllByPostId(postId)
                 .stream()
                 .map(PostHashtag::getHashtag)
                 .map(Hashtag::getName)
                 .collect(Collectors.toList());
-        assertThat(hashtags).isEqualTo(expected);
+        assertThat(hashtags).isEqualTo(List.of("태그1", "태그2"));
     }
 
 
@@ -105,8 +129,8 @@ class HashtagServiceTest {
     @Test
     void updatePostWithDeletingHashtag() {
         Long postId = savePostWithHashtags(post, List.of(tag1, tag2));
-
         PostUpdateRequest postUpdateRequest = new PostUpdateRequest("변경된 제목", "변경된 본문", List.of("태그1"));
+
         postService.updatePost(postId, postUpdateRequest, AUTH_INFO);
 
         List<String> hashtagNames = postHashtagRepository.findAllByPostId(postId)
@@ -121,11 +145,7 @@ class HashtagServiceTest {
     @Test
     void deletePostWithHashtag() {
         Long postId = savePostWithHashtags(post, List.of(tag1, tag2));
-        Post post = Post.builder()
-                .title("제목2").
-                content("내용2")
-                .build();
-        savePostWithHashtags(post, List.of(tag1));
+        savePostWithHashtags(post2, List.of(tag1));
 
         postService.deletePost(postId, AUTH_INFO);
 
@@ -136,10 +156,53 @@ class HashtagServiceTest {
         );
     }
 
+    @DisplayName("특정 해시태그로 검색 시 해시태그가 포함된 게시글 목록을 반환하는 조회 기능")
+    @Test
+    void findByHashtag() {
+        savePostWithHashtags(post, List.of(tag1, tag2));
+        savePostWithHashtags(post2, List.of(tag1));
+        savePostWithHashtags(post3, List.of(tag2));
+
+        Pageable pageable = PageRequest.of(0, 3, DESC, "createdAt");
+
+        PostsResponse postsResponse = hashtagService.findPostsWithHashtag(tag1.getName(), pageable);
+
+        List<PostsElementResponse> posts = postsResponse.getPosts();
+        assertAll(
+                () -> assertThat(posts).hasSize(2),
+                () -> assertThat(posts).usingRecursiveComparison()
+                        .comparingOnlyFields("title")
+                        .isEqualTo(List.of(PostsElementResponse.builder().title("제목2"),
+                                PostsElementResponse.builder().title("제목")))
+        );
+    }
+
+    @DisplayName("특정 해시태그로 검색 시 해당 해시태그가 없을 시 예외처리")
+    @Test
+    void findByHashtag_Exception_NoResult() {
+        savePostWithHashtags(post, List.of(tag1));
+
+        Pageable pageable = PageRequest.of(0, 3, DESC, "createdAt");
+        assertThatThrownBy(() -> hashtagService.findPostsWithHashtag("없는태그", pageable))
+                .isInstanceOf(HashtagNotFoundException.class)
+                .hasMessage("해당 이름의 해시태그를 찾을 수 없습니다.");
+    }
+
+    @DisplayName("특정 해시태그로 검색 시 해당 페이지의 결과가 없을 시 빈 배열을 반환")
+    @Test
+    void findByHashtag_Exception_NoPage() {
+        savePostWithHashtags(post, List.of(tag1));
+
+        Pageable pageable = PageRequest.of(10, 3, DESC, "createdAt");
+        PostsResponse postsResponse = hashtagService.findPostsWithHashtag(tag1.getName(), pageable);
+
+        List<PostsElementResponse> posts = postsResponse.getPosts();
+        assertThat(posts).hasSize(0);
+    }
+
     private Long savePostWithHashtags(Post post, List<Hashtag> tags) {
-        Long postId = postRepository.save(post).getId();
-        hashtagRepository.saveAll(tags);
-        tags.forEach(tag -> postHashtagRepository.save(PostHashtag.builder().post(post).hashtag(tag).build()));
-        return postId;
+        NewPostRequest newPostRequest = new NewPostRequest(
+                post.getTitle(), post.getContent(), new Hashtags(tags).getNames());
+        return postService.addPost(newPostRequest, AUTH_INFO);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
@@ -8,6 +8,7 @@ import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_PASSWORD;
 import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
 import com.wooteco.sokdak.like.dto.LikeFlipResponse;
 import com.wooteco.sokdak.member.domain.Member;
@@ -19,9 +20,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@Sql(
+        scripts = {"classpath:truncate.sql"},
+        executionPhase = BEFORE_TEST_METHOD)
 @Transactional
 class LikeServiceTest {
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/member/service/EmailServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/member/service/EmailServiceTest.java
@@ -3,6 +3,7 @@ package com.wooteco.sokdak.member.service;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
 import com.wooteco.sokdak.auth.domain.Ticket;
 import com.wooteco.sokdak.auth.service.AuthCodeGenerator;
@@ -15,10 +16,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 @SpringBootTest
+@Sql(
+        scripts = {"classpath:truncate.sql"},
+        executionPhase = BEFORE_TEST_METHOD)
+@Transactional
 class EmailServiceTest {
 
     @Autowired

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.data.domain.Sort.Direction.DESC;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
 import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.comment.dto.NewCommentRequest;
@@ -31,9 +32,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@Sql(
+        scripts = {"classpath:truncate.sql"},
+        executionPhase = BEFORE_TEST_METHOD)
 @Transactional
 class PostServiceTest {
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/ControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/ControllerTest.java
@@ -9,6 +9,8 @@ import com.wooteco.sokdak.board.controller.BoardController;
 import com.wooteco.sokdak.board.service.BoardService;
 import com.wooteco.sokdak.comment.controller.CommentController;
 import com.wooteco.sokdak.comment.service.CommentService;
+import com.wooteco.sokdak.hashtag.controller.HashtagController;
+import com.wooteco.sokdak.hashtag.service.HashtagService;
 import com.wooteco.sokdak.like.controller.LikeController;
 import com.wooteco.sokdak.like.service.LikeService;
 import com.wooteco.sokdak.member.controller.MemberController;
@@ -37,7 +39,8 @@ import org.springframework.web.context.WebApplicationContext;
         AuthController.class,
         CommentController.class,
         LikeController.class,
-        BoardController.class
+        BoardController.class,
+        HashtagController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 public class ControllerTest {
@@ -67,6 +70,9 @@ public class ControllerTest {
 
     @MockBean
     protected BoardService boardService;
+
+    @MockBean
+    protected HashtagService hashtagService;
 
     @MockBean
     protected TokenManager tokenManager;

--- a/backend/sokdak/src/test/resources/truncate.sql
+++ b/backend/sokdak/src/test/resources/truncate.sql
@@ -7,6 +7,7 @@ TRUNCATE TABLE post;
 TRUNCATE TABLE auth_code;
 TRUNCATE TABLE ticket;
 TRUNCATE TABLE member;
+TRUNCATE TABLE board;
 SET FOREIGN_KEY_CHECKS = 1;
 
 insert into member (username, nickname, password) values ('chris', 'chrisNickname', '6297d64078fc9abcfe37d0e2c910d4798bb4c04502d7dd1207f558860c2b382e');


### PR DESCRIPTION
### 구현기능
해시태그로 검색 기능 구현 및 테스트 격리를 위해 추가 조치
resolved: #172

### 세부 구현기능
- [x] 해시태그 패키지 분리
- [x] 해시태그 중복 저장 안되도록 변경
- [x] 해시태그 검색 인수테스트 구현
- [x] `Post` `get...Count()`에서 `null` 처리
- [x] 해시태그 검색 기능 구현
- [x] 테스트 격리를 위해 `ServiceTest`에 `@Sql` 어노테이션 추가
- [x] 해시태그 컨트롤러 테스트 구현 

### 관련 이슈
[테스트 격리 관련 노션 링크](https://utopian-galley-07b.notion.site/88edd0ef360e4fb3b55e5123a6bc9067)