### PR TITLE
fix: 댓글/게시글의 닉네임과 회원 닉네임 분리

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
@@ -43,8 +43,7 @@ public class Comment {
     @OneToMany(mappedBy = "comment")
     private List<CommentReport> commentReports = new ArrayList<>();
 
-    @Embedded
-    private Nickname nickname;
+    private String nickname;
 
     @Embedded
     private Message message;
@@ -59,7 +58,7 @@ public class Comment {
     public Comment(Member member, Post post, String nickname, String message) {
         this.member = member;
         this.post = post;
-        this.nickname = new Nickname(nickname);
+        this.nickname = nickname;
         this.message = new Message(message);
     }
 
@@ -93,7 +92,7 @@ public class Comment {
     }
 
     public String getNickname() {
-        return nickname.getValue();
+        return nickname;
     }
 
     public String getMessage() {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/repository/CommentRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/repository/CommentRepository.java
@@ -8,10 +8,10 @@ import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query(value = "SELECT c.nickname.value FROM Comment c WHERE c.member.id = :memberId and c.post.id = :postId")
+    @Query(value = "SELECT c.nickname FROM Comment c WHERE c.member.id = :memberId and c.post.id = :postId")
     List<String> findNickNamesByPostIdAndMemberId(@Param("postId") Long postId, @Param("memberId") Long memberId);
 
-    @Query(value = "SELECT c.nickname.value FROM Comment c WHERE c.post.id = :postId")
+    @Query(value = "SELECT c.nickname FROM Comment c WHERE c.post.id = :postId")
     List<String> findNicknamesByPostId(@Param("postId") Long postId);
 
     List<Comment> findAllByPostId(Long postId);

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -47,8 +47,7 @@ public class Post {
     @Embedded
     private Content content;
 
-    @Embedded
-    private Nickname writerNickname;
+    private String writerNickname;
 
     @OneToMany(mappedBy = "post")
     private List<Like> likes = new ArrayList<>();
@@ -72,7 +71,7 @@ public class Post {
     }
 
     @Builder
-    private Post(String title, String content, Member member, Nickname writerNickname, List<Like> likes,
+    private Post(String title, String content, Member member, String writerNickname, List<Like> likes,
                  List<Comment> comments, List<PostHashtag> postHashtags) {
         this.title = new Title(title);
         this.content = new Content(content);
@@ -157,6 +156,6 @@ public class Post {
     }
 
     public String getNickname() {
-        return writerNickname.getValue();
+        return writerNickname;
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -61,7 +61,7 @@ public class PostService {
         Post post = Post.builder()
                 .title(newPostRequest.getTitle())
                 .content(newPostRequest.getContent())
-                .writerNickname(new Nickname(writerNickname))
+                .writerNickname(writerNickname)
                 .member(member)
                 .build();
         Post savedPost = postRepository.save(post);

--- a/backend/sokdak/src/main/resources/logback/file-access-logger.xml
+++ b/backend/sokdak/src/main/resources/logback/file-access-logger.xml
@@ -2,7 +2,6 @@
 <included>
     <property name="DIR" value="/home/ubuntu/sokdak/logfiles/access/"/>
     <appender name="file-access-logger" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${DIR}access.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>${DIR}access-%d{yyyyMMdd}-%i.log</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
@@ -13,7 +12,7 @@
         <encoder>
             <charset>utf8</charset>
             <Pattern>
-                %n###### HTTP Request ###### %n%fullRequest###### HTTP Response ###### %n%fullResponse
+                %t{yyyy-MM-dd HH:mm:ss}%n###### HTTP Request ###### %n%fullRequest###### HTTP Response ######%n%t{yyyy-MM-dd HH:mm:ss}%n%fullResponse
             </Pattern>
         </encoder>
     </appender>

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/service/CommentServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/service/CommentServiceTest.java
@@ -58,13 +58,13 @@ class CommentServiceTest extends IntegrationTest {
                 .member(member)
                 .title(VALID_POST_TITLE)
                 .content(VALID_POST_CONTENT)
-                .writerNickname(new Nickname(randomNickname))
+                .writerNickname(randomNickname)
                 .build();
         identifiedPost = Post.builder()
                 .member(member)
                 .title(VALID_POST_TITLE)
                 .content(VALID_POST_CONTENT)
-                .writerNickname(new Nickname(member.getNickname()))
+                .writerNickname(member.getNickname())
                 .build();
         postRepository.save(anonymousPost);
         postRepository.save(identifiedPost);
@@ -196,7 +196,7 @@ class CommentServiceTest extends IntegrationTest {
     void findComments() {
         Post otherPost = Post.builder()
                 .member(member)
-                .writerNickname(new Nickname(member.getNickname()))
+                .writerNickname(member.getNickname())
                 .title("다른 게시글")
                 .content("본문")
                 .build();

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/member/repository/MemberRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/member/repository/MemberRepositoryTest.java
@@ -44,7 +44,7 @@ class MemberRepositoryTest {
         Member member = Member.builder()
                 .username(VALID_USERNAME)
                 .password(VALID_PASSWORD)
-                .nickname(VALID_NICKNAME)
+                .nickname("josh")
                 .build();
 
         assertThatThrownBy(() -> memberRepository.save(member))

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
@@ -70,7 +70,7 @@ class PostServiceTest extends IntegrationTest {
         post = Post.builder()
                 .title("제목")
                 .content("본문")
-                .writerNickname(new Nickname(member.getNickname()))
+                .writerNickname(member.getNickname())
                 .member(member)
                 .likes(new ArrayList<>())
                 .comments(new ArrayList<>())

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/MemberFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/MemberFixture.java
@@ -9,7 +9,7 @@ public class MemberFixture {
     public static final String VALID_USERNAME = "chris";
     public static final String VALID_PASSWORD = "Abcd123!@";
     public static final String VALID_ENCRYPTED_PASSWORD = "6297d64078fc9abcfe37d0e2c910d4798bb4c04502d7dd1207f558860c2b382e";
-    public static final String VALID_NICKNAME = "josh";
+    public static final String VALID_NICKNAME = "testNickname";
 
     public static final String INVALID_USERNAME = "invalidUsername";
     public static final String INVALID_PASSWORD = "invalidPassword1!";


### PR DESCRIPTION
### 구현기능
게시글 닉네임 유니크 제약조건 변경

### 세부 구현기능
기존 코드에서 회원 닉네임/ 댓글 닉네임/게시글 닉네임을 모두 같은 '닉네임' 객체를 쓰고 있었다.
그래서 유니크 제약 조건을 거니 테스트 코드가 다 깨졌다. 댓글과 게시글에서는 닉네임을 값 객체를 쓰지 않고
String으로 저장하도록 변경했다.
