### PR TITLE
feat: 메인페이지 조회 기능 구현

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/board/controller/BoardController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/board/controller/BoardController.java
@@ -1,6 +1,7 @@
 package com.wooteco.sokdak.board.controller;
 
 import com.wooteco.sokdak.auth.dto.AuthInfo;
+import com.wooteco.sokdak.board.dto.BoardContentResponse;
 import com.wooteco.sokdak.board.dto.BoardsResponse;
 import com.wooteco.sokdak.board.dto.NewBoardRequest;
 import com.wooteco.sokdak.board.dto.NewBoardResponse;
@@ -36,5 +37,11 @@ public class BoardController {
     public ResponseEntity<BoardsResponse> findBoards() {
         BoardsResponse boardsResponse = boardService.findBoards();
         return ResponseEntity.ok(boardsResponse);
+    }
+
+    @GetMapping("/content")
+    public ResponseEntity<BoardContentResponse> findBoardsContent() {
+        BoardContentResponse boardContentResponse = boardService.findBoardsContent();
+        return ResponseEntity.ok(boardContentResponse);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/board/controller/BoardController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/board/controller/BoardController.java
@@ -29,7 +29,7 @@ public class BoardController {
     public ResponseEntity<Void> createBoard(@Valid @RequestBody NewBoardRequest newBoardRequest,
                                             @Login AuthInfo authInfo) {
         NewBoardResponse board = boardService.createBoard(newBoardRequest);
-        return ResponseEntity.created(URI.create("/posts/" + board.getId())).build();
+        return ResponseEntity.created(URI.create("/boards/" + board.getId())).build();
     }
 
     @GetMapping

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/board/dto/BoardContentElement.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/board/dto/BoardContentElement.java
@@ -1,0 +1,32 @@
+package com.wooteco.sokdak.board.dto;
+
+import com.wooteco.sokdak.board.domain.Board;
+import com.wooteco.sokdak.post.dto.PostsElementResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public class BoardContentElement {
+
+    private Long id;
+    private String title;
+    private List<BoardContentPostElement> posts;
+
+    public BoardContentElement() {
+    }
+
+    public BoardContentElement(Long id, String title,
+                               List<BoardContentPostElement> posts) {
+        this.id = id;
+        this.title = title;
+        this.posts = posts;
+    }
+
+    public static BoardContentElement from(Board board, List<PostsElementResponse> postsElementResponses) {
+        List<BoardContentPostElement> boardContentPostElements = postsElementResponses.stream()
+                .map(it -> new BoardContentPostElement(it.getLikeCount(), it.getTitle(), it.getCommentCount()))
+                .collect(Collectors.toList());
+        return new BoardContentElement(board.getId(), board.getTitle(), boardContentPostElements);
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/board/dto/BoardContentPostElement.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/board/dto/BoardContentPostElement.java
@@ -9,7 +9,7 @@ public class BoardContentPostElement {
     private String title;
     private int commentCount;
 
-    public BoardContentPostElement() {
+    protected BoardContentPostElement() {
     }
 
     public BoardContentPostElement(int likeCount, String title, int commentCount) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/board/dto/BoardContentPostElement.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/board/dto/BoardContentPostElement.java
@@ -1,0 +1,20 @@
+package com.wooteco.sokdak.board.dto;
+
+import lombok.Getter;
+
+@Getter
+public class BoardContentPostElement {
+
+    private int likeCount;
+    private String title;
+    private int commentCount;
+
+    public BoardContentPostElement() {
+    }
+
+    public BoardContentPostElement(int likeCount, String title, int commentCount) {
+        this.likeCount = likeCount;
+        this.title = title;
+        this.commentCount = commentCount;
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/board/dto/BoardContentResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/board/dto/BoardContentResponse.java
@@ -8,7 +8,7 @@ public class BoardContentResponse {
 
     private List<BoardContentElement> boards;
 
-    public BoardContentResponse() {
+    protected BoardContentResponse() {
     }
 
     public BoardContentResponse(List<BoardContentElement> boards) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/board/dto/BoardContentResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/board/dto/BoardContentResponse.java
@@ -1,0 +1,21 @@
+package com.wooteco.sokdak.board.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class BoardContentResponse {
+
+    private List<BoardContentElement> boards;
+
+    public BoardContentResponse() {
+    }
+
+    public BoardContentResponse(List<BoardContentElement> boards) {
+        this.boards = boards;
+    }
+
+    public static BoardContentResponse of(List<BoardContentElement> boardContentElements) {
+        return new BoardContentResponse(boardContentElements);
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/board/service/BoardService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/board/service/BoardService.java
@@ -2,6 +2,8 @@ package com.wooteco.sokdak.board.service;
 
 import com.wooteco.sokdak.board.domain.Board;
 import com.wooteco.sokdak.board.domain.PostBoard;
+import com.wooteco.sokdak.board.dto.BoardContentElement;
+import com.wooteco.sokdak.board.dto.BoardContentResponse;
 import com.wooteco.sokdak.board.dto.BoardResponse;
 import com.wooteco.sokdak.board.dto.BoardsResponse;
 import com.wooteco.sokdak.board.dto.NewBoardRequest;
@@ -10,8 +12,15 @@ import com.wooteco.sokdak.board.exception.BoardNotFoundException;
 import com.wooteco.sokdak.board.repository.BoardRepository;
 import com.wooteco.sokdak.board.repository.PostBoardRepository;
 import com.wooteco.sokdak.post.domain.Post;
+import com.wooteco.sokdak.post.dto.PostsElementResponse;
+import com.wooteco.sokdak.post.dto.PostsResponse;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class BoardService {
 
+    public static final int PAGE_SIZE = 3;
     private final BoardRepository boardRepository;
     private final PostBoardRepository postBoardRepository;
 
@@ -44,17 +54,35 @@ public class BoardService {
         return new BoardsResponse(boardResponses);
     }
 
+    @Transactional
     public void savePostBoard(Post savedPost, Long boardId) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(BoardNotFoundException::new);
 
         PostBoard postBoard = PostBoard.builder()
-//                .post(savedPost)
-//                .board(board)
                 .build();
 
         postBoard.addPost(savedPost);
         postBoard.addBoard(board);
         postBoardRepository.save(postBoard);
+    }
+
+    public BoardContentResponse findBoardsContent() {
+        List<BoardContentElement> boardContentElements = new ArrayList<>();
+
+        List<Board> boards = boardRepository.findAll();
+        PageRequest page = PageRequest.of(0, 3, Sort.by("createdAt").descending());
+
+        for (Board board : boards) {
+            List<PostsElementResponse> postsElementResponses = findPostsByBoard(board.getId(),page).getPosts();
+            BoardContentElement boardContentElement = BoardContentElement.from(board, postsElementResponses);
+            boardContentElements.add(boardContentElement);
+        }
+        return BoardContentResponse.of(boardContentElements);
+    }
+
+    public PostsResponse findPostsByBoard(Long boardId, Pageable pageable) {
+        Slice<PostBoard> postBoards = postBoardRepository.findPostBoardsByBoardId(boardId, pageable);
+        return PostsResponse.ofPostBoardSlice(postBoards);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/board/service/BoardService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/board/service/BoardService.java
@@ -28,7 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class BoardService {
 
-    public static final int PAGE_SIZE = 3;
+    private static final int PAGE_SIZE = 3;
     private final BoardRepository boardRepository;
     private final PostBoardRepository postBoardRepository;
 
@@ -71,7 +71,7 @@ public class BoardService {
         List<BoardContentElement> boardContentElements = new ArrayList<>();
 
         List<Board> boards = boardRepository.findAll();
-        PageRequest page = PageRequest.of(0, 3, Sort.by("createdAt").descending());
+        PageRequest page = PageRequest.of(0, PAGE_SIZE, Sort.by("createdAt").descending());
 
         for (Board board : boards) {
             List<PostsElementResponse> postsElementResponses = findPostsByBoard(board.getId(),page).getPosts();

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -1,6 +1,7 @@
 package com.wooteco.sokdak.post.domain;
 
 import com.wooteco.sokdak.auth.exception.AuthenticationException;
+import com.wooteco.sokdak.board.domain.PostBoard;
 import com.wooteco.sokdak.comment.domain.Comment;
 import com.wooteco.sokdak.hashtag.domain.PostHashtag;
 import com.wooteco.sokdak.like.domain.Like;
@@ -55,7 +56,7 @@ public class Post {
     private List<PostHashtag> postHashtags;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
-    private List<PostBoard> postBoards;
+    private List<PostBoard> postBoards = new ArrayList<>();
 
     @CreatedDate
     private LocalDateTime createdAt;

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/board/acceptance/BoardAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/board/acceptance/BoardAcceptanceTest.java
@@ -67,9 +67,9 @@ public class BoardAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = httpGet("/boards/content");
 
         // then
-        List<BoardContentElement> boardsAll = response.body().jsonPath().getList("boards", BoardContentElement.class);
-        BoardContentElement board1 = response.body().jsonPath().getList("boards", BoardContentElement.class).get(0);
-        BoardContentElement board2 = response.body().jsonPath().getList("boards", BoardContentElement.class).get(1);
+        List<BoardContentElement> boardsAll = getBoardContentElements(response);
+        BoardContentElement board1 = getBoardContentElements(response).get(0);
+        BoardContentElement board2 = getBoardContentElements(response).get(1);
         List<BoardContentPostElement> posts1 = board1.getPosts();
         List<BoardContentPostElement> posts2 = board2.getPosts();
 
@@ -92,5 +92,9 @@ public class BoardAcceptanceTest extends AcceptanceTest {
                         .extracting("title")
                         .containsExactly("제목4")
         );
+    }
+
+    private List<BoardContentElement> getBoardContentElements(ExtractableResponse<Response> response) {
+        return response.body().jsonPath().getList("boards", BoardContentElement.class);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/board/acceptance/BoardAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/board/acceptance/BoardAcceptanceTest.java
@@ -40,4 +40,30 @@ public class BoardAcceptanceTest extends AcceptanceTest {
                 .extracting("title")
                 .containsExactly("포수타", "자유게시판");
     }
+
+    @DisplayName("게시판 목록을 게시글들과 함께 조회할 수 있다.")
+    @Test
+    void findBoardsContent() {
+        // given
+        String token = getToken();
+        NewBoardRequest newBoardRequest1 = new NewBoardRequest("포수타");
+        ExtractableResponse<Response> response1 = httpPostWithAuthorization(newBoardRequest1, "/boards", token);
+        Long boardId1 = parseBoardId(response1);
+
+        NewBoardRequest newBoardRequest2 = new NewBoardRequest("자유게시판");
+        ExtractableResponse<Response> response2 = httpPostWithAuthorization(newBoardRequest2, "/boards", token);
+        Long boardId2 = parseBoardId(response2);
+
+        // when
+        ExtractableResponse<Response> response = httpGet("/boards/content");
+
+        assertThat(response.body().jsonPath().getList("boards", BoardResponse.class))
+                .extracting("title")
+                .containsExactly("포수타", "자유게시판");
+    }
+
+    private Long parseBoardId(ExtractableResponse<Response> response) {
+        return Long.parseLong(response.header("Location")
+                .split("/boards/")[1]);
+    }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/board/controller/BoardControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/board/controller/BoardControllerTest.java
@@ -66,8 +66,18 @@ class BoardControllerTest extends ControllerTest {
     void findBoards() {
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                //.header("Authorization", "any")
                 .when().get("/boards")
+                .then().log().all()
+                .apply(document("board/create/success"))
+                .statusCode(HttpStatus.OK.value());
+    }
+
+
+    @DisplayName("메인페이지 게시판 목록 반환")
+    @Test
+    void findBoardsContent() {
+        restDocs
+                .when().get("/boards/content")
                 .then().log().all()
                 .apply(document("board/create/success"))
                 .statusCode(HttpStatus.OK.value());


### PR DESCRIPTION
### 구현기능
메인페이지 조회 기능 구현

### 세부 구현기능
- [x] 메인페이지에서 게시판 목록과 각 게시판마다 최신순으로 게시글 3개를 조회합니다

### 관련 이슈
가져오는 데이터 json 구조가 복잡하여 Dto 이름들이 헷갈릴 수도 있을 것 같습니다. 혹시 좋은 아이디어 있으면 언제든지 제시 부탁드립니다. 