### PR TITLE
feat: 신고 처리된 게시글 제목과 본문 가려서 반환

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -34,6 +34,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class Post {
 
     private static final int BLOCKED_CONDITION = 5;
+    private static final String BLIND_MESSAGE = "블라인드 처리된 글입니다";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -139,14 +140,14 @@ public class Post {
 
     public String getTitle() {
         if (isBlocked()) {
-            return "블라인드 처리된 글입니다";
+            return BLIND_MESSAGE;
         }
         return title.getValue();
     }
 
     public String getContent() {
         if (isBlocked()) {
-            return "블라인드 처리된 글입니다";
+            return BLIND_MESSAGE;
         }
         return content.getValue();
     }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -138,10 +138,16 @@ public class Post {
     }
 
     public String getTitle() {
+        if (isBlocked()) {
+            return "블라인드 처리된 글입니다";
+        }
         return title.getValue();
     }
 
     public String getContent() {
+        if (isBlocked()) {
+            return "블라인드 처리된 글입니다";
+        }
         return content.getValue();
     }
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostDetailResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostDetailResponse.java
@@ -35,10 +35,10 @@ public class PostDetailResponse {
                                boolean like, boolean authorized, boolean modified) {
         this.id = id;
         this.boardId = boardId;
+        this.blocked = blocked;
         this.nickname = nickname;
         this.title = title;
         this.content = content;
-        this.blocked = blocked;
         this.hashtags = hashtagResponses;
         this.createdAt = createdAt;
         this.likeCount = likeCount;
@@ -50,7 +50,7 @@ public class PostDetailResponse {
 
     public static PostDetailResponse of(Post post, PostBoard postBoard, boolean liked,
                                         boolean authorized, Hashtags hashtags) {
-        return PostDetailResponse.builder()
+        PostDetailResponse postDetailResponse = PostDetailResponse.builder()
                 .id(post.getId())
                 .boardId(postBoard.getBoard().getId())
                 .nickname(post.getNickname())
@@ -64,6 +64,16 @@ public class PostDetailResponse {
                 .hashtagResponses(toResponse(hashtags))
                 .modified(post.isModified())
                 .build();
+
+        if (post.isBlocked()) {
+            postDetailResponse.blind();
+        }
+        return postDetailResponse;
+    }
+
+    private void blind() {
+        this.title = "블라인드 처리된 글입니다";
+        this.content = "블라인드 처리된 글입니다";
     }
 
     private static List<HashtagResponse> toResponse(Hashtags hashtags) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostDetailResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostDetailResponse.java
@@ -50,7 +50,7 @@ public class PostDetailResponse {
 
     public static PostDetailResponse of(Post post, PostBoard postBoard, boolean liked,
                                         boolean authorized, Hashtags hashtags) {
-        PostDetailResponse postDetailResponse = PostDetailResponse.builder()
+        return PostDetailResponse.builder()
                 .id(post.getId())
                 .boardId(postBoard.getBoard().getId())
                 .nickname(post.getNickname())
@@ -64,16 +64,6 @@ public class PostDetailResponse {
                 .hashtagResponses(toResponse(hashtags))
                 .modified(post.isModified())
                 .build();
-
-        if (post.isBlocked()) {
-            postDetailResponse.blind();
-        }
-        return postDetailResponse;
-    }
-
-    private void blind() {
-        this.title = "블라인드 처리된 글입니다";
-        this.content = "블라인드 처리된 글입니다";
     }
 
     private static List<HashtagResponse> toResponse(Hashtags hashtags) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostsElementResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostsElementResponse.java
@@ -31,7 +31,7 @@ public class PostsElementResponse {
     }
 
     public static PostsElementResponse from(Post post) {
-        PostsElementResponse postsElementResponse = PostsElementResponse.builder()
+        return PostsElementResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
@@ -41,15 +41,5 @@ public class PostsElementResponse {
                 .modified(post.isModified())
                 .blocked(post.isBlocked())
                 .build();
-
-        if (postsElementResponse.isBlocked()) {
-            postsElementResponse.blind();
-        }
-        return postsElementResponse;
-    }
-
-    private void blind() {
-        this.title = "블라인드 처리된 글입니다";
-        this.content = "블라인드 처리된 글입니다";
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostsElementResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/PostsElementResponse.java
@@ -8,14 +8,14 @@ import lombok.Getter;
 @Getter
 public class PostsElementResponse {
 
-    private final Long id;
-    private final String title;
-    private final String content;
-    private final LocalDateTime createdAt;
-    private final int likeCount;
-    private final int commentCount;
-    private final boolean modified;
-    private final boolean blocked;
+    private Long id;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private int likeCount;
+    private int commentCount;
+    private boolean modified;
+    private boolean blocked;
 
     @Builder
     private PostsElementResponse(Long id, String title, String content, LocalDateTime createdAt,
@@ -31,7 +31,7 @@ public class PostsElementResponse {
     }
 
     public static PostsElementResponse from(Post post) {
-        return PostsElementResponse.builder()
+        PostsElementResponse postsElementResponse = PostsElementResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
@@ -41,5 +41,15 @@ public class PostsElementResponse {
                 .modified(post.isModified())
                 .blocked(post.isBlocked())
                 .build();
+
+        if (postsElementResponse.isBlocked()) {
+            postsElementResponse.blind();
+        }
+        return postsElementResponse;
+    }
+
+    private void blind() {
+        this.title = "블라인드 처리된 글입니다";
+        this.content = "블라인드 처리된 글입니다";
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
@@ -88,7 +88,7 @@ class PostAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    @DisplayName("특정 게시판의 게시글을 조회할때 누적신고 5개 이상인 게시글은 block된다.")
+    @DisplayName("특정 게시판의 게시글 목록을 조회할때 누적신고 5개 이상인 게시글은 block된다.")
     @Test
     void findPosts_Block() {
         Long blockedPostId = addPostAndGetPostId();
@@ -109,7 +109,32 @@ class PostAcceptanceTest extends AcceptanceTest {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(postsElementResponses.get(0).isBlocked()).isFalse(),
-                () -> assertThat(postsElementResponses.get(1).isBlocked()).isTrue()
+                () -> assertThat(postsElementResponses.get(1).isBlocked()).isTrue(),
+                () -> assertThat(postsElementResponses.get(1).getTitle()).isEqualTo("블라인드 처리된 글입니다"),
+                () -> assertThat(postsElementResponses.get(1).getContent()).isEqualTo("블라인드 처리된 글입니다")
+        );
+    }
+
+    @DisplayName("특정 게시글을 조회할때 누적신고 5개 이상인 게시글은 block된다.")
+    @Test
+    void findPost_Block() {
+        Long blockedPostId = addPostAndGetPostId();
+        List<String> tokens = getTokensForReport();
+        for (int i = 0; i < 5; ++i) {
+            ReportRequest reportRequest = new ReportRequest("신고");
+            httpPostWithAuthorization(reportRequest, "/posts/" + blockedPostId + "/report", tokens.get(i));
+        }
+
+        ExtractableResponse<Response> response = httpGet(
+                "/posts/" + blockedPostId);
+        PostDetailResponse postDetailResponse = response
+                .jsonPath()
+                .getObject(".", PostDetailResponse.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(postDetailResponse.isBlocked()).isTrue(),
+                () -> assertThat(postDetailResponse.getTitle()).isEqualTo("블라인드 처리된 글입니다"),
+                () -> assertThat(postDetailResponse.getContent()).isEqualTo("블라인드 처리된 글입니다")
         );
     }
 


### PR DESCRIPTION
### 구현기능
신고 처리된 게시글 제목과 본문 가려서 반환

### 세부 구현기능
데이터베이스에서는 변환될 필요가 없으므로 뷰의 로직이라고 생각했습니다. 따라서 Dto에서 신고 여부에 따라 변환해서 값을 반환합니다. 

### 관련 이슈
