### PR TITLE
fix: 테스트 격리를 위한 truncate.sql 수정

### DIFF
--- a/backend/sokdak/src/test/resources/truncate.sql
+++ b/backend/sokdak/src/test/resources/truncate.sql
@@ -10,6 +10,8 @@ TRUNCATE TABLE member;
 TRUNCATE TABLE board;
 TRUNCATE TABLE post_board;
 TRUNCATE TABLE post_report;
+TRUNCATE TABLE comment_report;
+TRUNCATE TABLE refresh_token;
 SET
 FOREIGN_KEY_CHECKS = 1;
 


### PR DESCRIPTION
### 구현기능
truncate.sql 을 수정하여 테스트 격리를 했습니다.