### PR TITLE
fix: 게시판 순서를 API 명세를 따라 수정

### DIFF
--- a/frontend/src/constants/board.ts
+++ b/frontend/src/constants/board.ts
@@ -1,18 +1,18 @@
 export const BOARDS = [
   {
     id: 1,
-    title: '🔥 핫 게시판 🔥',
+    title: '🔥 HOT 게시판 🔥',
   },
   {
     id: 2,
-    title: '📮 포수타',
+    title: '🗽 자유 게시판',
   },
   {
     id: 3,
-    title: '️💌 감동 크루',
+    title: '📮 포수타',
   },
   {
     id: 4,
-    title: '🗽 자유 게시판',
+    title: '️💌 감동 크루',
   },
 ];

--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -545,19 +545,19 @@ export const hashtagList: Hashtag[] = [
 export const boardList = [
   {
     id: 1,
-    title: '🔥 Hot 게시판 🔥',
+    title: '🔥 HOT 게시판 🔥',
   },
   {
     id: 2,
-    title: '📮 포수타',
+    title: '🗽 자유 게시판',
   },
   {
     id: 3,
-    title: '️💌 감동 크루',
+    title: '📮 포수타',
   },
   {
     id: 4,
-    title: '🗽 자유게시판',
+    title: '️💌 감동 크루',
   },
 ];
 


### PR DESCRIPTION
### 구현기능

게시판 목록에서 게시판 순서를 API 명세와 동일하게 한다.

### 세부 구현기능

#### 순서

1. Hot 게시판
2. 자유 게시판
3. 포수타
4. 감동크루 

### 관련 이슈

close #286 
