### PR TITLE
feat: 댓글에 작성자 표기

### DIFF
--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -359,6 +359,7 @@ export const validMemberEmail: { email: string; isSignedUp: boolean; code: strin
 interface CommentListType extends CommentType {
   postId: number;
   blocked: boolean;
+  postWriter: boolean;
 }
 
 export const commentList: CommentListType[] = [
@@ -368,18 +369,20 @@ export const commentList: CommentListType[] = [
     content:
       'ㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠㅠ첫댓글',
     createdAt: '2022-07-04T19:55:31.016376300',
-    nickname: '익명',
-    authorized: false,
+    nickname: '테스트 계정',
+    authorized: true,
     blocked: false,
+    postWriter: true,
   },
   {
     id: 2,
     postId: 1,
     content: '안녕하세요.',
     createdAt: '2022-07-04T19:55:31.016376300',
-    nickname: '익명',
-    authorized: false,
+    nickname: '테스트 계정',
+    authorized: true,
     blocked: false,
+    postWriter: true,
   },
   {
     id: 3,
@@ -387,8 +390,9 @@ export const commentList: CommentListType[] = [
     content: '안녕하세요.',
     createdAt: '2022-07-04T19:55:31.016376300',
     nickname: '익명',
-    authorized: true,
+    authorized: false,
     blocked: true,
+    postWriter: false,
   },
   {
     id: 4,
@@ -396,8 +400,9 @@ export const commentList: CommentListType[] = [
     content: '안녕하세요.',
     createdAt: '2022-07-04T19:55:31.016376300',
     nickname: '익명',
-    authorized: true,
+    authorized: false,
     blocked: false,
+    postWriter: false,
   },
   {
     id: 5,
@@ -407,6 +412,7 @@ export const commentList: CommentListType[] = [
     nickname: '익명',
     authorized: false,
     blocked: false,
+    postWriter: false,
   },
   {
     id: 6,
@@ -414,8 +420,9 @@ export const commentList: CommentListType[] = [
     content: '안녕하세요.',
     createdAt: '2022-07-04T19:55:31.016376300',
     nickname: '익명',
-    authorized: true,
+    authorized: false,
     blocked: false,
+    postWriter: false,
   },
   {
     id: 7,
@@ -425,6 +432,7 @@ export const commentList: CommentListType[] = [
     nickname: '익명',
     authorized: false,
     blocked: false,
+    postWriter: false,
   },
   {
     id: 8,
@@ -434,6 +442,7 @@ export const commentList: CommentListType[] = [
     nickname: '익명',
     authorized: false,
     blocked: true,
+    postWriter: false,
   },
   {
     id: 9,
@@ -441,8 +450,9 @@ export const commentList: CommentListType[] = [
     content: '안녕하세요.',
     createdAt: '2022-07-04T19:55:31.016376300',
     nickname: '익명',
-    authorized: true,
+    authorized: false,
     blocked: false,
+    postWriter: false,
   },
   {
     id: 10,
@@ -452,6 +462,7 @@ export const commentList: CommentListType[] = [
     nickname: '익명',
     authorized: false,
     blocked: false,
+    postWriter: false,
   },
   {
     id: 11,
@@ -459,8 +470,9 @@ export const commentList: CommentListType[] = [
     content: '안녕하세요.',
     createdAt: '2022-07-04T19:55:31.016376300',
     nickname: '익명',
-    authorized: true,
+    authorized: false,
     blocked: false,
+    postWriter: false,
   },
   {
     id: 12,
@@ -470,6 +482,7 @@ export const commentList: CommentListType[] = [
     nickname: '익명',
     authorized: false,
     blocked: false,
+    postWriter: false,
   },
   {
     id: 13,
@@ -477,8 +490,9 @@ export const commentList: CommentListType[] = [
     content: '안녕하세요.',
     createdAt: '2022-07-04T19:55:31.016376300',
     nickname: '익명',
-    authorized: true,
+    authorized: false,
     blocked: false,
+    postWriter: false,
   },
   {
     id: 14,
@@ -488,6 +502,7 @@ export const commentList: CommentListType[] = [
     nickname: '익명',
     authorized: false,
     blocked: false,
+    postWriter: false,
   },
   {
     id: 15,
@@ -497,6 +512,7 @@ export const commentList: CommentListType[] = [
     nickname: '익명',
     authorized: false,
     blocked: false,
+    postWriter: false,
   },
   {
     id: 16,
@@ -506,6 +522,7 @@ export const commentList: CommentListType[] = [
     nickname: '익명',
     authorized: false,
     blocked: false,
+    postWriter: false,
   },
 ];
 

--- a/frontend/src/hooks/queries/comment/useComments.ts
+++ b/frontend/src/hooks/queries/comment/useComments.ts
@@ -7,6 +7,7 @@ import QUERY_KEYS from '@/constants/queries';
 interface CommentResponse extends CommentType {
   id: number;
   blocked: boolean;
+  postWriter: boolean;
 }
 
 const useComments = ({

--- a/frontend/src/mocks/handlers/posts/index.ts
+++ b/frontend/src/mocks/handlers/posts/index.ts
@@ -182,10 +182,11 @@ const postHandlers = [
       id: commentList.length + 1,
       content,
       createdAt: new Date().toISOString(),
-      nickname: anonymous ? '익명' : '기명',
+      nickname: anonymous ? '짜증난 파이썬' : '테스트 계정',
       postId: id,
       authorized: true,
       blocked: false,
+      postWriter: targetPost.authorized,
     });
     targetPost.commentCount += 1;
 

--- a/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
@@ -31,12 +31,22 @@ export const DeleteButton = styled.button`
   color: ${props => props.theme.colors.red_200};
   font-size: 0.6rem;
 `;
+
 export const ReportButton = styled.button`
   background-color: transparent;
 `;
 
 export const Nickname = styled.p`
   font-weight: bold;
+  display: flex;
+`;
+
+export const PostWriter = styled.span`
+  color: ${props => props.theme.colors.sub};
+  font-weight: normal;
+  font-size: 10px;
+  align-self: center;
+  margin-left: 5px;
 `;
 
 export const Content = styled.p`

--- a/frontend/src/pages/PostPage/components/CommentBox/index.tsx
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.tsx
@@ -13,9 +13,10 @@ import ReportModal from '../ReportModal';
 
 interface CommentBoxProps extends CommentType {
   blocked: boolean;
+  postWriter: boolean;
 }
 
-const CommentBox = ({ id, nickname, content, createdAt, authorized, blocked }: CommentBoxProps) => {
+const CommentBox = ({ id, nickname, content, createdAt, authorized, blocked, postWriter }: CommentBoxProps) => {
   const [isReportModalOpen, handleReportModal] = useReducer(state => !state, false);
   const [isDeleteModalOpen, handleDeleteModal] = useReducer(state => !state, false);
 
@@ -50,11 +51,13 @@ const CommentBox = ({ id, nickname, content, createdAt, authorized, blocked }: C
     <>
       <Styled.Container>
         <Styled.CommentHeader>
-          <Styled.Nickname>{nickname}</Styled.Nickname>
+          <Styled.Nickname>
+            {nickname} {postWriter && <Styled.PostWriter>작성자</Styled.PostWriter>}
+          </Styled.Nickname>
           {authorized ? (
-            <Styled.ReportButton onClick={handleClickReportButton}>🚨</Styled.ReportButton>
-          ) : (
             <Styled.DeleteButton onClick={handleClickDeleteButton}>삭제</Styled.DeleteButton>
+          ) : (
+            <Styled.ReportButton onClick={handleClickReportButton}>🚨</Styled.ReportButton>
           )}
         </Styled.CommentHeader>
         <Styled.Content>{content}</Styled.Content>

--- a/frontend/src/pages/PostPage/components/CommentList/index.tsx
+++ b/frontend/src/pages/PostPage/components/CommentList/index.tsx
@@ -12,6 +12,7 @@ interface CommentListProps {
 
 const CommentList = ({ id }: CommentListProps) => {
   const { data } = useComments({ storeCode: id });
+
   return (
     <Styled.Container>
       <CommentInput amount={data?.length!} id={id} />
@@ -25,6 +26,7 @@ const CommentList = ({ id }: CommentListProps) => {
             content={comment.content}
             createdAt={comment.createdAt}
             blocked={comment.blocked}
+            postWriter={comment.postWriter}
           />
         ))}
       </Styled.CommentsContainer>


### PR DESCRIPTION
### 구현기능

글 작성자가 본인의 글에 댓글을 달았을 경우 작성자를 표기해준다. 

<img width="332" alt="스크린샷 2022-08-03 오후 5 57 30" src="https://user-images.githubusercontent.com/52737532/182568035-5341b4a3-8de4-4871-8ee2-f2885a5e03b2.png">

### 세부 구현기능

- [x] dummy comment list에 `postWriter` 필드 추가 (boolean)
- [x] 만약 글 작성자가 댓글을 달았다면 `작성자` 태그를 달아준다. 
- [x] **(확인 필요)** 댓글 작성자이면 댓글을 삭제할 수 있도록, 아니라면 신고할 수 있도록 수정한다. 

### 관련 이슈

close #294 
