### PR TITLE
refactor: 서비스 테스트 깨짐 해결

### DIFF
--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/IntegrationTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/IntegrationTest.java
@@ -13,7 +13,7 @@ public class IntegrationTest {
     private DatabaseCleaner databaseCleaner;
 
     @BeforeEach
-    void setUp(){
+    void cleanAndSetData(){
         databaseCleaner.clear();
         databaseCleaner.insertInitialData();
     }


### PR DESCRIPTION
### 설명
서비스 테스트 깨짐 해결

### 개선할 부분
IntegrationTest와 이를 상속받는 클래스에서 @BeforeEach 메서드명이 같아 override됨
- [ ] IntegrationTest의 @BeforeEach 메서드명 변경