### PR TITLE
feat: 게시글 작성시 익명/기명 선택 기능 구현

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -6,6 +6,7 @@ import com.wooteco.sokdak.comment.domain.Comment;
 import com.wooteco.sokdak.hashtag.domain.PostHashtag;
 import com.wooteco.sokdak.like.domain.Like;
 import com.wooteco.sokdak.member.domain.Member;
+import com.wooteco.sokdak.member.domain.Nickname;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -46,6 +47,9 @@ public class Post {
     @Embedded
     private Content content;
 
+    @Embedded
+    private Nickname writerNickname;
+
     @OneToMany(mappedBy = "post")
     private List<Like> likes = new ArrayList<>();
 
@@ -68,12 +72,13 @@ public class Post {
     }
 
     @Builder
-    private Post(String title, String content, Member member, List<Like> likes, List<Comment> comments,
-                 List<PostHashtag> postHashtags) {
+    private Post(String title, String content, Member member, Nickname writerNickname, List<Like> likes,
+                 List<Comment> comments, List<PostHashtag> postHashtags) {
         this.title = new Title(title);
         this.content = new Content(content);
         this.member = member;
         this.likes = likes;
+        this.writerNickname = writerNickname;
         this.comments = comments;
         this.postHashtags = postHashtags;
     }
@@ -149,5 +154,9 @@ public class Post {
 
     public List<PostBoard> getPostBoards() {
         return postBoards;
+    }
+
+    public String getNickname() {
+        return writerNickname.getValue();
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -148,10 +148,6 @@ public class Post {
         return likes;
     }
 
-    public List<PostHashtag> getPostHashtags() {
-        return postHashtags;
-    }
-
     public List<PostBoard> getPostBoards() {
         return postBoards;
     }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/NewPostRequest.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/NewPostRequest.java
@@ -1,6 +1,5 @@
 package com.wooteco.sokdak.post.dto;
 
-import com.wooteco.sokdak.post.domain.Post;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -12,21 +11,16 @@ public class NewPostRequest {
     private String title;
     @NotBlank(message = "본문은 1자 이상 5000자 이하여야 합니다.")
     private String content;
+    private boolean anonymous;
     private List<String> hashtags;
 
     public NewPostRequest() {
     }
 
-    public NewPostRequest(String title, String content, List<String> hashtags) {
+    public NewPostRequest(String title, String content, boolean anonymous, List<String> hashtags) {
         this.title = title;
         this.content = content;
+        this.anonymous = anonymous;
         this.hashtags = hashtags;
-    }
-
-    public Post toEntity() {
-        return Post.builder()
-                .title(title)
-                .content(content)
-                .build();
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostDetailResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostDetailResponse.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 public class PostDetailResponse {
 
     private Long id;
+    private String nickname;
     private String title;
     private String content;
     private List<HashtagResponse> hashtags;
@@ -26,10 +27,11 @@ public class PostDetailResponse {
     }
 
     @Builder
-    private PostDetailResponse(Long id, String title, String content, List<HashtagResponse> hashtagResponses,
-                               LocalDateTime createdAt, int likeCount,
+    private PostDetailResponse(Long id, String nickname, String title, String content,
+                               List<HashtagResponse> hashtagResponses, LocalDateTime createdAt, int likeCount,
                                boolean like, boolean authorized, boolean modified) {
         this.id = id;
+        this.nickname = nickname;
         this.title = title;
         this.content = content;
         this.hashtags = hashtagResponses;
@@ -44,6 +46,7 @@ public class PostDetailResponse {
     public static PostDetailResponse of(Post post, boolean liked, boolean authorized, Hashtags hashtags) {
         return PostDetailResponse.builder()
                 .id(post.getId())
+                .nickname(post.getNickname())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .createdAt(post.getCreatedAt())

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -2,7 +2,6 @@ package com.wooteco.sokdak.post.service;
 
 import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.board.domain.PostBoard;
-import com.wooteco.sokdak.board.repository.BoardRepository;
 import com.wooteco.sokdak.board.repository.PostBoardRepository;
 import com.wooteco.sokdak.board.service.BoardService;
 import com.wooteco.sokdak.comment.repository.CommentRepository;
@@ -10,8 +9,10 @@ import com.wooteco.sokdak.hashtag.domain.Hashtags;
 import com.wooteco.sokdak.hashtag.service.HashtagService;
 import com.wooteco.sokdak.like.repository.LikeRepository;
 import com.wooteco.sokdak.member.domain.Member;
+import com.wooteco.sokdak.member.domain.Nickname;
 import com.wooteco.sokdak.member.exception.MemberNotFoundException;
 import com.wooteco.sokdak.member.repository.MemberRepository;
+import com.wooteco.sokdak.member.util.RandomNicknameGenerator;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
 import com.wooteco.sokdak.post.dto.PostDetailResponse;
@@ -19,6 +20,7 @@ import com.wooteco.sokdak.post.dto.PostUpdateRequest;
 import com.wooteco.sokdak.post.dto.PostsResponse;
 import com.wooteco.sokdak.post.exception.PostNotFoundException;
 import com.wooteco.sokdak.post.repository.PostRepository;
+import java.util.Collections;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -30,23 +32,20 @@ public class PostService {
 
     private final HashtagService hashtagService;
     private final BoardService boardService;
-
     private final PostRepository postRepository;
     private final PostBoardRepository postBoardRepository;
-    private final BoardRepository boardRepository;
     private final MemberRepository memberRepository;
     private final CommentRepository commentRepository;
     private final LikeRepository likeRepository;
 
     public PostService(HashtagService hashtagService, BoardService boardService,
                        PostRepository postRepository, PostBoardRepository postBoardRepository,
-                       BoardRepository boardRepository, MemberRepository memberRepository,
-                       CommentRepository commentRepository, LikeRepository likeRepository) {
+                       MemberRepository memberRepository, CommentRepository commentRepository,
+                       LikeRepository likeRepository) {
         this.hashtagService = hashtagService;
         this.boardService = boardService;
         this.postRepository = postRepository;
         this.postBoardRepository = postBoardRepository;
-        this.boardRepository = boardRepository;
         this.memberRepository = memberRepository;
         this.commentRepository = commentRepository;
         this.likeRepository = likeRepository;
@@ -56,10 +55,11 @@ public class PostService {
     public Long addPost(Long boardId, NewPostRequest newPostRequest, AuthInfo authInfo) {
         Member member = memberRepository.findById(authInfo.getId())
                 .orElseThrow(MemberNotFoundException::new);
-
+        String randomNickname = createPostWriterNickname(newPostRequest.isAnonymous(), member);
         Post post = Post.builder()
                 .title(newPostRequest.getTitle())
                 .content(newPostRequest.getContent())
+                .writerNickname(new Nickname(randomNickname))
                 .member(member)
                 .build();
         Post savedPost = postRepository.save(post);
@@ -67,6 +67,13 @@ public class PostService {
         hashtagService.saveHashtag(newPostRequest.getHashtags(), savedPost);
         boardService.savePostBoard(savedPost, boardId, authInfo.getRole());
         return savedPost.getId();
+    }
+
+    private String createPostWriterNickname(boolean anonymous, Member member) {
+        if (anonymous) {
+            return RandomNicknameGenerator.generate(Collections.emptySet());
+        }
+        return member.getNickname();
     }
 
     public PostDetailResponse findPost(Long postId, AuthInfo authInfo) {

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/board/acceptance/BoardAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/board/acceptance/BoardAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.wooteco.sokdak.board.acceptance;
 
+import static com.wooteco.sokdak.post.util.PostFixture.NEW_POST_REQUEST;
 import static com.wooteco.sokdak.util.fixture.BoardFixture.FREE_BOARD_ID;
 import static com.wooteco.sokdak.util.fixture.BoardFixture.HOT_BOARD_ID;
 import static com.wooteco.sokdak.util.fixture.BoardFixture.POSUTA_BOARD_ID;
@@ -21,7 +22,6 @@ import com.wooteco.sokdak.board.dto.BoardContentPostElement;
 import com.wooteco.sokdak.board.dto.BoardResponse;
 import com.wooteco.sokdak.board.dto.NewBoardRequest;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
-import com.wooteco.sokdak.post.dto.PostDetailResponse;
 import com.wooteco.sokdak.post.dto.PostsElementResponse;
 import com.wooteco.sokdak.post.dto.PostsResponse;
 import com.wooteco.sokdak.util.AcceptanceTest;
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 @DisplayName("게시글 관련 인수테스트")
-public class BoardAcceptanceTest extends AcceptanceTest {
+class BoardAcceptanceTest extends AcceptanceTest {
 
     @DisplayName("게시판을 생성할 수 있다.")
     @Test
@@ -66,10 +66,10 @@ public class BoardAcceptanceTest extends AcceptanceTest {
     void findBoardsContent() {
         // given
         String token = getToken();
-        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", Collections.emptyList());
-        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", Collections.emptyList());
-        NewPostRequest postRequest3 = new NewPostRequest("제목3", "본문3", Collections.emptyList());
-        NewPostRequest postRequest4 = new NewPostRequest("제목4", "본문4", Collections.emptyList());
+        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", false, Collections.emptyList());
+        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", false, Collections.emptyList());
+        NewPostRequest postRequest3 = new NewPostRequest("제목3", "본문3", false, Collections.emptyList());
+        NewPostRequest postRequest4 = new NewPostRequest("제목4", "본문4", false, Collections.emptyList());
 
         httpPostWithAuthorization(postRequest1, "/boards/" + FREE_BOARD_ID + "/posts", token);
         httpPostWithAuthorization(postRequest2, "/boards/" + FREE_BOARD_ID + "/posts", token);
@@ -123,8 +123,7 @@ public class BoardAcceptanceTest extends AcceptanceTest {
         String token5 = httpPost(new LoginRequest("east", "Abcd123!@"), "/login").header(AUTHORIZATION);
         List<String> tokens = List.of(token1, token2, token3, token4, token5);
 
-        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", Collections.emptyList());
-        httpPostWithAuthorization(postRequest1, CREATE_POST_URI, token1);
+        httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, token1);
 
         // when
         for (String token : tokens) {
@@ -138,9 +137,9 @@ public class BoardAcceptanceTest extends AcceptanceTest {
         // then
         assertAll(
                 () -> assertThat(hotBoardResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(hotBoardPostNames).isEqualTo(List.of("제목1")),
+                () -> assertThat(hotBoardPostNames).isEqualTo(List.of("제목")),
                 () -> assertThat(boardResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(boardPostNames).isEqualTo(List.of("제목1"))
+                () -> assertThat(boardPostNames).isEqualTo(List.of("제목"))
         );
     }
 
@@ -155,8 +154,7 @@ public class BoardAcceptanceTest extends AcceptanceTest {
         String token5 = httpPost(new LoginRequest("east", "Abcd123!@"), "/login").header(AUTHORIZATION);
         List<String> tokens = List.of(token1, token2, token3, token4, token5);
 
-        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", Collections.emptyList());
-        httpPostWithAuthorization(postRequest1, CREATE_POST_URI, token1);
+        httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, token1);
 
         for (String token : tokens) {
             httpPutWithAuthorization("/posts/1/like", token);
@@ -174,9 +172,9 @@ public class BoardAcceptanceTest extends AcceptanceTest {
         // then
         assertAll(
                 () -> assertThat(hotBoardResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(hotBoardPostNames).isEqualTo(List.of("제목1")),
+                () -> assertThat(hotBoardPostNames).isEqualTo(List.of("제목")),
                 () -> assertThat(boardResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(boardPostNames).isEqualTo(List.of("제목1"))
+                () -> assertThat(boardPostNames).isEqualTo(List.of("제목"))
         );
     }
 
@@ -191,8 +189,7 @@ public class BoardAcceptanceTest extends AcceptanceTest {
         String token5 = httpPost(new LoginRequest("east", "Abcd123!@"), "/login").header(AUTHORIZATION);
         List<String> tokens = List.of(token1, token2, token3, token4, token5);
 
-        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", Collections.emptyList());
-        httpPostWithAuthorization(postRequest1, CREATE_POST_URI, token1);
+        httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, token1);
 
         for (String token : tokens) {
             httpPutWithAuthorization("/posts/1/like", token);

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/acceptance/CommentAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/acceptance/CommentAcceptanceTest.java
@@ -1,8 +1,7 @@
 package com.wooteco.sokdak.comment.acceptance;
 
 import static com.wooteco.sokdak.post.util.CommentFixture.VALID_COMMENT_MESSAGE;
-import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_CONTENT;
-import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_TITLE;
+import static com.wooteco.sokdak.post.util.PostFixture.NEW_POST_REQUEST;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpDeleteWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpGet;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPost;
@@ -16,13 +15,10 @@ import com.wooteco.sokdak.auth.dto.LoginRequest;
 import com.wooteco.sokdak.comment.dto.CommentResponse;
 import com.wooteco.sokdak.comment.dto.CommentsResponse;
 import com.wooteco.sokdak.comment.dto.NewCommentRequest;
-import com.wooteco.sokdak.post.dto.NewPostRequest;
-import com.wooteco.sokdak.post.util.CommentFixture;
 import com.wooteco.sokdak.report.dto.ReportRequest;
 import com.wooteco.sokdak.util.AcceptanceTest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -143,9 +139,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
     }
 
     private Long addPostAndGetPostId() {
-        NewPostRequest newPostRequest = new NewPostRequest(VALID_POST_TITLE, VALID_POST_CONTENT,
-                Collections.emptyList());
-        return Long.parseLong(httpPostWithAuthorization(newPostRequest, CREATE_POST_URI, getToken())
+        return Long.parseLong(httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, getToken())
                 .header("Location").split("/posts/")[1]);
     }
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/acceptance/HashtagAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/acceptance/HashtagAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.wooteco.sokdak.hashtag.acceptance;
 
+import static com.wooteco.sokdak.post.util.PostFixture.NEW_POST_REQUEST;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.getExceptionMessage;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpDeleteWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpGet;
@@ -31,8 +32,6 @@ import org.springframework.http.HttpStatus;
 
 @DisplayName("해시태그 관련 인수테스트")
 public class HashtagAcceptanceTest extends AcceptanceTest {
-
-    private static final NewPostRequest NEW_POST_REQUEST = new NewPostRequest("제목", "본문", List.of("태그1", "태그2"));
 
     @DisplayName("게시글을 작성하면서 해시태그를 추가하면, 게시글이 조회될 때 해시태그도 조회된다.")
     @Test
@@ -89,9 +88,9 @@ public class HashtagAcceptanceTest extends AcceptanceTest {
     @DisplayName("해시태그로 검색하면 해당 해시태그가 포함된 게시물들을 조회한다.")
     @Test
     void searchWithHashtag() {
-        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", List.of("태그1"));
-        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", List.of("태그2"));
-        NewPostRequest postRequest3 = new NewPostRequest("제목3", "본문3", List.of("태그1", "태그2"));
+        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", false, List.of("태그1"));
+        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", false, List.of("태그2"));
+        NewPostRequest postRequest3 = new NewPostRequest("제목3", "본문3", false, List.of("태그1", "태그2"));
         httpPostWithAuthorization(postRequest1, CREATE_POST_URI, getToken());
         httpPostWithAuthorization(postRequest2, CREATE_POST_URI, getToken());
         httpPostWithAuthorization(postRequest3, CREATE_POST_URI, getToken());
@@ -109,7 +108,7 @@ public class HashtagAcceptanceTest extends AcceptanceTest {
     @DisplayName("없는 해시태그로 조회할 수 없다.")
     @Test
     void searchWithHashtag_Exception_NoHashtag() {
-        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", List.of("태그1"));
+        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", false, List.of("태그1"));
         httpPostWithAuthorization(postRequest1, "/posts", getToken());
 
         ExtractableResponse<Response> response = httpGet("/posts?hashtag=없는태그&size=3&page=0");
@@ -123,8 +122,8 @@ public class HashtagAcceptanceTest extends AcceptanceTest {
     @DisplayName("특정 키워드로 검색하면 이름에 해당 키워드가 포함된 해시태그들을 조회한다.")
     @Test
     void searchHashtagsWithName() {
-        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", List.of("태그1", "태그2"));
-        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", List.of("태그2"));
+        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", false, List.of("태그1", "태그2"));
+        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", false, List.of("태그2"));
         httpPostWithAuthorization(postRequest1, CREATE_POST_URI, getToken());
         httpPostWithAuthorization(postRequest2, CREATE_POST_URI, getToken());
 
@@ -148,8 +147,8 @@ public class HashtagAcceptanceTest extends AcceptanceTest {
     @DisplayName("빈 키워드로 검색하면 모든 해시태그들을 조회한다.")
     @Test
     void searchHashtagsWithName_NoKeyword() {
-        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", List.of("태그1", "태그2"));
-        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", List.of("태그2"));
+        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", false, List.of("태그1", "태그2"));
+        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", false, List.of("태그2"));
         httpPostWithAuthorization(postRequest1, CREATE_POST_URI, getToken());
         httpPostWithAuthorization(postRequest2, CREATE_POST_URI, getToken());
 
@@ -173,8 +172,8 @@ public class HashtagAcceptanceTest extends AcceptanceTest {
     @DisplayName("없는 해시태그 키워드로 검색하면 빈 검색결과를 조회한다.")
     @Test
     void searchHashtagsWithName_NoResult() {
-        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", List.of("태그1", "태그2"));
-        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", List.of("태그2"));
+        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", false, List.of("태그1", "태그2"));
+        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", false, List.of("태그2"));
         httpPostWithAuthorization(postRequest1, "/posts", getToken());
         httpPostWithAuthorization(postRequest2, "/posts", getToken());
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/service/HashtagServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/hashtag/service/HashtagServiceTest.java
@@ -92,7 +92,7 @@ class HashtagServiceTest extends IntegrationTest {
     @DisplayName("해시태그가 포함된 게시글 작성 기능")
     @Test
     void addPostWithHashtag() {
-        NewPostRequest newPostRequest = new NewPostRequest("제목", "본문", List.of("태그1", "태그2"));
+        NewPostRequest newPostRequest = new NewPostRequest("제목", "본문", false, List.of("태그1", "태그2"));
 
         Long postId = postService.addPost(WRITABLE_BOARD_ID, newPostRequest, AUTH_INFO);
 
@@ -238,7 +238,7 @@ class HashtagServiceTest extends IntegrationTest {
 
     private Long savePostWithHashtags(Post post, List<Hashtag> tags) {
         NewPostRequest newPostRequest = new NewPostRequest(
-                post.getTitle(), post.getContent(), new Hashtags(tags).getNames());
+                post.getTitle(), post.getContent(), false, new Hashtags(tags).getNames());
         return postService.addPost(WRITABLE_BOARD_ID, newPostRequest, AUTH_INFO);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/like/acceptance/LikeAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/like/acceptance/LikeAcceptanceTest.java
@@ -1,7 +1,6 @@
 package com.wooteco.sokdak.like.acceptance;
 
-import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_CONTENT;
-import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_TITLE;
+import static com.wooteco.sokdak.post.util.PostFixture.NEW_POST_REQUEST;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPost;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPostWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPutWithAuthorization;
@@ -12,11 +11,9 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.wooteco.sokdak.auth.dto.LoginRequest;
 import com.wooteco.sokdak.like.dto.LikeFlipResponse;
-import com.wooteco.sokdak.post.dto.NewPostRequest;
 import com.wooteco.sokdak.util.AcceptanceTest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.Collections;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -26,9 +23,7 @@ class LikeAcceptanceTest extends AcceptanceTest {
     @DisplayName("로그인한 회원은 좋아요 하지 않은 게시물에 좋아요를 할 수 있다.")
     @Test
     void flipLike_Create() {
-        NewPostRequest newPostRequest = new NewPostRequest(VALID_POST_TITLE, VALID_POST_CONTENT,
-                Collections.emptyList());
-        httpPostWithAuthorization(newPostRequest, CREATE_POST_URI, getToken());
+        httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, getToken());
 
         ExtractableResponse<Response> response = httpPutWithAuthorization("/posts/1/like", getToken());
         LikeFlipResponse likeFlipResponse = response.jsonPath().getObject(".", LikeFlipResponse.class);
@@ -43,10 +38,8 @@ class LikeAcceptanceTest extends AcceptanceTest {
     @DisplayName("로그인한 회원이 좋아요를 누른 게시물에 좋아요를 취소할 수 있다.")
     @Test
     void flipLike_Delete() {
-        NewPostRequest newPostRequest = new NewPostRequest(VALID_POST_TITLE, VALID_POST_CONTENT,
-                Collections.emptyList());
         String sessionId = getToken();
-        httpPostWithAuthorization(newPostRequest, CREATE_POST_URI, sessionId);
+        httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, sessionId);
 
         httpPutWithAuthorization("/posts/1/like", sessionId);
 
@@ -63,10 +56,8 @@ class LikeAcceptanceTest extends AcceptanceTest {
     @DisplayName("로그인 하지 않은 회원이 좋아요를 누를 경우 예외를 반환한다")
     @Test
     void flipLike_Unauthorized() {
-        NewPostRequest newPostRequest = new NewPostRequest(VALID_POST_TITLE, VALID_POST_CONTENT,
-                Collections.emptyList());
         String sessionId = getToken();
-        httpPostWithAuthorization(newPostRequest, CREATE_POST_URI, sessionId);
+        httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, sessionId);
 
         ExtractableResponse<Response> response = httpPutWithAuthorization("/posts/1/like", "");
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
@@ -1,9 +1,9 @@
 package com.wooteco.sokdak.post.acceptance;
 
+import static com.wooteco.sokdak.post.util.PostFixture.NEW_POST_REQUEST;
 import static com.wooteco.sokdak.post.util.PostFixture.UPDATED_POST_CONTENT;
 import static com.wooteco.sokdak.post.util.PostFixture.UPDATED_POST_TITLE;
 import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_CONTENT;
-import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_TITLE;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.getExceptionMessage;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpDeleteWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpGet;
@@ -35,8 +35,6 @@ import org.springframework.http.HttpStatus;
 @DisplayName("게시글 관련 인수테스트")
 class PostAcceptanceTest extends AcceptanceTest {
 
-    private static final NewPostRequest NEW_POST_REQUEST = new NewPostRequest(VALID_POST_TITLE, VALID_POST_CONTENT,
-            Collections.emptyList());
     public static final long WRITABLE_BOARD_ID = 2L;
 
     @DisplayName("새로운 게시글을 작성할 수 있다.")
@@ -63,8 +61,8 @@ class PostAcceptanceTest extends AcceptanceTest {
     @Test
     void findPosts() {
         String token = getToken();
-        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", Collections.emptyList());
-        NewPostRequest postRequest3 = new NewPostRequest("제목3", "본문3", Collections.emptyList());
+        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", false, Collections.emptyList());
+        NewPostRequest postRequest3 = new NewPostRequest("제목3", "본문3", false, Collections.emptyList());
         httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, token);
         httpPostWithAuthorization(postRequest2, CREATE_POST_URI, token);
         httpPostWithAuthorization(postRequest3, CREATE_POST_URI, token);
@@ -82,9 +80,9 @@ class PostAcceptanceTest extends AcceptanceTest {
     @Test
     void findPostsInBoard() {
         String token = getToken();
-        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", Collections.emptyList());
-        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", Collections.emptyList());
-        NewPostRequest postRequest3 = new NewPostRequest("제목3", "본문3", Collections.emptyList());
+        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", false, Collections.emptyList());
+        NewPostRequest postRequest2 = new NewPostRequest("제목2", "본문2", false, Collections.emptyList());
+        NewPostRequest postRequest3 = new NewPostRequest("제목3", "본문3", false, Collections.emptyList());
         httpPostWithAuthorization(postRequest1, CREATE_POST_URI, token);
         httpPostWithAuthorization(postRequest2, CREATE_POST_URI, token);
         httpPostWithAuthorization(postRequest3, "/boards/3/posts", token);
@@ -102,8 +100,7 @@ class PostAcceptanceTest extends AcceptanceTest {
     @Test
     void findPostsInBoard_Exception() {
         String token = getToken();
-        NewPostRequest postRequest1 = new NewPostRequest("제목1", "본문1", Collections.emptyList());
-        ExtractableResponse<Response> response = httpPostWithAuthorization(postRequest1, CANNOT_CREATE_POST_URI,
+        ExtractableResponse<Response> response = httpPostWithAuthorization(NEW_POST_REQUEST, CANNOT_CREATE_POST_URI,
                 token);
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
@@ -129,7 +126,7 @@ class PostAcceptanceTest extends AcceptanceTest {
     @Test
     void addPost_Exception_NoTitle() {
         NewPostRequest newPostRequestWithoutTitle = new NewPostRequest(null, VALID_POST_CONTENT,
-                Collections.emptyList());
+                false, Collections.emptyList());
         ExtractableResponse<Response> response =
                 httpPostWithAuthorization(newPostRequestWithoutTitle, CREATE_POST_URI, getToken());
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
@@ -4,6 +4,7 @@ import static com.wooteco.sokdak.post.util.PostFixture.NEW_POST_REQUEST;
 import static com.wooteco.sokdak.post.util.PostFixture.UPDATED_POST_CONTENT;
 import static com.wooteco.sokdak.post.util.PostFixture.UPDATED_POST_TITLE;
 import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_CONTENT;
+import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_TITLE;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.getExceptionMessage;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpDeleteWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpGet;
@@ -106,9 +107,9 @@ class PostAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
-    @DisplayName("특정 게시글 조회할 수 있다.")
+    @DisplayName("닉네임으로 작성된 게시글 조회할 수 있다.")
     @Test
-    void findPost() {
+    void findPost_IdentifiedNickname() {
         String postId = parsePostId(
                 httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, getToken()));
 
@@ -118,7 +119,27 @@ class PostAcceptanceTest extends AcceptanceTest {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(postDetailResponse.getTitle()).isEqualTo(NEW_POST_REQUEST.getTitle()),
-                () -> assertThat(postDetailResponse.getContent()).isEqualTo(NEW_POST_REQUEST.getContent())
+                () -> assertThat(postDetailResponse.getContent()).isEqualTo(NEW_POST_REQUEST.getContent()),
+                () -> assertThat(postDetailResponse.getNickname()).isEqualTo("chrisNickname")
+        );
+    }
+
+    @DisplayName("닉네임으로 작성된 게시글 조회할 수 있다.")
+    @Test
+    void findPost_Anonymous() {
+        NewPostRequest newPostRequest = new NewPostRequest(VALID_POST_TITLE, VALID_POST_CONTENT, true,
+                Collections.emptyList());
+        String postId = parsePostId(
+                httpPostWithAuthorization(newPostRequest, CREATE_POST_URI, getToken()));
+
+        ExtractableResponse<Response> response = httpGet("/posts/" + postId);
+        PostDetailResponse postDetailResponse = response.jsonPath().getObject(".", PostDetailResponse.class);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(postDetailResponse.getTitle()).isEqualTo(NEW_POST_REQUEST.getTitle()),
+                () -> assertThat(postDetailResponse.getContent()).isEqualTo(NEW_POST_REQUEST.getContent()),
+                () -> assertThat(postDetailResponse.getNickname()).isNotEqualTo("chrisNickname")
         );
     }
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/controller/PostControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/controller/PostControllerTest.java
@@ -1,5 +1,6 @@
 package com.wooteco.sokdak.post.controller;
 
+import static com.wooteco.sokdak.post.util.PostFixture.NEW_POST_REQUEST;
 import static com.wooteco.sokdak.post.util.PostFixture.UPDATED_POST_CONTENT;
 import static com.wooteco.sokdak.post.util.PostFixture.UPDATED_POST_TITLE;
 import static com.wooteco.sokdak.util.fixture.MemberFixture.AUTH_INFO;
@@ -63,8 +64,6 @@ class PostControllerTest extends ControllerTest {
     @DisplayName("글 작성 요청을 받으면 새로운 게시글을 등록한다.")
     @Test
     void addPost() {
-        NewPostRequest postRequest = new NewPostRequest("제목", "본문", List.of("태그1"));
-
         doReturn(true)
                 .when(authInterceptor)
                 .preHandle(any(), any(), any());
@@ -72,7 +71,7 @@ class PostControllerTest extends ControllerTest {
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", "any")
-                .body(postRequest)
+                .body(NEW_POST_REQUEST)
                 .when().post("/boards/1/posts")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value());
@@ -81,7 +80,7 @@ class PostControllerTest extends ControllerTest {
     @DisplayName("게시글 제목이 없는 경우 400을 반환한다.")
     @Test
     void addPost_Exception_NoTitle() {
-        NewPostRequest postRequest = new NewPostRequest(null, "본문", Collections.emptyList());
+        NewPostRequest postRequest = new NewPostRequest(null, "본문", false, Collections.emptyList());
 
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -95,7 +94,7 @@ class PostControllerTest extends ControllerTest {
     @DisplayName("게시글 내용이 없는 경우 400을 반환한다.")
     @Test
     void addPost_Exception_NoContent() {
-        NewPostRequest postRequest = new NewPostRequest("제목", null, Collections.emptyList());
+        NewPostRequest postRequest = new NewPostRequest("제목", null, false, Collections.emptyList());
 
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
@@ -11,10 +11,10 @@ import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.board.domain.Board;
 import com.wooteco.sokdak.board.domain.BoardType;
 import com.wooteco.sokdak.board.repository.BoardRepository;
-import com.wooteco.sokdak.board.repository.PostBoardRepository;
 import com.wooteco.sokdak.comment.dto.NewCommentRequest;
 import com.wooteco.sokdak.comment.service.CommentService;
 import com.wooteco.sokdak.member.domain.Member;
+import com.wooteco.sokdak.member.domain.Nickname;
 import com.wooteco.sokdak.member.exception.MemberNotFoundException;
 import com.wooteco.sokdak.member.repository.MemberRepository;
 import com.wooteco.sokdak.post.domain.Post;
@@ -49,9 +49,6 @@ class PostServiceTest extends IntegrationTest {
     private PostRepository postRepository;
 
     @Autowired
-    private PostBoardRepository postBoardRepository;
-
-    @Autowired
     private BoardRepository boardRepository;
 
     @Autowired
@@ -66,6 +63,7 @@ class PostServiceTest extends IntegrationTest {
         post = Post.builder()
                 .title("제목")
                 .content("본문")
+                .writerNickname(new Nickname(member.getNickname()))
                 .member(member)
                 .likes(new ArrayList<>())
                 .comments(new ArrayList<>())

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/util/PostFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/util/PostFixture.java
@@ -1,5 +1,8 @@
 package com.wooteco.sokdak.post.util;
 
+import com.wooteco.sokdak.post.dto.NewPostRequest;
+import java.util.List;
+
 public class PostFixture {
 
     public static final String VALID_POST_TITLE = "제목";
@@ -8,6 +11,6 @@ public class PostFixture {
     public static final String UPDATED_POST_TITLE = "변경된 제목";
     public static final String UPDATED_POST_CONTENT = "변경된 본문";
 
-    public static final String INVALID_POST_TITLE = "A".repeat(51);
-    public static final String INVALID_POST_CONTENT = "A".repeat(5001);
+    public static final NewPostRequest NEW_POST_REQUEST =
+            new NewPostRequest("제목", "본문", false, List.of("태그1", "태그2"));
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/report/acceptance/CommentReportAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/report/acceptance/CommentReportAcceptanceTest.java
@@ -1,8 +1,7 @@
 package com.wooteco.sokdak.report.acceptance;
 
 import static com.wooteco.sokdak.post.util.CommentFixture.VALID_COMMENT_MESSAGE;
-import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_CONTENT;
-import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_TITLE;
+import static com.wooteco.sokdak.post.util.PostFixture.NEW_POST_REQUEST;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPost;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPostWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.PostFixture.CREATE_POST_URI;
@@ -11,12 +10,10 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.wooteco.sokdak.auth.dto.LoginRequest;
 import com.wooteco.sokdak.comment.dto.NewCommentRequest;
-import com.wooteco.sokdak.post.dto.NewPostRequest;
 import com.wooteco.sokdak.report.dto.ReportRequest;
 import com.wooteco.sokdak.util.AcceptanceTest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.Collections;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -39,10 +36,8 @@ class CommentReportAcceptanceTest extends AcceptanceTest {
 
     private Long addCommentAndGetCommentId() {
         String token = getToken();
-        NewPostRequest newPostRequest = new NewPostRequest(VALID_POST_TITLE, VALID_POST_CONTENT,
-                Collections.emptyList());
         String postId = parsePostId(
-                httpPostWithAuthorization(newPostRequest, CREATE_POST_URI, getToken()));
+                httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, getToken()));
 
         NewCommentRequest newCommentRequest = new NewCommentRequest(VALID_COMMENT_MESSAGE, true);
         Long commentId = Long.parseLong(

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/report/acceptance/PostReportAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/report/acceptance/PostReportAcceptanceTest.java
@@ -1,7 +1,6 @@
 package com.wooteco.sokdak.report.acceptance;
 
-import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_CONTENT;
-import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_TITLE;
+import static com.wooteco.sokdak.post.util.PostFixture.NEW_POST_REQUEST;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPost;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPostWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.PostFixture.CREATE_POST_URI;
@@ -9,12 +8,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.wooteco.sokdak.auth.dto.LoginRequest;
-import com.wooteco.sokdak.post.dto.NewPostRequest;
 import com.wooteco.sokdak.report.dto.ReportRequest;
 import com.wooteco.sokdak.util.AcceptanceTest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.Collections;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -53,9 +50,7 @@ class PostReportAcceptanceTest extends AcceptanceTest {
     }
 
     private Long addPostAndGetPostId() {
-        NewPostRequest newPostRequest = new NewPostRequest(VALID_POST_TITLE, VALID_POST_CONTENT,
-                Collections.emptyList());
-        return Long.parseLong(httpPostWithAuthorization(newPostRequest, CREATE_POST_URI, getToken())
+        return Long.parseLong(httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, getToken())
                 .header("Location").split("/posts/")[1]);
     }
 }


### PR DESCRIPTION
### 구현기능
- [x] 게시글 작성시 익명/기명 선택 기능 구현

### 세부 구현기능
- [x] 게시글 작성시 익명으로 글 작성하면, 랜덤 닉네임 지정

### 관련 이슈
- [x] 회원가입시 서비스에서 사용하는 랜덤 닉네임 사용하지 못하도록 막기
