### PR TITLE
feat: 누적신고 5개 이상 게시글 block 기능 구현

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -6,6 +6,7 @@ import com.wooteco.sokdak.comment.domain.Comment;
 import com.wooteco.sokdak.hashtag.domain.PostHashtag;
 import com.wooteco.sokdak.like.domain.Like;
 import com.wooteco.sokdak.member.domain.Member;
+import com.wooteco.sokdak.report.domain.PostReport;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +31,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class Post {
+
+    private static final int BLOCKED_CONDITION = 5;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,6 +60,9 @@ public class Post {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private List<PostBoard> postBoards = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    private List<PostReport> postReports = new ArrayList<>();
 
     @CreatedDate
     private LocalDateTime createdAt;
@@ -105,6 +111,10 @@ public class Post {
         return member.getId().equals(accessMemberId);
     }
 
+    public boolean isBlocked() {
+        return postReports.size() >= BLOCKED_CONDITION;
+    }
+
     public Long getId() {
         return id;
     }
@@ -149,5 +159,9 @@ public class Post {
 
     public List<PostBoard> getPostBoards() {
         return postBoards;
+    }
+
+    public List<PostReport> getPostReports() {
+        return postReports;
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostDetailResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostDetailResponse.java
@@ -21,12 +21,13 @@ public class PostDetailResponse {
     private final boolean like;
     private final boolean authorized;
     private final boolean modified;
+    private final boolean blocked;
 
     @Builder
     private PostDetailResponse(Long id, String title, String content, List<HashtagResponse> hashtagResponses,
                                LocalDateTime createdAt, int likeCount,
                                boolean like,
-                               boolean authorized, boolean modified) {
+                               boolean authorized, boolean modified, boolean blocked) {
         this.id = id;
         this.title = title;
         this.content = content;
@@ -36,6 +37,7 @@ public class PostDetailResponse {
         this.like = like;
         this.authorized = authorized;
         this.modified = modified;
+        this.blocked = blocked;
     }
 
 
@@ -50,6 +52,7 @@ public class PostDetailResponse {
                 .authorized(authorized)
                 .hashtagResponses(toResponse(hashtags))
                 .modified(post.isModified())
+                .blocked(post.isBlocked())
                 .build();
     }
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostsElementResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostsElementResponse.java
@@ -15,10 +15,11 @@ public class PostsElementResponse {
     private final int likeCount;
     private final int commentCount;
     private final boolean modified;
+    private final boolean blocked;
 
     @Builder
     private PostsElementResponse(Long id, String title, String content, LocalDateTime createdAt,
-                                 int likeCount, int commentCount, boolean modified) {
+                                 int likeCount, int commentCount, boolean modified, boolean blocked) {
         this.id = id;
         this.title = title;
         this.content = content;
@@ -26,6 +27,7 @@ public class PostsElementResponse {
         this.likeCount = likeCount;
         this.commentCount = commentCount;
         this.modified = modified;
+        this.blocked = blocked;
     }
 
     public static PostsElementResponse from(Post post) {
@@ -37,6 +39,7 @@ public class PostsElementResponse {
                 .likeCount(post.getLikeCount())
                 .commentCount(post.getCommentCount())
                 .modified(post.isModified())
+                .blocked(post.isBlocked())
                 .build();
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/report/domain/PostReport.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/report/domain/PostReport.java
@@ -48,6 +48,11 @@ public class PostReport {
         this.post = post;
         this.reporter = reporter;
         this.reportMessage = new ReportMessage(reportMessage);
+        addPost();
+    }
+
+    private void addPost() {
+        this.post.getPostReports().add(this);
     }
 
     public Long getId() {

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
@@ -90,7 +90,7 @@ class PostAcceptanceTest extends AcceptanceTest {
                 parsePostId(httpPostWithAuthorization(postRequest2, CREATE_POST_URI, token)));
         reportPostToBlockPost(blockedPostId);
 
-        ExtractableResponse<Response> response = httpGet("/boards/1/posts?size=2&page=0");
+        ExtractableResponse<Response> response = httpGet("/boards/" + WRITABLE_BOARD_ID + "/posts?size=2&page=0");
         List<PostsElementResponse> postsElementResponses = parsePostsElementResponse(response);
 
         assertAll(

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.wooteco.sokdak.auth.dto.LoginRequest;
-import com.wooteco.sokdak.member.dto.SignupRequest;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
 import com.wooteco.sokdak.post.dto.PostDetailResponse;
 import com.wooteco.sokdak.post.dto.PostUpdateRequest;
@@ -80,7 +79,7 @@ class PostAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    @DisplayName("게시글 목록 중 누적 신고가 5개 이상인 게시글은 blocked 왼다.")
+    @DisplayName("게시글 목록 중 누적 신고가 5개 이상인 게시글은 blocked 된다.")
     @Test
     void findPosts_Blocked() {
         String token = getToken();
@@ -88,7 +87,7 @@ class PostAcceptanceTest extends AcceptanceTest {
         httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, token);
         Long blockedPostId = Long.parseLong(
                 parsePostId(httpPostWithAuthorization(postRequest2, CREATE_POST_URI, token)));
-        reportPostToBlockPost(blockedPostId);
+        blockPost(blockedPostId);
 
         ExtractableResponse<Response> response = httpGet("/boards/" + WRITABLE_BOARD_ID + "/posts?size=2&page=0");
         List<PostsElementResponse> postsElementResponses = parsePostsElementResponse(response);
@@ -152,7 +151,7 @@ class PostAcceptanceTest extends AcceptanceTest {
     void findPost_Blocked() {
         Long postId = Long.parseLong(
                 parsePostId(httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, getToken())));
-        reportPostToBlockPost(postId);
+        blockPost(postId);
 
         ExtractableResponse<Response> response = httpGet("/posts/" + postId);
         PostDetailResponse postDetailResponse = response.jsonPath().getObject(".", PostDetailResponse.class);
@@ -249,7 +248,7 @@ class PostAcceptanceTest extends AcceptanceTest {
                 .getPosts();
     }
 
-    private void reportPostToBlockPost(Long postId) {
+    private void blockPost(Long postId) {
         String token1 = getToken();
         String token2 = httpPost(new LoginRequest("josh", "Abcd123!@"), "/login").header(AUTHORIZATION);
         String token3 = httpPost(new LoginRequest("thor", "Abcd123!@"), "/login").header(AUTHORIZATION);

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.wooteco.sokdak.auth.exception.AuthenticationException;
 import com.wooteco.sokdak.member.domain.Member;
+import com.wooteco.sokdak.report.domain.PostReport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,10 +18,11 @@ import org.junit.jupiter.params.provider.CsvSource;
 class PostTest {
 
     private Post post;
+    private Member member;
 
     @BeforeEach
     void setUp() {
-        Member member = Member.builder()
+        member = Member.builder()
                 .id(1L)
                 .username(VALID_USERNAME)
                 .password(VALID_PASSWORD)
@@ -74,5 +76,20 @@ class PostTest {
         boolean actual = post.isAuthenticated(accessMemberId);
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @DisplayName("신고가 5개 이상이면 isBlocked()가 true를 반환")
+    @ParameterizedTest
+    @CsvSource({"4, false", "5, true"})
+    void isBlocked(int reportCount, boolean expected) {
+        for (int i = 0; i < reportCount; ++i) {
+            PostReport.builder()
+                    .post(post)
+                    .reporter(member)
+                    .reportMessage("신고")
+                    .build();
+        }
+
+        assertThat(post.isBlocked()).isEqualTo(expected);
     }
 }

--- a/backend/sokdak/src/test/resources/truncate.sql
+++ b/backend/sokdak/src/test/resources/truncate.sql
@@ -34,6 +34,7 @@ insert into member (username, nickname, password, role_type) values ('east', 'ea
 insert into member (username, nickname, password, role_type) values ('thor', 'thorNickname', '6297d64078fc9abcfe37d0e2c910d4798bb4c04502d7dd1207f558860c2b382e', 'USER');
 insert into member (username, nickname, password, role_type) values ('hunch', 'hunchNickname', '6297d64078fc9abcfe37d0e2c910d4798bb4c04502d7dd1207f558860c2b382e', 'USER');
 insert into member (username, nickname, password, role_type) values ('testAdmin', 'adminNick', '6297d64078fc9abcfe37d0e2c910d4798bb4c04502d7dd1207f558860c2b382e', 'ADMIN');
+
 insert into ticket (serial_number, used) values ('21f46568bf6002c23843d198af30bb2bc8123695bd3d12ce86e0fc35bc5d3279', false);
 insert into ticket (serial_number, used) values ('5810c81b6f78b1bcf62b53035d879e1309750ab60d1b4b601dfbc368005645cb', false);
 insert into ticket (serial_number, used) values ('694f51c40e1910a86b3f4a655ac874a0511402a6ac347b1cadccf7b9e3678fac', false);


### PR DESCRIPTION
### 구현기능
누적신고 5개 이상 게시글 block 기능 구현

### 세부 구현기능
- [x] 특정 게시판 모든 글 가져오는 기능에서 누적신고 5개 이상인 게시글은 block
- [x] 특정 게시글 가져오는 기능에서 누적신고 5개 이상인 게시글은 block