### PR TITLE
feat: 인증코드 시간 만료 #229

### DIFF
--- a/backend/sokdak/build.gradle
+++ b/backend/sokdak/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'io.rest-assured:rest-assured:4.4.0'
 	testImplementation 'io.rest-assured:spring-mock-mvc:4.4.0'
+	testImplementation 'org.mockito:mockito-inline:3.8.0'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/domain/AuthCode.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/domain/AuthCode.java
@@ -49,9 +49,9 @@ public class AuthCode {
         }
     }
 
-    public void verifyTime(LocalDateTime time) {
+    public void verifyTime(LocalDateTime now) {
         LocalDateTime expireTime = this.createdAt.plusMinutes(VALID_MINUIT);
-        if (time.isAfter(expireTime)) {
+        if (now.isAfter(expireTime)) {
             throw new InvalidAuthCodeException();
         }
     }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/domain/AuthCode.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/domain/AuthCode.java
@@ -7,6 +7,7 @@ import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -16,6 +17,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class AuthCode {
 
+    private static final long VALID_MINUIT = 5L;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -29,6 +31,13 @@ public class AuthCode {
     protected AuthCode() {
     }
 
+    @Builder
+    public AuthCode(String code, String serialNumber, LocalDateTime createdAt) {
+        this.code = code;
+        this.serialNumber = serialNumber;
+        this.createdAt = createdAt;
+    }
+
     public AuthCode(String code, String serialNumber) {
         this.code = code;
         this.serialNumber = serialNumber;
@@ -36,6 +45,13 @@ public class AuthCode {
 
     public void verify(String code) {
         if (!this.code.equals(code)) {
+            throw new InvalidAuthCodeException();
+        }
+    }
+
+    public void verifyTime(LocalDateTime time) {
+        LocalDateTime expireTime = this.createdAt.plusMinutes(VALID_MINUIT);
+        if (time.isAfter(expireTime)) {
             throw new InvalidAuthCodeException();
         }
     }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/domain/AuthCode.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/domain/AuthCode.java
@@ -17,7 +17,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class AuthCode {
 
-    private static final long VALID_MINUIT = 5L;
+    private static final long VALID_MINUTE = 5L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -50,7 +51,7 @@ public class AuthCode {
     }
 
     public void verifyTime(LocalDateTime now) {
-        LocalDateTime expireTime = this.createdAt.plusMinutes(VALID_MINUIT);
+        LocalDateTime expireTime = this.createdAt.plusMinutes(VALID_MINUTE);
         if (now.isAfter(expireTime)) {
             throw new InvalidAuthCodeException();
         }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/service/AuthService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/service/AuthService.java
@@ -13,6 +13,8 @@ import com.wooteco.sokdak.member.exception.TicketUsedException;
 import com.wooteco.sokdak.member.repository.AuthCodeRepository;
 import com.wooteco.sokdak.member.repository.MemberRepository;
 import com.wooteco.sokdak.member.repository.TicketRepository;
+import java.time.Clock;
+import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,14 +25,16 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final TicketRepository ticketRepository;
     private final Encryptor encryptor;
+    private final Clock clock;
 
     public AuthService(AuthCodeRepository authCodeRepository,
                        MemberRepository memberRepository,
-                       TicketRepository ticketRepository, Encryptor encryptor) {
+                       TicketRepository ticketRepository, Encryptor encryptor, Clock clock) {
         this.authCodeRepository = authCodeRepository;
         this.memberRepository = memberRepository;
         this.ticketRepository = ticketRepository;
         this.encryptor = encryptor;
+        this.clock = clock;
     }
 
     public AuthInfo login(LoginRequest loginRequest) {
@@ -54,6 +58,8 @@ public class AuthService {
         AuthCode authCode = authCodeRepository.findBySerialNumber(serialNumber)
                 .orElseThrow(SerialNumberNotFoundException::new);
         authCode.verify(verificationRequest.getCode());
+        LocalDateTime now = LocalDateTime.now(clock);
+        authCode.verifyTime(now);
     }
 
     public void validateSignUpMember(String serialNumber) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/util/TimeConfig.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/util/TimeConfig.java
@@ -1,0 +1,14 @@
+package com.wooteco.sokdak.member.util;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/acceptance/AuthAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/acceptance/AuthAcceptanceTest.java
@@ -1,20 +1,43 @@
 package com.wooteco.sokdak.auth.acceptance;
 
+import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.getToken;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPost;
+import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPostWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.MemberFixture.INVALID_LOGIN_REQUEST;
 import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_LOGIN_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.doReturn;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
+import com.wooteco.sokdak.auth.domain.AuthCode;
+import com.wooteco.sokdak.auth.service.Encryptor;
+import com.wooteco.sokdak.member.dto.VerificationRequest;
+import com.wooteco.sokdak.member.repository.AuthCodeRepository;
 import com.wooteco.sokdak.util.AcceptanceTest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpStatus;
 
+@DisplayName("인증 관련 인수테스트")
 class AuthAcceptanceTest extends AcceptanceTest {
+
+    private static final Clock FUTURE_CLOCK = Clock.fixed(Instant.parse("3333-08-22T10:00:00Z"), ZoneOffset.UTC);
+
+    @Autowired
+    private AuthCodeRepository authCodeRepository;
+    @Autowired
+    private Encryptor encryptor;
+
+    @SpyBean
+    private Clock clock;
 
     @DisplayName("존재하는 회원 정보로 로그인 할 수 있다.")
     @Test
@@ -31,6 +54,77 @@ class AuthAcceptanceTest extends AcceptanceTest {
     @Test
     void login_Exception_NotExistUser() {
         ExtractableResponse<Response> response = httpPost(INVALID_LOGIN_REQUEST, "/login");
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("올바른 인증번호로 인증할 수 있다.")
+    @Test
+    void verifyAuthCode() {
+        String email = "sokdak@gmail.com";
+        String code = "ABCDEF";
+        AuthCode authCode = AuthCode.builder()
+                .code(code)
+                .serialNumber(encryptor.encrypt(email))
+                .build();
+        authCodeRepository.save(authCode);
+
+        ExtractableResponse<Response> response = httpPostWithAuthorization(new VerificationRequest(email, code),
+                "members/signup/email/verification", getToken());
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    @DisplayName("잘못된 인증번호로 인증할 수 없다.")
+    @Test
+    void verifyAuthCode_Exception_WrongCode() {
+        String email = "sokdak@gmail.com";
+        String code = "ABCDEF";
+        AuthCode authCode = AuthCode.builder()
+                .code(code)
+                .serialNumber(encryptor.encrypt(email))
+                .build();
+        authCodeRepository.save(authCode);
+
+        ExtractableResponse<Response> response = httpPostWithAuthorization(new VerificationRequest(email, "NONONO"),
+                "members/signup/email/verification", getToken());
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("잘못된 이메일로로 인증할 수 없다.")
+    @Test
+    void verifyAuthCode_Exception_WrongEmail() {
+        String email = "sokdak@gmail.com";
+        String code = "ABCDEF";
+        AuthCode authCode = AuthCode.builder()
+                .code(code)
+                .serialNumber(encryptor.encrypt(email))
+                .build();
+        authCodeRepository.save(authCode);
+
+        ExtractableResponse<Response> response = httpPostWithAuthorization(new VerificationRequest("wrong@gmail.com", code),
+                "members/signup/email/verification", getToken());
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("만료된 인증번호로 인증할 수 없다.")
+    @Test
+    void verifyAuthCode_Exception_Expired() {
+        String email = "sokdak@gmail.com";
+        String code = "ABCDEF";
+        AuthCode authCode = AuthCode.builder()
+                .code(code)
+                .serialNumber(encryptor.encrypt(email))
+                .build();
+        authCodeRepository.save(authCode);
+
+        doReturn(Instant.now(FUTURE_CLOCK))
+                .when(clock)
+                .instant();
+        ExtractableResponse<Response> response = httpPostWithAuthorization(new VerificationRequest(email, code),
+                "members/signup/email/verification", getToken());
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/acceptance/AuthAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/acceptance/AuthAcceptanceTest.java
@@ -92,7 +92,7 @@ class AuthAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
-    @DisplayName("잘못된 이메일로로 인증할 수 없다.")
+    @DisplayName("잘못된 이메일로 인증할 수 없다.")
     @Test
     void verifyAuthCode_Exception_WrongEmail() {
         String email = "sokdak@gmail.com";

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/domain/AuthCodeTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/domain/AuthCodeTest.java
@@ -1,0 +1,37 @@
+package com.wooteco.sokdak.auth.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.wooteco.sokdak.member.exception.InvalidAuthCodeException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AuthCodeTest {
+
+    @DisplayName("인증코드 생성시간으로부터 5분 내에 인증이 가능하다")
+    @Test
+    void verifyTime() {
+        AuthCode authCode = AuthCode.builder()
+                .code("ABCDEF")
+                .serialNumber("21f46568bf6002c23843d198af30bb2bc8123695bd3d12ce86e0fc35bc5d3279")
+                .createdAt(LocalDateTime.parse("2007-12-03T10:15:30"))
+                .build();
+
+        assertDoesNotThrow(() -> authCode.verifyTime(LocalDateTime.parse("2007-12-03T10:19:30")));
+    }
+
+    @DisplayName("인증코드 생성시간으로부터 5분이 지나면 인증이 불가능하다")
+    @Test
+    void verifyTime_Exception_Time() {
+        AuthCode authCode = AuthCode.builder()
+                .code("ABCDEF")
+                .serialNumber("21f46568bf6002c23843d198af30bb2bc8123695bd3d12ce86e0fc35bc5d3279")
+                .createdAt(LocalDateTime.parse("2007-12-03T10:15:30"))
+                .build();
+
+        assertThatThrownBy(() -> authCode.verifyTime(LocalDateTime.parse("2007-12-03T10:50:30")))
+                .isInstanceOf(InvalidAuthCodeException.class);
+    }
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/domain/AuthCodeTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/domain/AuthCodeTest.java
@@ -1,14 +1,53 @@
 package com.wooteco.sokdak.auth.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.wooteco.sokdak.member.exception.InvalidAuthCodeException;
+import com.wooteco.sokdak.member.repository.AuthCodeRepository;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
+@SpringBootTest
 class AuthCodeTest {
+    @Autowired
+    private AuthCodeRepository authCodeRepository;
+
+    @DisplayName("학습테스트:빌더 null값이 자동 재매핑되는가")
+    @Test
+    void builderTest_createdAt(){
+        AuthCode authCode = AuthCode.builder()
+                .code("ABCDEF")
+                .serialNumber("21f46568bf6002c23843d198af30bb2bc8123695bd3d12ce86e0fc35bc5d3279")
+                .build();
+        System.err.println(authCode.getCreatedAt());
+        assertThat(authCode.getCreatedAt()).isNull();
+
+        AuthCode save = authCodeRepository.save(authCode);
+        System.err.println(save.getCreatedAt());
+        assertThat(save.getCreatedAt()).isNotNull();
+    }
+
+    @DisplayName("학습테스트:빌더 createdAt 값이 DB에 저장시 무시되는가")
+    @Test
+    void builderTest_createdAt_DB(){
+        LocalDateTime TimeSetting = LocalDateTime.parse("2007-12-03T10:15:30");
+        AuthCode authCode = AuthCode.builder()
+                .code("ABCDEF")
+                .serialNumber("21f46568bf6002c23843d198af30bb2bc8123695bd3d12ce86e0fc35bc5d3279")
+                .createdAt(TimeSetting)
+                .build();
+        System.err.println(authCode.getCreatedAt());
+        assertThat(authCode.getCreatedAt()).isEqualTo(TimeSetting);
+
+        AuthCode save = authCodeRepository.save(authCode);
+        System.err.println(save.getCreatedAt());
+        assertThat(save.getCreatedAt()).isNotEqualTo(TimeSetting);
+    }
 
     @DisplayName("인증코드 생성시간으로부터 5분 내에 인증이 가능하다")
     @Test

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/service/AuthServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/service/AuthServiceTest.java
@@ -4,21 +4,42 @@ import static com.wooteco.sokdak.util.fixture.MemberFixture.INVALID_LOGIN_REQUES
 import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_LOGIN_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doReturn;
 
+import com.wooteco.sokdak.auth.domain.AuthCode;
 import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.auth.exception.LoginFailedException;
+import com.wooteco.sokdak.member.dto.VerificationRequest;
+import com.wooteco.sokdak.member.exception.InvalidAuthCodeException;
+import com.wooteco.sokdak.member.exception.SerialNumberNotFoundException;
+import com.wooteco.sokdak.member.repository.AuthCodeRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
 class AuthServiceTest {
 
+    private static final String EMAIL = "test@gmail.com";
+    private static final String AUTH_CODE = "ABCDEF";
+    private static final Clock FUTURE_CLOCK = Clock.fixed(Instant.parse("3333-08-22T10:00:00Z"), ZoneOffset.UTC);
     @Autowired
     private AuthService authService;
+    @Autowired
+    private Encryptor encryptor;
+    @Autowired
+    private AuthCodeRepository authCodeRepository;
+
+    @SpyBean
+    private Clock clock;
 
     @DisplayName("로그인 기능")
     @Test
@@ -33,5 +54,64 @@ class AuthServiceTest {
     void login_Exception() {
         assertThatThrownBy(() -> authService.login(INVALID_LOGIN_REQUEST))
                 .isInstanceOf(LoginFailedException.class);
+    }
+
+    @DisplayName("인증번호 만료 여부 검증 기능")
+    @Test
+    void verifyAuthCode() {
+        AuthCode authCode = AuthCode.builder()
+                .code(AUTH_CODE)
+                .serialNumber(encryptor.encrypt(EMAIL))
+                .build();
+        authCodeRepository.save(authCode);
+
+        VerificationRequest verificationRequest = new VerificationRequest(EMAIL, AUTH_CODE);
+        assertDoesNotThrow(() -> authService.verifyAuthCode(verificationRequest));
+    }
+
+    @DisplayName("잘못된 인증번호일 시 예외 발생")
+    @Test
+    void verifyAuthCode_Exception_WrongAuthCode() {
+        AuthCode authCode = AuthCode.builder()
+                .code(AUTH_CODE)
+                .serialNumber(encryptor.encrypt(EMAIL))
+                .build();
+        authCodeRepository.save(authCode);
+
+        VerificationRequest verificationRequest = new VerificationRequest(EMAIL, "NONONO");
+        assertThatThrownBy(() -> authService.verifyAuthCode(verificationRequest))
+                .isInstanceOf(InvalidAuthCodeException.class);
+    }
+
+    @DisplayName("인증번호와 이메일이 매칭되지 않을 시 예외 발생")
+    @Test
+    void verifyAuthCode_Exception_WrongEmail() {
+        AuthCode authCode = AuthCode.builder()
+                .code(AUTH_CODE)
+                .serialNumber(encryptor.encrypt(EMAIL))
+                .build();
+        authCodeRepository.save(authCode);
+
+        VerificationRequest verificationRequest = new VerificationRequest("wrong@gmail.com", AUTH_CODE);
+        assertThatThrownBy(() -> authService.verifyAuthCode(verificationRequest))
+                .isInstanceOf(SerialNumberNotFoundException.class);
+    }
+
+    @DisplayName("인증번호 만료 시 예외 발생")
+    @Test
+    void verifyAuthCode_Exception_Expired() {
+        AuthCode authCode = AuthCode.builder()
+                .code(AUTH_CODE)
+                .serialNumber(encryptor.encrypt(EMAIL))
+                .build();
+        authCodeRepository.save(authCode);
+
+        doReturn(Instant.now(FUTURE_CLOCK))
+                .when(clock)
+                .instant();
+
+        VerificationRequest verificationRequest = new VerificationRequest(EMAIL, AUTH_CODE);
+        assertThatThrownBy(() -> authService.verifyAuthCode(verificationRequest))
+                .isInstanceOf(InvalidAuthCodeException.class);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/member/controller/MemberControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/member/controller/MemberControllerTest.java
@@ -87,7 +87,7 @@ class MemberControllerTest extends ControllerTest {
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
 
-    @DisplayName("인증코드가 일치하지 않으면 400 반환")
+    @DisplayName("인증코드가 일치하지 않거나 만료되었으면 400 반환")
     @Test
     void verifyAuthCode_Exception_different() {
         VerificationRequest verificationRequest = new VerificationRequest("test@gmail.com", "a1b2c3");
@@ -102,7 +102,7 @@ class MemberControllerTest extends ControllerTest {
                 .then().log().all()
                 .assertThat()
                 .body("message", equalTo("잘못된 인증번호입니다."))
-                .apply(document("member/email/success"))
+                .apply(document("member/email/fail"))
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 


### PR DESCRIPTION
### 구현기능
인증코드의 시간을 체크해, 만료된 인증코드를 사용할 수 없게 한다

### 세부 구현기능
- [x] 인증코드의 시간을 체크한다
- [x] 만료된 인증코드의 경우 사용할 수 없게 한다
- [x] 인증번호 관련 인수테스트, 서비스 테스트를 구현
resolved: #229 

### 관련 이슈
- 회원가입 관련 인수테스트, 서비스테스트 미흡
    - 관련 인수테스트 위치 고민
