### PR TITLE
fix: 게시판 드롭다운에 이모지 추가

### DIFF
--- a/frontend/src/pages/BoardPage/components/BoardCategory/index.styles.ts
+++ b/frontend/src/pages/BoardPage/components/BoardCategory/index.styles.ts
@@ -15,6 +15,7 @@ export const TitleContainer = styled.div`
   width: 12rem;
   display: flex;
   justify-content: center;
+  align-items: center;
 `;
 
 export const Title = styled.p`

--- a/frontend/src/pages/BoardPage/components/BoardCategory/index.tsx
+++ b/frontend/src/pages/BoardPage/components/BoardCategory/index.tsx
@@ -2,29 +2,31 @@ import Dropdown from '@/components/@shared/Dropdown';
 
 import * as Styled from './index.styles';
 
-interface BoardCategory {
+import { BOARDS } from '@/constants/board';
+
+interface BoardCategoryProps {
   id: string;
   boards: Board[];
 }
 
-const BoardCategory = ({ id, boards }: BoardCategory) => {
-  const currentBoard = boards.find(board => board.id === Number(id));
+const BoardCategory = ({ id, boards }: BoardCategoryProps) => {
   const boardList = boards.filter(board => board.id !== Number(id));
+
   return (
     <Styled.BoardCategoryContainer>
       <div>
         <Dropdown>
           <Dropdown.Trigger>
             <Styled.TitleContainer>
-              <Styled.Title>{currentBoard?.title}</Styled.Title>
+              <Styled.Title>{BOARDS[Number(id) - 1].title}</Styled.Title>
               <Styled.DropdownIcon />
             </Styled.TitleContainer>
           </Dropdown.Trigger>
           <Dropdown.OptionList>
             <Styled.BoardList>
-              {boardList.map(({ id, title }) => (
+              {boardList.map(({ id }) => (
                 <Styled.BoardItem key={id} to={`/board/${id}`}>
-                  {title}
+                  {BOARDS[id - 1].title}
                 </Styled.BoardItem>
               ))}
             </Styled.BoardList>


### PR DESCRIPTION
### 구현기능

<img width="318" alt="스크린샷 2022-08-04 오후 8 07 23" src="https://user-images.githubusercontent.com/52737532/182832611-b35b7fc4-7cf6-40b5-a9cc-557cb588e5ec.png">

게시판 드롭다운에 특정 게시판에 해당하는 이모지를 추가한다.

### 세부 구현기능

### 관련 이슈

close #352 
