### PR TITLE
feat: 해시태그 목록 조회 기능 구현 #171

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/config/WebMvcConfig.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/config/WebMvcConfig.java
@@ -41,7 +41,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addInterceptor(authInterceptor)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/login")
-                .excludePathPatterns("/members/signup/**");
+                .excludePathPatterns("/members/signup/**")
+                .excludePathPatterns("/hashtags/**");
     }
 
     @Override

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/controller/HashtagController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/controller/HashtagController.java
@@ -2,6 +2,7 @@ package com.wooteco.sokdak.hashtag.controller;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
+import com.wooteco.sokdak.hashtag.dto.HashtagsSearchRequest;
 import com.wooteco.sokdak.hashtag.dto.HashtagsSearchResponse;
 import com.wooteco.sokdak.hashtag.service.HashtagService;
 import com.wooteco.sokdak.post.dto.PostsResponse;
@@ -10,6 +11,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,8 +34,9 @@ public class HashtagController {
     }
 
     @GetMapping(path = "/hashtags/popular", params = {"limit", "include"})
-    public ResponseEntity<HashtagsSearchResponse> findHashtagsWithTagName(@RequestParam String include, @RequestParam int limit) {
-        HashtagsSearchResponse hashtagsSearchResponse = hashtagService.findHashtagsWithTagName(include,limit);
+    public ResponseEntity<HashtagsSearchResponse> findHashtagsWithTagName(
+            @ModelAttribute HashtagsSearchRequest hashtagsSearchRequest) {
+        HashtagsSearchResponse hashtagsSearchResponse = hashtagService.findHashtagsWithTagName(hashtagsSearchRequest);
         return ResponseEntity.status(HttpStatus.OK).body(hashtagsSearchResponse);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/controller/HashtagController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/controller/HashtagController.java
@@ -2,10 +2,12 @@ package com.wooteco.sokdak.hashtag.controller;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
+import com.wooteco.sokdak.hashtag.dto.HashtagsSearchResponse;
 import com.wooteco.sokdak.hashtag.service.HashtagService;
 import com.wooteco.sokdak.post.dto.PostsResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,5 +29,11 @@ public class HashtagController {
                                                               @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
         PostsResponse postsResponse = hashtagService.findPostsWithHashtag(hashtag, pageable);
         return ResponseEntity.ok(postsResponse);
+    }
+
+    @GetMapping(path = "/hashtags/popular", params = {"limit", "include"})
+    public ResponseEntity<HashtagsSearchResponse> findHashtagsWithTagName(@RequestParam String include, @RequestParam int limit) {
+        HashtagsSearchResponse hashtagsSearchResponse = hashtagService.findHashtagsWithTagName(include,limit);
+        return ResponseEntity.status(HttpStatus.OK).body(hashtagsSearchResponse);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/dto/HashtagSearchElementResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/dto/HashtagSearchElementResponse.java
@@ -1,22 +1,26 @@
 package com.wooteco.sokdak.hashtag.dto;
 
 import com.wooteco.sokdak.hashtag.domain.Hashtag;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class HashtagSearchElementResponse {
 
     private Long id;
     private String name;
-    private int count;
+    private Long count;
 
-    public HashtagSearchElementResponse(Long id, String name, int count) {
+    protected HashtagSearchElementResponse() {}
+
+    public HashtagSearchElementResponse(Long id, String name, Long count) {
         this.id = id;
         this.name = name;
         this.count = count;
     }
 
-    public HashtagSearchElementResponse(Hashtag hashtag, int count) {
+    public HashtagSearchElementResponse(Hashtag hashtag, Long count) {
         this(hashtag.getId(), hashtag.getName(), count);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/dto/HashtagSearchElementResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/dto/HashtagSearchElementResponse.java
@@ -1,0 +1,22 @@
+package com.wooteco.sokdak.hashtag.dto;
+
+import com.wooteco.sokdak.hashtag.domain.Hashtag;
+import lombok.Getter;
+
+@Getter
+public class HashtagSearchElementResponse {
+
+    private Long id;
+    private String name;
+    private int count;
+
+    public HashtagSearchElementResponse(Long id, String name, int count) {
+        this.id = id;
+        this.name = name;
+        this.count = count;
+    }
+
+    public HashtagSearchElementResponse(Hashtag hashtag, int count) {
+        this(hashtag.getId(), hashtag.getName(), count);
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/dto/HashtagsSearchRequest.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/dto/HashtagsSearchRequest.java
@@ -1,0 +1,21 @@
+package com.wooteco.sokdak.hashtag.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Positive;
+import lombok.Getter;
+
+@Getter
+public class HashtagsSearchRequest {
+
+    @NotBlank(message = "해시태그는 1자 이상 50자 이하여야 합니다.")
+    private String include;
+    @Positive
+    private int limit;
+
+    protected HashtagsSearchRequest() {}
+
+    public HashtagsSearchRequest(String include, int limit) {
+        this.include = include;
+        this.limit = limit;
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/dto/HashtagsSearchResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/dto/HashtagsSearchResponse.java
@@ -1,0 +1,14 @@
+package com.wooteco.sokdak.hashtag.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class HashtagsSearchResponse {
+
+    private final List<HashtagSearchElementResponse> hashtags;
+
+    public HashtagsSearchResponse(List<HashtagSearchElementResponse> hashtags) {
+        this.hashtags = hashtags;
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/repository/HashtagRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/repository/HashtagRepository.java
@@ -1,6 +1,7 @@
 package com.wooteco.sokdak.hashtag.repository;
 
 import com.wooteco.sokdak.hashtag.domain.Hashtag;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
     boolean existsByName(String name);
 
     Optional<Hashtag> findByName(String name);
+
+    List<Hashtag> findAllByNameContains(String name);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/repository/PostHashtagRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/repository/PostHashtagRepository.java
@@ -1,8 +1,11 @@
 package com.wooteco.sokdak.hashtag.repository;
 
+import com.wooteco.sokdak.hashtag.domain.Hashtag;
 import com.wooteco.sokdak.hashtag.domain.PostHashtag;
+import com.wooteco.sokdak.hashtag.dto.HashtagSearchElementResponse;
 import com.wooteco.sokdak.post.domain.Post;
 import java.util.List;
+import javax.persistence.Tuple;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,5 +20,10 @@ public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> 
     boolean existsByHashtagId(Long id);
 
     @Query(value = "SELECT p FROM Post p INNER JOIN PostHashtag ph ON p=ph.post and ph.hashtag.id = :hashtagId")
-    Slice<Post> findAllByHashtagId(Long hashtagId, Pageable pageable);
+    Slice<Post> findAllPostByHashtagId(Long hashtagId, Pageable pageable);
+
+    int countByHashtagId(Long hashtagId);
+
+    @Query(value = "SELECT ph.hashtag, COUNT(ph.hashtag.id) FROM PostHashtag ph WHERE ph.hashtag IN :hashtags GROUP BY ph.hashtag ORDER BY COUNT(ph.hashtag.id) DESC")
+    List<Tuple> findAllByHashtagOrderByCount(List<Hashtag> hashtags, Pageable pageable);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/service/HashtagService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/service/HashtagService.java
@@ -3,12 +3,12 @@ package com.wooteco.sokdak.hashtag.service;
 import com.wooteco.sokdak.hashtag.domain.Hashtag;
 import com.wooteco.sokdak.hashtag.domain.Hashtags;
 import com.wooteco.sokdak.hashtag.dto.HashtagSearchElementResponse;
+import com.wooteco.sokdak.hashtag.dto.HashtagsSearchRequest;
 import com.wooteco.sokdak.hashtag.dto.HashtagsSearchResponse;
 import com.wooteco.sokdak.hashtag.exception.HashtagNotFoundException;
 import com.wooteco.sokdak.hashtag.repository.HashtagRepository;
 import com.wooteco.sokdak.hashtag.repository.PostHashtagRepository;
 import com.wooteco.sokdak.post.domain.Post;
-import com.wooteco.sokdak.post.dto.PostsElementResponse;
 import com.wooteco.sokdak.post.dto.PostsResponse;
 import java.util.ArrayList;
 import java.util.List;
@@ -72,14 +72,14 @@ public class HashtagService {
         return PostsResponse.ofSlice(posts);
     }
 
-    public HashtagsSearchResponse findHashtagsWithTagName(String include, int limit) {
-        List<Hashtag> contains = hashtagRepository.findAllByNameContains(include);
+    public HashtagsSearchResponse findHashtagsWithTagName(HashtagsSearchRequest hashtagsSearchRequest) {
+        List<Hashtag> contains = hashtagRepository.findAllByNameContains(hashtagsSearchRequest.getInclude());
         if (contains.isEmpty()) {
             return new HashtagsSearchResponse(new ArrayList<>());
         }
 
         List<Tuple> hashtagOrderByCount = postHashtagRepository.findAllByHashtagOrderByCount(
-                contains, PageRequest.of(0, limit));
+                contains, PageRequest.of(0, hashtagsSearchRequest.getLimit()));
 
         List<HashtagSearchElementResponse> hashtagSearchElementResponses = hashtagOrderByCount.stream()
                 .map(tuple -> new HashtagSearchElementResponse(tuple.get(0, Hashtag.class), tuple.get(1, Long.class)))

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -1,6 +1,7 @@
 package com.wooteco.sokdak.post.domain;
 
 import com.wooteco.sokdak.auth.exception.AuthenticationException;
+import com.wooteco.sokdak.board.domain.PostBoard;
 import com.wooteco.sokdak.comment.domain.Comment;
 import com.wooteco.sokdak.hashtag.domain.PostHashtag;
 import com.wooteco.sokdak.like.domain.Like;

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/controller/HashtagControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/controller/HashtagControllerTest.java
@@ -3,10 +3,13 @@ package com.wooteco.sokdak.hashtag.controller;
 import static com.wooteco.sokdak.util.fixture.MemberFixture.AUTH_INFO;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 
+import com.wooteco.sokdak.hashtag.dto.HashtagSearchElementResponse;
+import com.wooteco.sokdak.hashtag.dto.HashtagsSearchResponse;
 import com.wooteco.sokdak.hashtag.exception.HashtagNotFoundException;
 import com.wooteco.sokdak.post.dto.PostsElementResponse;
 import com.wooteco.sokdak.post.dto.PostsResponse;
@@ -61,7 +64,7 @@ class HashtagControllerTest extends ControllerTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/posts?hashtag=속닥&size=5&page=0")
                 .then().log().all()
-                .apply(document("hashtag/search/success"))
+                .apply(document("search/byHashtag/success"))
                 .statusCode(HttpStatus.OK.value());
     }
 
@@ -76,7 +79,27 @@ class HashtagControllerTest extends ControllerTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/posts?hashtag=없는태그&size=5&page=0")
                 .then().log().all()
-                .apply(document("hashtag/search/success"))
+                .apply(document("search/byHashtag/success"))
                 .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    @DisplayName("해시태그 목록 조회 시 200 반환")
+    @Test
+    void findHashtagsWithTagName() {
+        HashtagsSearchResponse hashtagsSearchResponse = new HashtagsSearchResponse(List.of(
+                new HashtagSearchElementResponse(1L,"태그1",5L),
+                new HashtagSearchElementResponse(2L,"태그2",2L)
+        ));
+
+        doReturn(hashtagsSearchResponse)
+                .when(hashtagService)
+                .findHashtagsWithTagName(matches("태그"), same(3));
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/hashtags/popular?include=태그&limit=3")
+                .then().log().all()
+                .apply(document("hashtags/search/success"))
+                .statusCode(HttpStatus.OK.value());
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/controller/HashtagControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/controller/HashtagControllerTest.java
@@ -3,12 +3,13 @@ package com.wooteco.sokdak.hashtag.controller;
 import static com.wooteco.sokdak.util.fixture.MemberFixture.AUTH_INFO;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.matches;
-import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 
 import com.wooteco.sokdak.hashtag.dto.HashtagSearchElementResponse;
+import com.wooteco.sokdak.hashtag.dto.HashtagsSearchRequest;
 import com.wooteco.sokdak.hashtag.dto.HashtagsSearchResponse;
 import com.wooteco.sokdak.hashtag.exception.HashtagNotFoundException;
 import com.wooteco.sokdak.post.dto.PostsElementResponse;
@@ -87,13 +88,13 @@ class HashtagControllerTest extends ControllerTest {
     @Test
     void findHashtagsWithTagName() {
         HashtagsSearchResponse hashtagsSearchResponse = new HashtagsSearchResponse(List.of(
-                new HashtagSearchElementResponse(1L,"태그1",5L),
-                new HashtagSearchElementResponse(2L,"태그2",2L)
+                new HashtagSearchElementResponse(1L, "태그1", 5L),
+                new HashtagSearchElementResponse(2L, "태그2", 2L)
         ));
 
         doReturn(hashtagsSearchResponse)
                 .when(hashtagService)
-                .findHashtagsWithTagName(matches("태그"), same(3));
+                .findHashtagsWithTagName(refEq(new HashtagsSearchRequest("태그", 3)));
 
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/repository/HashtagRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/repository/HashtagRepositoryTest.java
@@ -1,0 +1,75 @@
+package com.wooteco.sokdak.hashtag.repository;
+
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_ENCRYPTED_PASSWORD;
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_USERNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wooteco.sokdak.config.JPAConfig;
+import com.wooteco.sokdak.hashtag.domain.Hashtag;
+import com.wooteco.sokdak.hashtag.domain.Hashtags;
+import com.wooteco.sokdak.hashtag.domain.PostHashtag;
+import com.wooteco.sokdak.member.domain.Member;
+import com.wooteco.sokdak.member.repository.MemberRepository;
+import com.wooteco.sokdak.post.domain.Post;
+import com.wooteco.sokdak.post.repository.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(JPAConfig.class)
+class HashtagRepositoryTest {
+    @Autowired
+    private PostHashtagRepository postHashtagRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PostRepository postRepository;
+    @Autowired
+    private HashtagRepository hashtagRepository;
+
+    private final Hashtag tag1 = Hashtag.builder().name("태그1").build();
+    private final Hashtag tag2 = Hashtag.builder().name("태그2").build();
+
+    @BeforeEach
+    void setUp() {
+        Member member = memberRepository
+                .findByUsernameValueAndPassword(VALID_USERNAME, VALID_ENCRYPTED_PASSWORD)
+                .orElseThrow();
+
+        Post post1 = Post.builder()
+                .title("제목1")
+                .content("본문1")
+                .member(member)
+                .build();
+        Post post2 = Post.builder()
+                .title("제목2")
+                .content("본문2")
+                .member(member)
+                .build();
+        Post post3 = Post.builder()
+                .title("제목3")
+                .content("본문3")
+                .member(member)
+                .build();
+        postRepository.save(post1);
+        postRepository.save(post2);
+        postRepository.save(post3);
+
+        hashtagRepository.save(tag1);
+        hashtagRepository.save(tag2);
+
+        postHashtagRepository.save(PostHashtag.builder().post(post1).hashtag(tag1).build());
+        postHashtagRepository.save(PostHashtag.builder().post(post1).hashtag(tag2).build());
+        postHashtagRepository.save(PostHashtag.builder().post(post2).hashtag(tag1).build());
+        postHashtagRepository.save(PostHashtag.builder().post(post3).hashtag(tag2).build());
+    }
+
+    @Test
+    void findAllByNameContains() {
+        Hashtags hashtags = new Hashtags(hashtagRepository.findAllByNameContains("태그"));
+        assertThat(hashtags.getNames()).containsOnly("태그1", "태그2");
+    }
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/repository/PostHashtagRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/repository/PostHashtagRepositoryTest.java
@@ -7,11 +7,16 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 
 import com.wooteco.sokdak.config.JPAConfig;
 import com.wooteco.sokdak.hashtag.domain.Hashtag;
+import com.wooteco.sokdak.hashtag.domain.Hashtags;
 import com.wooteco.sokdak.hashtag.domain.PostHashtag;
+import com.wooteco.sokdak.hashtag.dto.HashtagSearchElementResponse;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.repository.MemberRepository;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.repository.PostRepository;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Tuple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +41,7 @@ class PostHashtagRepositoryTest {
 
     private final Hashtag tag1 = Hashtag.builder().name("태그1").build();
     private final Hashtag tag2 = Hashtag.builder().name("태그2").build();
+    private final Hashtag tag3 = Hashtag.builder().name("태그3").build();
 
     @BeforeEach
     void setUp() {
@@ -64,11 +70,20 @@ class PostHashtagRepositoryTest {
 
         hashtagRepository.save(tag1);
         hashtagRepository.save(tag2);
+        hashtagRepository.save(tag3);
 
         postHashtagRepository.save(PostHashtag.builder().post(post1).hashtag(tag1).build());
         postHashtagRepository.save(PostHashtag.builder().post(post1).hashtag(tag2).build());
+        postHashtagRepository.save(PostHashtag.builder().post(post1).hashtag(tag3).build());
         postHashtagRepository.save(PostHashtag.builder().post(post2).hashtag(tag1).build());
-        postHashtagRepository.save(PostHashtag.builder().post(post3).hashtag(tag2).build());
+        postHashtagRepository.save(PostHashtag.builder().post(post2).hashtag(tag3).build());
+        postHashtagRepository.save(PostHashtag.builder().post(post3).hashtag(tag1).build());
+    }
+
+    @Test
+    void countByHashtagId() {
+        int count = postHashtagRepository.countByHashtagId(tag1.getId());
+        assertThat(count).isEqualTo(3);
     }
 
     @Test
@@ -77,5 +92,19 @@ class PostHashtagRepositoryTest {
 
         Slice<Post> posts = postHashtagRepository.findAllByHashtagId(tag1.getId(), pageable);
         assertThat(posts.getNumberOfElements()).isEqualTo(2);
+    }
+
+    @Test
+    void findAllByHashtagOrderByCount(){
+        List<Hashtag> hashtags = hashtagRepository.findAllByNameContains("태그");
+        PageRequest pageable = PageRequest.of(0, 5);
+        List<Tuple> allByHashtagOrderByCount = postHashtagRepository.findAllByHashtagOrderByCount(hashtags, pageable);
+        List<String> names = new ArrayList<>();
+
+        for (Tuple tuple : allByHashtagOrderByCount) {
+            names.add(tuple.get(0, Hashtag.class).getName());
+        }
+
+        assertThat(names).containsExactly("태그1","태그3","태그2");
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/repository/PostHashtagRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/repository/PostHashtagRepositoryTest.java
@@ -90,8 +90,8 @@ class PostHashtagRepositoryTest {
     void findAllByHashtagId() {
         Pageable pageable = PageRequest.of(0, 3, DESC, "createdAt");
 
-        Slice<Post> posts = postHashtagRepository.findAllByHashtagId(tag1.getId(), pageable);
-        assertThat(posts.getNumberOfElements()).isEqualTo(2);
+        Slice<Post> posts = postHashtagRepository.findAllPostByHashtagId(tag1.getId(), pageable);
+        assertThat(posts.getNumberOfElements()).isEqualTo(3);
     }
 
     @Test

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/service/HashtagServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/service/HashtagServiceTest.java
@@ -11,6 +11,7 @@ import com.wooteco.sokdak.hashtag.domain.Hashtag;
 import com.wooteco.sokdak.hashtag.domain.Hashtags;
 import com.wooteco.sokdak.hashtag.domain.PostHashtag;
 import com.wooteco.sokdak.hashtag.dto.HashtagSearchElementResponse;
+import com.wooteco.sokdak.hashtag.dto.HashtagsSearchRequest;
 import com.wooteco.sokdak.hashtag.dto.HashtagsSearchResponse;
 import com.wooteco.sokdak.hashtag.exception.HashtagNotFoundException;
 import com.wooteco.sokdak.hashtag.repository.HashtagRepository;
@@ -211,14 +212,15 @@ class HashtagServiceTest {
                 HashtagSearchElementResponse.builder().name(tag1.getName()).count(2L).build(),
                 HashtagSearchElementResponse.builder().name(tag2.getName()).count(1L).build());
 
-        HashtagsSearchResponse hashtagsSearchResponse = hashtagService.findHashtagsWithTagName("태그", 3);
+        HashtagsSearchResponse hashtagsSearchResponse = hashtagService.findHashtagsWithTagName(
+                new HashtagsSearchRequest("태그", 3));
 
         List<HashtagSearchElementResponse> responseHashtags = hashtagsSearchResponse.getHashtags();
 
         assertAll(
                 () -> assertThat(responseHashtags).hasSize(2),
                 () -> assertThat(responseHashtags).usingRecursiveComparison()
-                        .comparingOnlyFields("name","count")
+                        .comparingOnlyFields("name", "count")
                         .isEqualTo(expectedHashtags)
         );
     }
@@ -226,7 +228,8 @@ class HashtagServiceTest {
     @DisplayName("특정 키워드로 검색 시 해당 키워드가 이름에 포함된 해시태그가 없을 시 결과 값이 비어있다.")
     @Test
     void findHashtagsWithTagName_Exception_NoHashtagName() {
-        HashtagsSearchResponse hashtagsSearchResponse = hashtagService.findHashtagsWithTagName("태그", 3);
+        HashtagsSearchResponse hashtagsSearchResponse = hashtagService.findHashtagsWithTagName(
+                new HashtagsSearchRequest("태그", 3));
 
         assertThat(hashtagsSearchResponse.getHashtags()).isEmpty();
     }
@@ -234,7 +237,8 @@ class HashtagServiceTest {
     @DisplayName("특정 키워드로 검색 시 결과 개수 설정이 0 이하일 시 결과 값이 비어있다.")
     @Test
     void findHashtagsWithTagName_Exception_InvalidLimit() {
-        HashtagsSearchResponse hashtagsSearchResponse = hashtagService.findHashtagsWithTagName("태그", 0);
+        HashtagsSearchResponse hashtagsSearchResponse = hashtagService.findHashtagsWithTagName(
+                new HashtagsSearchRequest("태그", 0));
 
         assertThat(hashtagsSearchResponse.getHashtags()).isEmpty();
     }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/service/HashtagServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/service/HashtagServiceTest.java
@@ -10,6 +10,8 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 import com.wooteco.sokdak.hashtag.domain.Hashtag;
 import com.wooteco.sokdak.hashtag.domain.Hashtags;
 import com.wooteco.sokdak.hashtag.domain.PostHashtag;
+import com.wooteco.sokdak.hashtag.dto.HashtagSearchElementResponse;
+import com.wooteco.sokdak.hashtag.dto.HashtagsSearchResponse;
 import com.wooteco.sokdak.hashtag.exception.HashtagNotFoundException;
 import com.wooteco.sokdak.hashtag.repository.HashtagRepository;
 import com.wooteco.sokdak.hashtag.repository.PostHashtagRepository;
@@ -198,6 +200,43 @@ class HashtagServiceTest {
 
         List<PostsElementResponse> posts = postsResponse.getPosts();
         assertThat(posts).hasSize(0);
+    }
+
+    @DisplayName("특정 키워드로 검색 시 해당 키워드가 이름에 포함된 해시태그들을 조회하는 기능")
+    @Test
+    void findHashtagsWithTagName() {
+        savePostWithHashtags(post, List.of(tag1, tag2));
+        savePostWithHashtags(post2, List.of(tag1));
+        List<HashtagSearchElementResponse> expectedHashtags = List.of(
+                HashtagSearchElementResponse.builder().name(tag1.getName()).count(2L).build(),
+                HashtagSearchElementResponse.builder().name(tag2.getName()).count(1L).build());
+
+        HashtagsSearchResponse hashtagsSearchResponse = hashtagService.findHashtagsWithTagName("태그", 3);
+
+        List<HashtagSearchElementResponse> responseHashtags = hashtagsSearchResponse.getHashtags();
+
+        assertAll(
+                () -> assertThat(responseHashtags).hasSize(2),
+                () -> assertThat(responseHashtags).usingRecursiveComparison()
+                        .comparingOnlyFields("name","count")
+                        .isEqualTo(expectedHashtags)
+        );
+    }
+
+    @DisplayName("특정 키워드로 검색 시 해당 키워드가 이름에 포함된 해시태그가 없을 시 결과 값이 비어있다.")
+    @Test
+    void findHashtagsWithTagName_Exception_NoHashtagName() {
+        HashtagsSearchResponse hashtagsSearchResponse = hashtagService.findHashtagsWithTagName("태그", 3);
+
+        assertThat(hashtagsSearchResponse.getHashtags()).isEmpty();
+    }
+
+    @DisplayName("특정 키워드로 검색 시 결과 개수 설정이 0 이하일 시 결과 값이 비어있다.")
+    @Test
+    void findHashtagsWithTagName_Exception_InvalidLimit() {
+        HashtagsSearchResponse hashtagsSearchResponse = hashtagService.findHashtagsWithTagName("태그", 0);
+
+        assertThat(hashtagsSearchResponse.getHashtags()).isEmpty();
     }
 
     private Long savePostWithHashtags(Post post, List<Hashtag> tags) {


### PR DESCRIPTION
### 구현기능
- 키워드로 검색하면 해당 키워드가 포함된 해시태그 목록을 반환하는 기능 구현
- 인터셉터에 "/hashtags/**" 주소를 토큰 검증에서 제외시킴

resolved: #171 

### 세부 구현기능
- [x] 해시태그 목록 조회 인수테스트 작성
- [x] 해시태그 검색 JPQL문 구현
    - [x] 해당 해시태그가 포함된 게시물 개수가 많은 순으로 정렬해 페이지네이션 구현
- [x] 해시태그 목록 조회 기능 구현
### 관련 이슈
- `BE` 브랜치로 재 리베이스 후 pr 다시 날렸습니다!
- `PostHashtagRepository`에서 JPQL 사용