### PR TITLE
feat: 게시글 작성자 댓글 식별 기능 구현

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
@@ -8,7 +8,6 @@ import com.wooteco.sokdak.report.domain.CommentReport;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -68,6 +67,10 @@ public class Comment {
         if (accessMemberId != member.getId()) {
             throw new AuthenticationException();
         }
+    }
+
+    public boolean isPostWriter() {
+        return post.getMember().equals(member);
     }
 
     public boolean isBlocked() {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/dto/CommentResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/dto/CommentResponse.java
@@ -2,7 +2,6 @@ package com.wooteco.sokdak.comment.dto;
 
 import com.wooteco.sokdak.comment.domain.Comment;
 import java.time.LocalDateTime;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -13,19 +12,23 @@ public class CommentResponse {
     private final String content;
     private final LocalDateTime createdAt;
     private final boolean blocked;
+    private final boolean postWriter;
     private final boolean authorized;
 
-    public CommentResponse(Long id, String nickname, String content, LocalDateTime createdAt, boolean blocked, boolean authorized) {
+    public CommentResponse(Long id, String nickname, String content, LocalDateTime createdAt, boolean blocked,
+                           boolean postWriter, boolean authorized) {
         this.id = id;
         this.nickname = nickname;
         this.content = content;
         this.createdAt = createdAt;
         this.blocked = blocked;
+        this.postWriter = postWriter;
         this.authorized = authorized;
     }
 
     public static CommentResponse of(Comment comment, Long accessMemberId) {
         return new CommentResponse(comment.getId(), comment.getNickname(), comment.getMessage(),
-                comment.getCreatedAt(), comment.isBlocked(), comment.isAuthenticated(accessMemberId));
+                comment.getCreatedAt(), comment.isBlocked(), comment.isPostWriter(),
+                comment.isAuthenticated(accessMemberId));
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/service/CommentService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/service/CommentService.java
@@ -16,6 +16,7 @@ import com.wooteco.sokdak.post.exception.PostNotFoundException;
 import com.wooteco.sokdak.post.repository.PostRepository;
 import java.util.HashSet;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,7 +44,7 @@ public class CommentService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(PostNotFoundException::new);
 
-        String nickname = getCommentNickname(newCommentRequest, authInfo, postId);
+        String nickname = getCommentNickname(newCommentRequest, authInfo, post);
         Comment comment = Comment.builder()
                 .member(member)
                 .post(post)
@@ -55,20 +56,43 @@ public class CommentService {
         return savedComment.getId();
     }
 
-    private String getCommentNickname(NewCommentRequest newCommentRequest, AuthInfo authInfo, Long postId) {
+    private String getCommentNickname(NewCommentRequest newCommentRequest, AuthInfo authInfo, Post post) {
         String memberNickname = memberRepository.findNicknameValueById(authInfo.getId())
                 .orElseThrow(MemberNotFoundException::new);
         if (!newCommentRequest.isAnonymous()) { // 기명이면 member table에서 memberId로 닉네임 가져옴.
             return memberNickname;
         }
-        // 익명이면, comment table에서 memberId에 해당하는 nickname들을 다 가져와서, member
-        List<String> nickNamesByMember = commentRepository.findNickNamesByPostIdAndMemberId(postId, authInfo.getId());
-        List<String> usedNicknames = commentRepository.findNicknamesByPostId(postId);
+        if (post.isAuthenticated(authInfo.getId())) { // 댓글 작성하는 사람과 게시글 작성자 일치
+            return getPostWriterNickname(post);
+        }
 
-        return nickNamesByMember.stream()
-                .filter(nickname -> !nickname.equals(memberNickname))
+        // 익명이면, comment table에서 memberId에 해당하는 nickname들을 다 가져와서, member
+        List<String> usedNicknames = getUsedNicknameInPage(post);
+        List<String> pastNicknamesByMemberId =
+                commentRepository.findNickNamesByPostIdAndMemberId(post.getId(), authInfo.getId());
+
+        return pastNicknamesByMemberId.stream()
+                .filter(isRandomNicknameGeneratedInPast(memberNickname))
                 .findAny()
                 .orElseGet(() -> RandomNicknameGenerator.generate(new HashSet<>(usedNicknames)));
+    }
+
+    private String getPostWriterNickname(Post post) {
+        if (post.isAnonymous()) { // 작성자가 기명으로 글 작성
+            return post.getNickname();
+        }
+        List<String> commentNicknames = commentRepository.findNicknamesByPostId(post.getId());
+        return RandomNicknameGenerator.generate(new HashSet<>(commentNicknames));
+    }
+
+    private Predicate<String> isRandomNicknameGeneratedInPast(String memberNickname) {
+        return nickname -> !nickname.equals(memberNickname);
+    }
+
+    private List<String> getUsedNicknameInPage(Post post) {
+        List<String> usedNicknames = commentRepository.findNicknamesByPostId(post.getId());
+        usedNicknames.add(post.getNickname());
+        return usedNicknames;
     }
 
     public CommentsResponse findComments(Long postId, AuthInfo authInfo) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/domain/Member.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.wooteco.sokdak.member.domain;
 
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -9,7 +10,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.Builder;
-import lombok.Getter;
 
 @Entity
 public class Member {
@@ -59,5 +59,22 @@ public class Member {
 
     public RoleType getRoleType() {
         return roleType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Member)) {
+            return false;
+        }
+        Member member = (Member) o;
+        return Objects.equals(id, member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -110,6 +110,10 @@ public class Post {
         return member.getId().equals(accessMemberId);
     }
 
+    public boolean isAnonymous() {
+        return !getNickname().equals(member.getNickname());
+    }
+
     public Long getId() {
         return id;
     }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -55,11 +55,11 @@ public class PostService {
     public Long addPost(Long boardId, NewPostRequest newPostRequest, AuthInfo authInfo) {
         Member member = memberRepository.findById(authInfo.getId())
                 .orElseThrow(MemberNotFoundException::new);
-        String randomNickname = createPostWriterNickname(newPostRequest.isAnonymous(), member);
+        String writerNickname = createPostWriterNickname(newPostRequest.isAnonymous(), member);
         Post post = Post.builder()
                 .title(newPostRequest.getTitle())
                 .content(newPostRequest.getContent())
-                .writerNickname(new Nickname(randomNickname))
+                .writerNickname(new Nickname(writerNickname))
                 .member(member)
                 .build();
         Post savedPost = postRepository.save(post);

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/controller/CommentControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/controller/CommentControllerTest.java
@@ -63,8 +63,10 @@ class CommentControllerTest extends ControllerTest {
     @DisplayName("특정 글의 댓글 조회 요청이 오면 모든 댓글들을 반환한다.")
     @Test
     void findComments() {
-        CommentResponse commentResponse1 = new CommentResponse(1L, "조시1", "댓글1", LocalDateTime.now(), false, false);
-        CommentResponse commentResponse2 = new CommentResponse(2L, "조시2", "댓글2", LocalDateTime.now(), false, false);
+        CommentResponse commentResponse1 = new CommentResponse(1L, "조시1", "댓글1", LocalDateTime.now(), false, false,
+                false);
+        CommentResponse commentResponse2 = new CommentResponse(2L, "조시2", "댓글2", LocalDateTime.now(), false, true,
+                false);
         doReturn(new CommentsResponse(List.of(commentResponse1, commentResponse2)))
                 .when(commentService)
                 .findComments(any(), any());

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/domain/CommentTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/domain/CommentTest.java
@@ -10,14 +10,18 @@ import com.wooteco.sokdak.auth.exception.AuthenticationException;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.report.domain.CommentReport;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class CommentTest {
 
+    private Post post;
     private Comment comment;
     private Member member;
 
@@ -29,7 +33,7 @@ class CommentTest {
                 .password(VALID_PASSWORD)
                 .nickname(VALID_NICKNAME)
                 .build();
-        Post post = Post.builder()
+        post = Post.builder()
                 .title("제목")
                 .content("본문")
                 .member(member)
@@ -71,5 +75,40 @@ class CommentTest {
     @CsvSource({"1, true", "2, false"})
     void isAuthenticated(Long userId, boolean expected) {
         assertThat(comment.isAuthenticated(userId)).isEqualTo(expected);
+    }
+
+    @DisplayName("게시글 작성자의 댓글인지 반환")
+    @ParameterizedTest
+    @MethodSource("provideMemberAndExpected")
+    void isPostWriter_True(Member member, boolean expected) {
+        Comment comment = Comment.builder()
+                .member(member)
+                .post(post)
+                .nickname(VALID_NICKNAME)
+                .message("댓글")
+                .build();
+
+        boolean actual = comment.isPostWriter();
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> provideMemberAndExpected() {
+        Member member1 = Member.builder()
+                .id(1L)
+                .username(VALID_USERNAME)
+                .password(VALID_PASSWORD)
+                .nickname(VALID_NICKNAME)
+                .build();
+        Member member2 = Member.builder()
+                .id(2L)
+                .username(VALID_USERNAME)
+                .password(VALID_PASSWORD)
+                .nickname(VALID_NICKNAME)
+                .build();
+        return Stream.of(
+                Arguments.of(member1, true),
+                Arguments.of(member2, false)
+        );
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/service/CommentServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/service/CommentServiceTest.java
@@ -4,6 +4,7 @@ import static com.wooteco.sokdak.member.domain.RoleType.USER;
 import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_CONTENT;
 import static com.wooteco.sokdak.post.util.PostFixture.VALID_POST_TITLE;
 import static com.wooteco.sokdak.util.fixture.MemberFixture.AUTH_INFO;
+import static com.wooteco.sokdak.util.fixture.MemberFixture.AUTH_INFO2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -15,11 +16,13 @@ import com.wooteco.sokdak.comment.dto.CommentResponse;
 import com.wooteco.sokdak.comment.dto.NewCommentRequest;
 import com.wooteco.sokdak.comment.repository.CommentRepository;
 import com.wooteco.sokdak.member.domain.Member;
+import com.wooteco.sokdak.member.domain.Nickname;
 import com.wooteco.sokdak.member.repository.MemberRepository;
 import com.wooteco.sokdak.member.util.RandomNicknameGenerator;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.repository.PostRepository;
 import com.wooteco.sokdak.util.IntegrationTest;
+import java.util.HashSet;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -40,18 +43,31 @@ class CommentServiceTest extends IntegrationTest {
     @Autowired
     private CommentRepository commentRepository;
 
-    private Post post;
+    private Post anonymousPost;
+    private Post identifiedPost;
     private Member member;
+    private Member member2;
+    private String randomNickname;
 
     @BeforeEach
     void setUp() {
         member = memberRepository.findById(1L).get();
-        post = Post.builder()
+        member2 = memberRepository.findById(2L).get();
+        randomNickname = RandomNicknameGenerator.generate(new HashSet<>());
+        anonymousPost = Post.builder()
                 .member(member)
                 .title(VALID_POST_TITLE)
                 .content(VALID_POST_CONTENT)
+                .writerNickname(new Nickname(randomNickname))
                 .build();
-        postRepository.save(post);
+        identifiedPost = Post.builder()
+                .member(member)
+                .title(VALID_POST_TITLE)
+                .content(VALID_POST_CONTENT)
+                .writerNickname(new Nickname(member.getNickname()))
+                .build();
+        postRepository.save(anonymousPost);
+        postRepository.save(identifiedPost);
     }
 
     @DisplayName("기명으로 댓글을 등록")
@@ -59,20 +75,96 @@ class CommentServiceTest extends IntegrationTest {
     void addComment_Identified() {
         NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", false);
 
-        Long commentId = commentService.addComment(post.getId(), newCommentRequest, AUTH_INFO);
+        Long commentId = commentService.addComment(anonymousPost.getId(), newCommentRequest, AUTH_INFO);
 
         Comment foundComment = commentRepository.findById(commentId).get();
         assertAll(
                 () -> assertThat(foundComment.getMessage()).isEqualTo("댓글"),
-                () -> assertThat(foundComment.getMember()).isEqualTo(member)
+                () -> assertThat(foundComment.getMember()).isEqualTo(member),
+                () -> assertThat(foundComment.getNickname()).isEqualTo(member.getNickname())
         );
     }
 
-    @DisplayName("익명으로 첫 댓글 작성")
+    @DisplayName("익명 게시글에서 게시글 작성자가 기명으로 댓글 등록")
     @Test
-    void addComment_FirstAnonymous() {
+    void addComment_Identified_PostWriterAnonymous_PostWriterCommentWriterSame() {
+        NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", false);
+        Long commentId = commentService.addComment(anonymousPost.getId(), newCommentRequest, AUTH_INFO);
+
+        Comment foundComment = commentRepository.findById(commentId).get();
+
+        assertAll(
+                () -> assertThat(foundComment.getMessage()).isEqualTo("댓글"),
+                () -> assertThat(foundComment.getMember()).isEqualTo(member),
+                () -> assertThat(foundComment.getNickname()).isEqualTo(member.getNickname())
+        );
+    }
+
+    @DisplayName("익명 게시글에서 게시글 작성자가 아닌 유저가 기명으로 댓글 등록")
+    @Test
+    void addComment_Identified_PostWriterAnonymous_PostWriterCommentWriterDifferent() {
+        NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", false);
+        Long commentId = commentService.addComment(anonymousPost.getId(), newCommentRequest, AUTH_INFO2);
+
+        Comment foundComment = commentRepository.findById(commentId).get();
+
+        assertAll(
+                () -> assertThat(foundComment.getMessage()).isEqualTo("댓글"),
+                () -> assertThat(foundComment.getMember()).isEqualTo(member2),
+                () -> assertThat(foundComment.getNickname()).isEqualTo(member2.getNickname())
+        );
+    }
+
+    @DisplayName("익명 게시글에서 게시글 작성자가 익명으로 댓글 등록")
+    @Test
+    void addComment_Anonymous_PostWriterAnonymous_PostWriterCommentWriterSame() {
         NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", true);
-        Long commentId = commentService.addComment(post.getId(), newCommentRequest, AUTH_INFO);
+        Long commentId = commentService.addComment(anonymousPost.getId(), newCommentRequest, AUTH_INFO);
+
+        Comment foundComment = commentRepository.findById(commentId).get();
+
+        assertAll(
+                () -> assertThat(foundComment.getMessage()).isEqualTo("댓글"),
+                () -> assertThat(foundComment.getMember()).isEqualTo(member),
+                () -> assertThat(foundComment.getNickname()).isEqualTo(randomNickname)
+        );
+    }
+
+    @DisplayName("기명 게시글에서 게시글 작성자가 익명으로 댓글 등록")
+    @Test
+    void addComment_Anonymous_PostWriterIdentified_PostWriterCommentWriterSame() {
+        NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", true);
+        Long commentId = commentService.addComment(identifiedPost.getId(), newCommentRequest, AUTH_INFO);
+
+        Comment foundComment = commentRepository.findById(commentId).get();
+
+        assertAll(
+                () -> assertThat(foundComment.getMessage()).isEqualTo("댓글"),
+                () -> assertThat(foundComment.getMember()).isEqualTo(member),
+                () -> assertThat(foundComment.getNickname()).isNotEqualTo(member.getNickname())
+        );
+    }
+
+    @DisplayName("익명 게시글에서 게시글 작성자 아닌 사용자가 익명으로 댓글 등록")
+    @Test
+    void addComment_Anonymous_PostWriterAnonymous_PostWriterCommentWriterDifferent() {
+        NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", true);
+        Long commentId = commentService.addComment(anonymousPost.getId(), newCommentRequest, AUTH_INFO2);
+
+        Comment foundComment = commentRepository.findById(commentId).get();
+
+        assertAll(
+                () -> assertThat(foundComment.getMessage()).isEqualTo("댓글"),
+                () -> assertThat(foundComment.getMember()).isEqualTo(member2),
+                () -> assertThat(foundComment.getNickname()).isNotEqualTo(anonymousPost.getNickname())
+        );
+    }
+
+    @DisplayName("기명 게시글에서 게시글 작성자가 아난 사용자가 익명으로 첫 댓글 작성")
+    @Test
+    void addComment_Anonymous_PostWriterIdentified_PostWriterCommentWriterDifferent_firstComment() {
+        NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", true);
+        Long commentId = commentService.addComment(anonymousPost.getId(), newCommentRequest, AUTH_INFO);
 
         Comment foundComment = commentRepository.findById(commentId).get();
 
@@ -83,17 +175,20 @@ class CommentServiceTest extends IntegrationTest {
         );
     }
 
-    @DisplayName("익명으로 댓글을 단 후, 다시 익명으로 댓글 작성")
+    @DisplayName("익명 게시글에서 게시글 작성자가 익명으로 댓글을 단 후, 다시 익명으로 댓글 작성")
     @Test
-    void addComment_SecondAnonymous() {
+    void addComment_Anonymous_PostWriterIdentified_PostWriterCommentWriterDifferent_SComment() {
         NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", true);
-        Long firstCommentId = commentService.addComment(post.getId(), newCommentRequest, AUTH_INFO);
-        Long secondCommentId = commentService.addComment(post.getId(), newCommentRequest, AUTH_INFO);
+        Long firstCommentId = commentService.addComment(anonymousPost.getId(), newCommentRequest, AUTH_INFO);
+        Long secondCommentId = commentService.addComment(anonymousPost.getId(), newCommentRequest, AUTH_INFO);
 
         Comment firstComment = commentRepository.findById(firstCommentId).get();
         Comment secondComment = commentRepository.findById(secondCommentId).get();
 
-        assertThat(secondComment.getNickname()).isEqualTo(firstComment.getNickname());
+        assertAll(
+                () -> assertThat(firstComment.getNickname()).isEqualTo(secondComment.getNickname()),
+                () -> assertThat(anonymousPost.getNickname()).isEqualTo(firstComment.getNickname())
+        );
     }
 
     @DisplayName("특정 게시물의 달린 댓글을 가져옴")
@@ -101,16 +196,18 @@ class CommentServiceTest extends IntegrationTest {
     void findComments() {
         Post otherPost = Post.builder()
                 .member(member)
+                .writerNickname(new Nickname(member.getNickname()))
                 .title("다른 게시글")
                 .content("본문")
                 .build();
         postRepository.save(otherPost);
         NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", true);
         NewCommentRequest newCommentRequestToOtherPost = new NewCommentRequest("다른 게시글의 댓글", true);
-        commentService.addComment(post.getId(), newCommentRequest, AUTH_INFO);
+        commentService.addComment(anonymousPost.getId(), newCommentRequest, AUTH_INFO);
         commentService.addComment(otherPost.getId(), newCommentRequestToOtherPost, AUTH_INFO);
 
-        List<CommentResponse> commentResponses = commentService.findComments(post.getId(), AUTH_INFO).getComments();
+        List<CommentResponse> commentResponses = commentService.findComments(anonymousPost.getId(), AUTH_INFO)
+                .getComments();
 
         assertAll(
                 () -> assertThat(commentResponses.size()).isEqualTo(1),
@@ -128,11 +225,13 @@ class CommentServiceTest extends IntegrationTest {
                 .build();
         memberRepository.save(otherMember);
         NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", true);
-        commentService.addComment(post.getId(), newCommentRequest, AUTH_INFO);
+        commentService.addComment(anonymousPost.getId(), newCommentRequest, AUTH_INFO);
         commentService.addComment(
-                post.getId(), newCommentRequest, new AuthInfo(otherMember.getId(), "USER", member.getNickname()));
+                anonymousPost.getId(), newCommentRequest,
+                new AuthInfo(otherMember.getId(), "USER", member.getNickname()));
 
-        List<CommentResponse> commentResponses = commentService.findComments(post.getId(), AUTH_INFO).getComments();
+        List<CommentResponse> commentResponses = commentService.findComments(anonymousPost.getId(), AUTH_INFO)
+                .getComments();
 
         assertAll(
                 () -> assertThat(commentResponses.get(0).isAuthorized()).isTrue(),
@@ -144,7 +243,7 @@ class CommentServiceTest extends IntegrationTest {
     @Test
     void deleteComment() {
         NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", true);
-        Long commentId = commentService.addComment(post.getId(), newCommentRequest, AUTH_INFO);
+        Long commentId = commentService.addComment(anonymousPost.getId(), newCommentRequest, AUTH_INFO);
 
         commentService.deleteComment(commentId, new AuthInfo(member.getId(), USER.getName(), member.getNickname()));
 
@@ -155,7 +254,7 @@ class CommentServiceTest extends IntegrationTest {
     @Test
     void deleteComment_Exception_NotOwner() {
         NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", true);
-        Long commentId = commentService.addComment(post.getId(), newCommentRequest, AUTH_INFO);
+        Long commentId = commentService.addComment(anonymousPost.getId(), newCommentRequest, AUTH_INFO);
         Long invalidOwnerId = 9999L;
 
         assertThatThrownBy(() -> commentService

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/MemberFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/MemberFixture.java
@@ -18,5 +18,6 @@ public class MemberFixture {
     public static final LoginRequest INVALID_LOGIN_REQUEST = new LoginRequest(INVALID_USERNAME, INVALID_PASSWORD);
 
     public static final String SESSION_ID = "mySessionId";
-    public static final AuthInfo AUTH_INFO = new AuthInfo(1L, RoleType.ADMIN.getName(), "nickname");
+    public static final AuthInfo AUTH_INFO = new AuthInfo(1L, RoleType.ADMIN.getName(), "chrisNickname");
+    public static final AuthInfo AUTH_INFO2 = new AuthInfo(2L, RoleType.ADMIN.getName(), "adminNick");
 }


### PR DESCRIPTION
### 설명
게시글 작성자 댓글 식별 기능 구현

### 세부 기능 요구사항
- 게시글 익명(랜덤 닉네임)으로 작성 (ex : 짜증난 파이썬)
  - 작성자가 익명으로 댓글 작성 : 게시글 닉네임과 동일한 랜덤 닉네임
  - 작성자가 기명으로 댓글 작성 : 작성자의 회원 정보에 있는 닉네임 반환
- 게시글 기명으로 작성 
  - 작성자가 익명으로 댓글 작성 : 랜덤 닉네임 반환
  - 작성자가 기명으로 댓글 작성 : 작성자의 회원 정보에 있는 닉네임 반환

모든 댓글에 대해, 게시글 작성자가 작성한 댓글 여부 반환
