### PR TITLE
feat: 게시물 작성시 익명/기명을 선택할 수 있는 기능 구현

### DIFF
--- a/frontend/src/components/CheckBox/index.stories.tsx
+++ b/frontend/src/components/CheckBox/index.stories.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+
+import CheckBox from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Components/CheckBox',
+  component: CheckBox,
+} as ComponentMeta<typeof CheckBox>;
+
+const Template: ComponentStory<typeof CheckBox> = args => {
+  const [isChecked, setIsChecked] = useState(true);
+
+  return <CheckBox {...args} isChecked={isChecked} setIsChecked={setIsChecked} />;
+};
+
+export const CheckBoxTemplate = Template.bind({});
+CheckBoxTemplate.args = {
+  labelText: '익명',
+};

--- a/frontend/src/components/CheckBox/index.styles.ts
+++ b/frontend/src/components/CheckBox/index.styles.ts
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.label`
+  display: flex;
+  align-items: center;
+  width: 50px;
+  height: 35px;
+  user-select: none;
+  gap: 7px;
+`;
+
+export const CheckBox = styled.div`
+  width: 13px;
+  height: 13px;
+  border: 2px solid ${props => props.theme.colors.gray_400};
+  position: relative;
+`;
+
+export const HiddenCheckBox = styled.input`
+  display: none;
+
+  :checked + ${CheckBox}::after {
+    content: '✔';
+    font-size: 11px;
+    color: ${props => props.theme.colors.sub};
+    position: absolute;
+    left: 2px;
+    top: 2px;
+  }
+`;
+
+export const Label = styled.span`
+  display: block;
+  font-size: 12px;
+  color: ${props => props.theme.colors.gray_200};
+`;

--- a/frontend/src/components/CheckBox/index.tsx
+++ b/frontend/src/components/CheckBox/index.tsx
@@ -1,0 +1,24 @@
+import * as Styled from './index.styles';
+
+interface CheckBoxProps {
+  className?: string;
+  isChecked: boolean;
+  setIsChecked: React.Dispatch<React.SetStateAction<boolean>>;
+  labelText: string;
+}
+
+const CheckBox = ({ className, isChecked, setIsChecked, labelText }: CheckBoxProps) => {
+  return (
+    <Styled.Container className={className}>
+      <Styled.HiddenCheckBox
+        type="checkbox"
+        checked={isChecked}
+        onChange={e => setIsChecked(e.currentTarget.checked)}
+      />
+      <Styled.CheckBox />
+      <Styled.Label>{labelText}</Styled.Label>
+    </Styled.Container>
+  );
+};
+
+export default CheckBox;

--- a/frontend/src/components/PostForm/index.styles.ts
+++ b/frontend/src/components/PostForm/index.styles.ts
@@ -1,3 +1,5 @@
+import CheckBoxComponent from '@/components/CheckBox';
+
 import { invalidInputAnimation } from '@/style/GlobalStyle';
 import styled from '@emotion/styled';
 
@@ -65,17 +67,6 @@ export const SubmitButton = styled.button`
   cursor: pointer;
 `;
 
-export const CheckBoxContainer = styled.div`
+export const CheckBox = styled(CheckBoxComponent)`
   width: 100%;
-  margin: 15px 0;
-`;
-
-export const CheckBox = styled.input``;
-
-export const Label = styled.label`
-  font-size: 12px;
-  color: ${props => props.theme.colors.gray_200};
-  display: flex;
-  align-items: center;
-  user-select: none;
 `;

--- a/frontend/src/components/PostForm/index.styles.ts
+++ b/frontend/src/components/PostForm/index.styles.ts
@@ -64,3 +64,18 @@ export const SubmitButton = styled.button`
   height: 55px;
   cursor: pointer;
 `;
+
+export const CheckBoxContainer = styled.div`
+  width: 100%;
+  margin: 15px 0;
+`;
+
+export const CheckBox = styled.input``;
+
+export const Label = styled.label`
+  font-size: 12px;
+  color: ${props => props.theme.colors.gray_200};
+  display: flex;
+  align-items: center;
+  user-select: none;
+`;

--- a/frontend/src/components/PostForm/index.tsx
+++ b/frontend/src/components/PostForm/index.tsx
@@ -88,16 +88,7 @@ const PostForm = ({
       <HashTagInput hashtags={hashtags} setHashtags={setHashtags} />
       <Styled.SubmitButton>{submitType}</Styled.SubmitButton>
       {submitType === SubmitType.POST && (
-        <Styled.CheckBoxContainer>
-          <Styled.Label>
-            <Styled.CheckBox
-              type="checkbox"
-              checked={anonymous}
-              onChange={e => setAnonymous(e.currentTarget.checked)}
-            />
-            익명
-          </Styled.Label>
-        </Styled.CheckBoxContainer>
+        <Styled.CheckBox isChecked={anonymous} setIsChecked={setAnonymous} labelText="익명" />
       )}
     </Styled.Container>
   );

--- a/frontend/src/components/PostForm/index.tsx
+++ b/frontend/src/components/PostForm/index.tsx
@@ -6,13 +6,18 @@ import useSnackbar from '@/hooks/useSnackbar';
 
 import * as Styled from './index.styles';
 
+const SubmitType = {
+  POST: '글 작성하기',
+  PUT: '글 수정하기',
+} as const;
+
 interface PostFormProps {
   heading: string;
-  submitType: string;
+  submitType: typeof SubmitType[keyof typeof SubmitType];
   prevTitle?: string;
   prevContent?: string;
   prevHashTags?: Omit<Hashtag, 'count'>[];
-  handlePost: (post: Pick<Post, 'title' | 'content'> & { hashtags: string[] }) => void;
+  handlePost: (post: Pick<Post, 'title' | 'content'> & { hashtags: string[]; anonymous?: boolean }) => void;
 }
 
 const PostForm = ({
@@ -28,6 +33,7 @@ const PostForm = ({
   const [title, setTitle] = useState(prevTitle);
   const [content, setContent] = useState(prevContent);
   const [hashtags, setHashtags] = useState(prevHashTags.map(hashtag => hashtag.name));
+  const [anonymous, setAnonymous] = useState(true);
 
   const [isValidTitle, setIsValidTitle] = useState(true);
   const [isValidContent, setIsValidContent] = useState(true);
@@ -36,7 +42,8 @@ const PostForm = ({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    handlePost({ title, content, hashtags });
+
+    handlePost({ title, content, hashtags, anonymous });
   };
 
   return (
@@ -80,6 +87,18 @@ const PostForm = ({
       />
       <HashTagInput hashtags={hashtags} setHashtags={setHashtags} />
       <Styled.SubmitButton>{submitType}</Styled.SubmitButton>
+      {submitType === SubmitType.POST && (
+        <Styled.CheckBoxContainer>
+          <Styled.Label>
+            <Styled.CheckBox
+              type="checkbox"
+              checked={anonymous}
+              onChange={e => setAnonymous(e.currentTarget.checked)}
+            />
+            익명
+          </Styled.Label>
+        </Styled.CheckBoxContainer>
+      )}
     </Styled.Container>
   );
 };

--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -28,6 +28,7 @@ export const postList: Post[] = [
     ],
     authorized: true,
     boardId: 1,
+    nickname: '테스트 계정',
   },
   {
     id: 2,
@@ -50,6 +51,7 @@ export const postList: Post[] = [
     ],
     authorized: false,
     boardId: 1,
+    nickname: '짜증난 파이썬',
   },
 
   {
@@ -69,6 +71,7 @@ export const postList: Post[] = [
     ],
     authorized: true,
     boardId: 2,
+    nickname: '테스트 계정',
   },
   {
     id: 4,
@@ -87,6 +90,7 @@ export const postList: Post[] = [
     ],
     authorized: false,
     boardId: 3,
+    nickname: '짜증난 파이썬',
   },
   {
     id: 5,
@@ -105,6 +109,7 @@ export const postList: Post[] = [
     ],
     authorized: true,
     boardId: 4,
+    nickname: '테스트 계정',
   },
   {
     id: 6,
@@ -118,6 +123,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 3,
+    nickname: '못된 젠킨스',
   },
   {
     id: 7,
@@ -131,6 +137,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 3,
+    nickname: '행복한 리액트',
   },
   {
     id: 8,
@@ -144,6 +151,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 2,
+    nickname: '슬픈 자바',
   },
   {
     id: 9,
@@ -157,6 +165,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 1,
+    nickname: '짜증난 파이썬',
   },
   {
     id: 10,
@@ -170,6 +179,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 3,
+    nickname: '짜증난 파이썬',
   },
   {
     id: 11,
@@ -183,6 +193,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 4,
+    nickname: '짜증난 파이썬',
   },
   {
     id: 12,
@@ -196,6 +207,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 4,
+    nickname: '짜증난 파이썬',
   },
   {
     id: 13,
@@ -209,6 +221,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 3,
+    nickname: '짜증난 파이썬',
   },
   {
     id: 14,
@@ -222,6 +235,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 2,
+    nickname: '짜증난 파이썬',
   },
   {
     id: 15,
@@ -235,6 +249,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 3,
+    nickname: '짜증난 파이썬',
   },
   {
     id: 16,
@@ -248,6 +263,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 2,
+    nickname: '짜증난 파이썬',
   },
   {
     id: 17,
@@ -261,6 +277,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 3,
+    nickname: '짜증난 파이썬',
   },
   {
     id: 18,
@@ -274,6 +291,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 1,
+    nickname: '짜증난 파이썬',
   },
   {
     id: 19,
@@ -287,6 +305,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 2,
+    nickname: '짜증난 파이썬',
   },
   {
     id: 20,
@@ -300,6 +319,7 @@ export const postList: Post[] = [
     hashtags: [],
     authorized: false,
     boardId: 3,
+    nickname: '못된 젠킨스',
   },
 ];
 

--- a/frontend/src/hooks/queries/post/useCreatePost.ts
+++ b/frontend/src/hooks/queries/post/useCreatePost.ts
@@ -11,7 +11,7 @@ const useCreatePost = (
   options?: UseMutationOptions<
     AxiosResponse<string, string>,
     AxiosError,
-    Pick<Post, 'title' | 'content'> & { hashtags: string[] }
+    Pick<Post, 'title' | 'content'> & { hashtags: string[]; anonymous?: boolean }
   >,
 ) => {
   const queryClient = useQueryClient();
@@ -22,11 +22,15 @@ const useCreatePost = (
       title,
       content,
       hashtags,
-    }: Pick<Post, 'title' | 'content'> & { hashtags: string[] }): Promise<AxiosResponse<string, string>> =>
+      anonymous,
+    }: Pick<Post, 'title' | 'content'> & { hashtags: string[]; anonymous?: boolean }): Promise<
+      AxiosResponse<string, string>
+    > =>
       axios.post('/posts', {
         title,
         content,
         hashtags,
+        anonymous,
       }),
     {
       ...options,

--- a/frontend/src/mocks/handlers/posts/index.ts
+++ b/frontend/src/mocks/handlers/posts/index.ts
@@ -3,8 +3,8 @@ import { rest } from 'msw';
 import { hashtagList, commentList, postList, boardList } from '@/dummy';
 
 const postHandlers = [
-  rest.post<Pick<Post, 'title' | 'content'> & { hashtags: string[] }>('/posts', (req, res, ctx) => {
-    const { title, content, hashtags } = req.body;
+  rest.post<Pick<Post, 'title' | 'content'> & { hashtags: string[]; anonymous: boolean }>('/posts', (req, res, ctx) => {
+    const { title, content, hashtags, anonymous } = req.body;
     const id = postList.length + 1;
 
     if (!title || !content) {
@@ -38,6 +38,7 @@ const postHandlers = [
       hashtags: hashtags.map(hashtagName => hashtagList.find(hashtag => hashtag.name === hashtagName)!),
       authorized: true,
       boardId: 1,
+      nickname: anonymous ? '짜증난 파이썬' : '테스트 계정',
     };
 
     postList.unshift(newPost);

--- a/frontend/src/pages/PostPage/components/PostHeader/index.tsx
+++ b/frontend/src/pages/PostPage/components/PostHeader/index.tsx
@@ -8,7 +8,14 @@ import PATH from '@/constants/path';
 import timeConverter from '@/utils/timeConverter';
 
 interface PostHeaderProps {
-  post: { content: string; title: string; createdAt: string; hashtags: Omit<Hashtag, 'count'>[]; authorized: boolean };
+  post: {
+    content: string;
+    title: string;
+    createdAt: string;
+    hashtags: Omit<Hashtag, 'count'>[];
+    authorized: boolean;
+    nickname: string;
+  };
   like: { isLiked: boolean; likeCount: number };
   onClickDeleteButton: () => void;
   onClickLikeButton: () => void;
@@ -31,7 +38,7 @@ const PostHeader = ({ post, like, onClickDeleteButton, onClickLikeButton }: Post
         </Styled.PostController>
       )}
       <Styled.PostInfo>
-        <Styled.Author>익명</Styled.Author>
+        <Styled.Author>{post.nickname}</Styled.Author>
         <Styled.Date>{timeConverter(post.createdAt)}</Styled.Date>
       </Styled.PostInfo>
       <Styled.LikeButtonContainer>

--- a/frontend/src/types/post.d.ts
+++ b/frontend/src/types/post.d.ts
@@ -16,4 +16,5 @@ interface Post {
   hashtags: Omit<Hashtag, 'count'>[];
   authorized: boolean;
   boardId: number;
+  nickname: string;
 }


### PR DESCRIPTION
### 구현기능

게시물 작성시 익명 혹은 기명을 선택할 수 있는 기능을 구현한다.

### 세부 구현기능

- [x] 게시물을 등록하는 msw mocking에서 `nickname` 필드를 추가해야 한다. 
- [x] 게시물을 가져오는 msw mocking에서 `nickname` 데이터를 가져와 컴포넌트에 render 해주어야한다. 
- [x] dummy 데이터에서 `nickname` 필드를 추가해야 한다. 
- [x] `CheckBox` 컴포넌트를 구현한다.
- [x] 사용자는 게시물을 등록할 때 익명/기명을 선택할 수 있다.

### 주의사항

- 게시물을 수정할 경우에는 익명 / 기명을 변경할 수 없다. 

### 관련 이슈

close #272 
