### PR TITLE
feat:MainPage 기능 변경

### DIFF
--- a/frontend/src/components/PostListItem/index.tsx
+++ b/frontend/src/components/PostListItem/index.tsx
@@ -5,7 +5,7 @@ import * as Styled from './index.styles';
 import countFormatter from '@/utils/countFormatter';
 import timeConverter from '@/utils/timeConverter';
 
-interface PostListItemProps extends Omit<Post, 'id' | 'like' | 'hashtags' | 'authorized'> {
+interface PostListItemProps extends Omit<Post, 'id' | 'like' | 'hashtags' | 'authorized' | 'boardId'> {
   handleClick: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   testid: number;
 }

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -5,6 +5,7 @@ const PATH = {
   SIGN_UP: '/sign-up',
   LOGIN: '/login',
   UPDATE_POST: '/post/update',
+  BOARD: '/board',
 };
 
 export default PATH;

--- a/frontend/src/constants/queries.ts
+++ b/frontend/src/constants/queries.ts
@@ -4,6 +4,7 @@ const QUERY_KEYS = {
   MEMBER_ID_CHECK: 'member-id-check',
   MEMBER_NICKNAME_CHECK: 'member-nickname-check',
   COMMENTS: 'comments',
+  POSTS_BY_BOARDS: 'posts-by-boards',
 };
 
 export default QUERY_KEYS;

--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -19,13 +19,14 @@ export const postList: Post[] = [
       },
     ],
     authorized: true,
+    boardId: 1,
   },
   {
     id: 2,
     title: '오늘 날씨 좋네요',
     createdAt: '2022-07-18T19:55:31.016376300',
     content: '어항에 있는 것 같아요.',
-    likeCount: 4,
+    likeCount: 1200,
     commentCount: 0,
     like: false,
     modified: true,
@@ -40,7 +41,9 @@ export const postList: Post[] = [
       },
     ],
     authorized: false,
+    boardId: 1,
   },
+
   {
     id: 3,
     title: '오늘 날씨 싫어요',
@@ -57,6 +60,7 @@ export const postList: Post[] = [
       },
     ],
     authorized: true,
+    boardId: 2,
   },
   {
     id: 4,
@@ -74,6 +78,7 @@ export const postList: Post[] = [
       },
     ],
     authorized: false,
+    boardId: 3,
   },
   {
     id: 5,
@@ -86,6 +91,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: true,
+    boardId: 4,
   },
   {
     id: 6,
@@ -98,6 +104,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 3,
   },
   {
     id: 7,
@@ -110,6 +117,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 3,
   },
   {
     id: 8,
@@ -122,6 +130,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 2,
   },
   {
     id: 9,
@@ -134,6 +143,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 1,
   },
   {
     id: 10,
@@ -146,6 +156,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 3,
   },
   {
     id: 11,
@@ -158,6 +169,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 4,
   },
   {
     id: 12,
@@ -170,6 +182,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 4,
   },
   {
     id: 13,
@@ -182,6 +195,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 3,
   },
   {
     id: 14,
@@ -194,6 +208,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 2,
   },
   {
     id: 15,
@@ -206,6 +221,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 3,
   },
   {
     id: 16,
@@ -218,6 +234,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 2,
   },
   {
     id: 17,
@@ -230,6 +247,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 3,
   },
   {
     id: 18,
@@ -242,6 +260,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 1,
   },
   {
     id: 19,
@@ -254,6 +273,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 2,
   },
   {
     id: 20,
@@ -266,6 +286,7 @@ export const postList: Post[] = [
     modified: false,
     hashtags: [],
     authorized: false,
+    boardId: 3,
   },
 ];
 
@@ -419,5 +440,24 @@ export const hashtagList: Hashtag[] = [
   {
     id: 4,
     name: '속닥속닥',
+  },
+];
+
+export const boardList = [
+  {
+    id: 1,
+    title: '🔥Hot 게시판🔥',
+  },
+  {
+    id: 2,
+    title: '📮포수타',
+  },
+  {
+    id: 3,
+    title: '️💌감동 크루',
+  },
+  {
+    id: 4,
+    title: '🗽자유게시판',
   },
 ];

--- a/frontend/src/hooks/queries/post/usePostsByBoard.ts
+++ b/frontend/src/hooks/queries/post/usePostsByBoard.ts
@@ -1,0 +1,28 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+
+import axios, { AxiosError, AxiosResponse } from 'axios';
+
+import QUERY_KEYS from '@/constants/queries';
+
+interface PostListByBoards {
+  boards: {
+    id: number;
+    title: string;
+    posts: Pick<Post, 'id' | 'likeCount' | 'commentCount' | 'title'>[];
+  }[];
+}
+
+const usePostByBoards = ({
+  options,
+}: {
+  options?: Omit<
+    UseQueryOptions<AxiosResponse<PostListByBoards>, AxiosError<{ message: string }>, PostListByBoards, string>,
+    'queryKey' | 'queryFn'
+  >;
+}) =>
+  useQuery(QUERY_KEYS.POSTS_BY_BOARDS, () => axios.get('/boards/contents'), {
+    select: data => data.data,
+    ...options,
+  });
+
+export default usePostByBoards;

--- a/frontend/src/mocks/handlers/posts/index.ts
+++ b/frontend/src/mocks/handlers/posts/index.ts
@@ -1,6 +1,6 @@
 import { rest } from 'msw';
 
-import { hashtagList, commentList, postList } from '@/dummy';
+import { hashtagList, commentList, postList, boardList } from '@/dummy';
 
 const postHandlers = [
   rest.post<Pick<Post, 'title' | 'content'> & { hashtags: string[] }>('/posts', (req, res, ctx) => {
@@ -31,6 +31,7 @@ const postHandlers = [
       like: false,
       hashtags: hashtags.map(hashtagName => hashtagList.find(hashtag => hashtag.name === hashtagName)!),
       authorized: true,
+      boardId: 1,
     };
 
     postList.unshift(newPost);
@@ -171,6 +172,19 @@ const postHandlers = [
     targetPost.commentCount += 1;
 
     return res(ctx.status(204));
+  }),
+
+  rest.get('/boards/contents', (req, res, ctx) => {
+    const boards = boardList.map(board => {
+      return {
+        ...board,
+        posts: postList
+          .filter(({ boardId }) => board.id === boardId)
+          .slice(0, 3)
+          .map(({ id, likeCount, commentCount, title }) => ({ id, likeCount, commentCount, title })),
+      };
+    });
+    return res(ctx.status(200), ctx.json({ boards: boards }));
   }),
 ];
 

--- a/frontend/src/pages/MainPage/components/BoardItem/index.stories.tsx
+++ b/frontend/src/pages/MainPage/components/BoardItem/index.stories.tsx
@@ -1,0 +1,27 @@
+import { withRouter } from 'storybook-addon-react-router-v6';
+
+import BoardItem from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Components/BoardItem',
+  component: BoardItem,
+  decorators: [withRouter],
+} as ComponentMeta<typeof BoardItem>;
+
+const Template: ComponentStory<typeof BoardItem> = args => (
+  <div style={{ maxWidth: '400px' }}>
+    <BoardItem {...args} />
+  </div>
+);
+
+export const BoardItemTemplate: ComponentStory<typeof BoardItem> = Template.bind({});
+BoardItemTemplate.args = {
+  id: 1,
+  posts: [
+    { commentCount: 3, id: 1, likeCount: 4, title: '나는야 조현근' },
+    { commentCount: 3, id: 2, likeCount: 4, title: '나는야 조현근' },
+    { commentCount: 3, id: 3, likeCount: 4, title: '나는야 조현근' },
+  ],
+  title: '🔥핫게시판🔥',
+};

--- a/frontend/src/pages/MainPage/components/BoardItem/index.styles.ts
+++ b/frontend/src/pages/MainPage/components/BoardItem/index.styles.ts
@@ -1,0 +1,72 @@
+import { Link } from 'react-router-dom';
+
+import Comment from '@/assets/images/comment.svg';
+import Heart from '@/assets/images/heart.svg';
+
+import styled from '@emotion/styled';
+
+export const Title = styled.p`
+  font-family: 'BMHANNAPro';
+  font-size: 1.5rem;
+  margin-bottom: 0.5em;
+`;
+
+export const Item = styled(Link)`
+  width: calc(100%-2em);
+  display: flex;
+  justify-content: space-between;
+  font-family: 'BMHANNAPro';
+  padding: 1em;
+`;
+
+export const ItemContainer = styled.section`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  ${Item} {
+    border-bottom: 1.5px solid ${props => props.theme.colors.gray_50};
+  }
+  ${Item}:last-child {
+    border: none;
+  }
+`;
+
+export const PostInfoContainer = styled.div`
+  align-self: flex-end;
+  display: flex;
+  justify-content: space-between;
+  gap: 1px;
+  font-family: 'NotoSansKR';
+  opacity: 0.7;
+`;
+
+export const LikeIcon = styled(Heart)`
+  fill: ${props => props.theme.colors.pink_300};
+  stroke: ${props => props.theme.colors.pink_300};
+  width: 16px;
+  height: 14px;
+  margin: 0 4px 0 10px;
+`;
+
+export const LikeCount = styled.span`
+  color: ${props => props.theme.colors.pink_300};
+`;
+
+export const CommentIcon = styled(Comment)`
+  width: 16px;
+  height: 15px;
+  margin: 0 4px 0 10px;
+`;
+
+export const CommentCount = styled.span`
+  color: ${props => props.theme.colors.gray_200};
+`;
+
+export const LoadMoreButton = styled(Link)`
+  display: block;
+  width: 100%;
+  padding: 1em 0em;
+  text-align: center;
+  color: ${props => props.theme.colors.gray_300};
+  border: 1px solid ${props => props.theme.colors.gray_50};
+`;

--- a/frontend/src/pages/MainPage/components/BoardItem/index.styles.ts
+++ b/frontend/src/pages/MainPage/components/BoardItem/index.styles.ts
@@ -11,6 +11,12 @@ export const Title = styled.p`
   margin-bottom: 0.5em;
 `;
 
+export const ItemTitle = styled.p`
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+`;
+
 export const Item = styled(Link)`
   width: calc(100%-2em);
   display: flex;
@@ -32,12 +38,14 @@ export const ItemContainer = styled.section`
 `;
 
 export const PostInfoContainer = styled.div`
-  align-self: flex-end;
   display: flex;
-  justify-content: space-between;
-  gap: 1px;
+  gap: 10px;
   font-family: 'NotoSansKR';
   opacity: 0.7;
+`;
+
+export const IconContainer = styled.div`
+  min-width: 2.5rem;
 `;
 
 export const LikeIcon = styled(Heart)`
@@ -45,7 +53,7 @@ export const LikeIcon = styled(Heart)`
   stroke: ${props => props.theme.colors.pink_300};
   width: 16px;
   height: 14px;
-  margin: 0 4px 0 10px;
+  margin: 0 4px 0 0;
 `;
 
 export const LikeCount = styled.span`
@@ -55,7 +63,7 @@ export const LikeCount = styled.span`
 export const CommentIcon = styled(Comment)`
   width: 16px;
   height: 15px;
-  margin: 0 4px 0 10px;
+  margin: 0 4px 0 0;
 `;
 
 export const CommentCount = styled.span`

--- a/frontend/src/pages/MainPage/components/BoardItem/index.styles.ts
+++ b/frontend/src/pages/MainPage/components/BoardItem/index.styles.ts
@@ -41,7 +41,6 @@ export const PostInfoContainer = styled.div`
   display: flex;
   gap: 10px;
   font-family: 'NotoSansKR';
-  opacity: 0.7;
 `;
 
 export const IconContainer = styled.div`

--- a/frontend/src/pages/MainPage/components/BoardItem/index.tsx
+++ b/frontend/src/pages/MainPage/components/BoardItem/index.tsx
@@ -1,5 +1,6 @@
 import * as Styled from './index.styles';
 
+import PATH from '@/constants/path';
 import countFormatter from '@/utils/countFormatter';
 
 interface BoardItemProps {
@@ -14,18 +15,22 @@ const BoardItem = ({ id, title, posts }: BoardItemProps) => {
       <Styled.Title>{title}</Styled.Title>
       <Styled.ItemContainer>
         {posts.map(post => (
-          <Styled.Item key={post.id} to={`/post/${post.id}`}>
-            {post.title}
+          <Styled.Item key={post.id} to={`${PATH.POST}/${post.id}`}>
+            <Styled.ItemTitle>{post.title}</Styled.ItemTitle>
             <Styled.PostInfoContainer>
-              <Styled.LikeIcon />
-              <Styled.LikeCount>{countFormatter(post.likeCount)}</Styled.LikeCount>
-              <Styled.CommentIcon />
-              <Styled.CommentCount>{countFormatter(post.commentCount)}</Styled.CommentCount>
+              <Styled.IconContainer>
+                <Styled.LikeIcon />
+                <Styled.LikeCount>{countFormatter(post.likeCount)}</Styled.LikeCount>
+              </Styled.IconContainer>
+              <Styled.IconContainer>
+                <Styled.CommentIcon />
+                <Styled.CommentCount>{countFormatter(post.commentCount)}</Styled.CommentCount>
+              </Styled.IconContainer>
             </Styled.PostInfoContainer>
           </Styled.Item>
         ))}
       </Styled.ItemContainer>
-      <Styled.LoadMoreButton to={`/board/${id}/posts`}>더보기</Styled.LoadMoreButton>
+      <Styled.LoadMoreButton to={`${PATH.BOARD}/${id}`}>더보기</Styled.LoadMoreButton>
     </div>
   );
 };

--- a/frontend/src/pages/MainPage/components/BoardItem/index.tsx
+++ b/frontend/src/pages/MainPage/components/BoardItem/index.tsx
@@ -1,0 +1,33 @@
+import * as Styled from './index.styles';
+
+import countFormatter from '@/utils/countFormatter';
+
+interface BoardItemProps {
+  id: number;
+  title: string;
+  posts: Pick<Post, 'likeCount' | 'commentCount' | 'title' | 'id'>[];
+}
+
+const BoardItem = ({ id, title, posts }: BoardItemProps) => {
+  return (
+    <div>
+      <Styled.Title>{title}</Styled.Title>
+      <Styled.ItemContainer>
+        {posts.map(post => (
+          <Styled.Item key={post.id} to={`/post/${post.id}`}>
+            {post.title}
+            <Styled.PostInfoContainer>
+              <Styled.LikeIcon />
+              <Styled.LikeCount>{countFormatter(post.likeCount)}</Styled.LikeCount>
+              <Styled.CommentIcon />
+              <Styled.CommentCount>{countFormatter(post.commentCount)}</Styled.CommentCount>
+            </Styled.PostInfoContainer>
+          </Styled.Item>
+        ))}
+      </Styled.ItemContainer>
+      <Styled.LoadMoreButton to={`/board/${id}/posts`}>더보기</Styled.LoadMoreButton>
+    </div>
+  );
+};
+
+export default BoardItem;

--- a/frontend/src/pages/MainPage/index.stories.tsx
+++ b/frontend/src/pages/MainPage/index.stories.tsx
@@ -9,7 +9,11 @@ export default {
   decorators: [withRouter],
 } as ComponentMeta<typeof MainPage>;
 
-const Template = () => <MainPage />;
+const Template = () => (
+  <div style={{ width: '400px' }}>
+    <MainPage />
+  </div>
+);
 
 export const MainPageTemplate: ComponentStory<typeof MainPage> = Template.bind({});
 MainPageTemplate.args = {};

--- a/frontend/src/pages/MainPage/index.styles.ts
+++ b/frontend/src/pages/MainPage/index.styles.ts
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
-export const PostListContainer = styled.div`
+export const MainPageContainer = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 2em;
+  gap: 3rem;
+  padding-bottom: 5em;
 `;

--- a/frontend/src/pages/MainPage/index.tsx
+++ b/frontend/src/pages/MainPage/index.tsx
@@ -1,74 +1,32 @@
-import { useRef, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-
+import BoardItem from './components/BoardItem';
 import Layout from '@/components/@styled/Layout';
-import FAB from '@/components/FAB';
-import PostListItem from '@/components/PostListItem';
 import Spinner from '@/components/Spinner';
 
-import usePosts from '@/hooks/queries/post/usePosts';
+import usePostByBoards from '@/hooks/queries/post/usePostsByBoard';
 
 import * as Styled from './index.styles';
 
-import PATH from '@/constants/path';
-
 const MainPage = () => {
-  const navigate = useNavigate();
-  const scrollRef = useRef(null);
-  const { isLoading, data, fetchNextPage } = usePosts({ storeCode: [3] });
+  const { isLoading, data } = usePostByBoards({});
 
-  const io = new IntersectionObserver(
-    (entries, io) => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          io.unobserve(entry.target);
-          fetchNextPage();
-        }
-      });
-    },
-    { threshold: 0.7 },
-  );
-
-  const handleClickFAB = () => {
-    navigate(PATH.CREATE_POST);
-  };
-
-  const handleClickPostItem = (id: number) => {
-    navigate(`${PATH.POST}/${id}`);
-  };
-
-  useEffect(() => {
-    if (!data) {
-      fetchNextPage();
-    }
-
-    if (scrollRef.current) {
-      io.observe(scrollRef.current);
-    }
-  }, [data]);
-
-  return (
-    <Layout>
-      <Styled.PostListContainer>
-        {data?.pages.map(({ id, title, content, createdAt, likeCount, commentCount, modified }, index) => (
-          <PostListItem
-            testid={id}
-            title={title}
-            content={content}
-            createdAt={createdAt}
-            likeCount={likeCount}
-            commentCount={commentCount}
-            modified={modified}
-            key={id}
-            handleClick={() => handleClickPostItem(id)}
-            ref={index === data.pages.length - 1 ? scrollRef : null}
-          />
-        ))}
-        {isLoading && <Spinner />}
-      </Styled.PostListContainer>
-      <FAB handleClick={handleClickFAB} />
-    </Layout>
-  );
+  if (isLoading) {
+    return (
+      <Layout>
+        <Spinner />
+      </Layout>
+    );
+  }
+  if (data)
+    return (
+      <Layout>
+        <Styled.MainPageContainer>
+          {data.boards.map(board => (
+            <BoardItem key={board.id} {...board} />
+          ))}
+        </Styled.MainPageContainer>
+      </Layout>
+    );
+  return <div />;
 };
 
 export default MainPage;

--- a/frontend/src/types/post.d.ts
+++ b/frontend/src/types/post.d.ts
@@ -14,4 +14,5 @@ interface Post {
   like: boolean;
   hashtags: Hashtag[];
   authorized: boolean;
+  boardId: number;
 }


### PR DESCRIPTION
### 구현기능

- 메인페이지 UI 변경에 따른 게시판 분리 기능 및 UI 구현
<img width="150" alt="image" src="https://user-images.githubusercontent.com/65863017/182272896-0830ef41-6bfb-4e07-a53e-8edbe3d3fc15.png">


### 세부 구현기능
- [x] 게시판에 따라 아이템들을 분류하여 렌더링한다.
- [x] 해당 게시글을 클릭하면 상세 페이지로 이동한다.
- [x] 더보기 클릭시 상세게시판 화면으로 이동한다.
  
### 관련 이슈
close #242 