### PR TITLE
feat: 프로필에서 내가 쓴 글 보기 #392

### DIFF
--- a/backend/sokdak/src/docs/asciidoc/index.adoc
+++ b/backend/sokdak/src/docs/asciidoc/index.adoc
@@ -175,3 +175,10 @@ operation::member/patch/nickname/success[snippets='http-request,http-response']
 operation::member/patch/nickname/fail/duplicate[snippets='http-request,http-response']
 ===== 잘못된 형식인 경우
 operation::member/patch/nickname/fail/invalidFormat[snippets='http-request,http-response']
+
+=== 내가 쓴 글 조회
+==== 성공
+===== 해당 페이지의 글이 존재할 경우
+operation::member/find/posts/success/postIn[snippets='http-request,http-response']
+===== 해당 페이지의 글이 없을 경우
+operation::member/find/posts/success/noPost[snippets='http-request,http-response']

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/repository/PostRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/repository/PostRepository.java
@@ -1,6 +1,8 @@
 package com.wooteco.sokdak.post.repository;
 
+import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.post.domain.Post;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +12,6 @@ import org.springframework.stereotype.Repository;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     Slice<Post> findSliceBy(Pageable pageable);
+
+    Page<Post> findPostsByMemberOrderByCreatedAtDesc(Pageable pageable, Member member);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/profile/controller/ProfileController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/profile/controller/ProfileController.java
@@ -29,7 +29,7 @@ public class ProfileController {
         return ResponseEntity.ok(nicknameResponse);
     }
 
-    @PatchMapping ("/members/nickname")
+    @PatchMapping("/members/nickname")
     public ResponseEntity<Void> editNickname(@RequestBody NicknameUpdateRequest nicknameUpdateRequest,
                                              @Login AuthInfo authInfo) {
         profileService.editNickname(nicknameUpdateRequest, authInfo);

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/profile/controller/ProfileController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/profile/controller/ProfileController.java
@@ -1,10 +1,13 @@
 package com.wooteco.sokdak.profile.controller;
 
 import com.wooteco.sokdak.auth.dto.AuthInfo;
-import com.wooteco.sokdak.profile.dto.NicknameUpdateRequest;
+import com.wooteco.sokdak.profile.dto.MyPostsResponse;
 import com.wooteco.sokdak.profile.dto.NicknameResponse;
+import com.wooteco.sokdak.profile.dto.NicknameUpdateRequest;
 import com.wooteco.sokdak.profile.service.ProfileService;
 import com.wooteco.sokdak.support.token.Login;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -26,10 +29,17 @@ public class ProfileController {
         return ResponseEntity.ok(nicknameResponse);
     }
 
-    @PatchMapping("/members/nickname")
+    @PatchMapping ("/members/nickname")
     public ResponseEntity<Void> editNickname(@RequestBody NicknameUpdateRequest nicknameUpdateRequest,
                                              @Login AuthInfo authInfo) {
         profileService.editNickname(nicknameUpdateRequest, authInfo);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping(path = "/posts/me", params = {"size", "page"})
+    public ResponseEntity<MyPostsResponse> searchMyPost(@PageableDefault Pageable pageable,
+                                                        @Login AuthInfo authInfo) {
+        MyPostsResponse myPosts = profileService.findMyPosts(pageable, authInfo);
+        return ResponseEntity.ok(myPosts);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/profile/dto/MyPostsResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/profile/dto/MyPostsResponse.java
@@ -1,7 +1,9 @@
 package com.wooteco.sokdak.profile.dto;
 
+import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.dto.PostsElementResponse;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Getter;
 
 @Getter
@@ -16,5 +18,12 @@ public class MyPostsResponse {
     public MyPostsResponse(List<PostsElementResponse> posts, int totalPageCount) {
         this.posts = posts;
         this.totalPageCount = totalPageCount;
+    }
+
+    public static MyPostsResponse ofPosts(List<Post> posts, int totalPageCount) {
+        List<PostsElementResponse> postsElementResponses = posts.stream()
+                .map(PostsElementResponse::from)
+                .collect(Collectors.toList());
+        return new MyPostsResponse(postsElementResponses, totalPageCount);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/profile/dto/MyPostsResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/profile/dto/MyPostsResponse.java
@@ -1,0 +1,20 @@
+package com.wooteco.sokdak.profile.dto;
+
+import com.wooteco.sokdak.post.dto.PostsElementResponse;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class MyPostsResponse {
+
+    private List<PostsElementResponse> posts;
+    private int totalPageCount;
+
+    public MyPostsResponse() {
+    }
+
+    public MyPostsResponse(List<PostsElementResponse> posts, int totalPageCount) {
+        this.posts = posts;
+        this.totalPageCount = totalPageCount;
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/profile/service/ProfileService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/profile/service/ProfileService.java
@@ -5,10 +5,14 @@ import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.domain.Nickname;
 import com.wooteco.sokdak.member.exception.MemberNotFoundException;
 import com.wooteco.sokdak.member.repository.MemberRepository;
-import com.wooteco.sokdak.profile.dto.NicknameUpdateRequest;
+import com.wooteco.sokdak.post.domain.Post;
+import com.wooteco.sokdak.post.repository.PostRepository;
+import com.wooteco.sokdak.profile.dto.MyPostsResponse;
 import com.wooteco.sokdak.profile.dto.NicknameResponse;
+import com.wooteco.sokdak.profile.dto.NicknameUpdateRequest;
 import com.wooteco.sokdak.profile.exception.DuplicateNicknameException;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,9 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProfileService {
 
     public MemberRepository memberRepository;
+    public PostRepository postRepository;
 
-    public ProfileService(MemberRepository memberRepository) {
+    public ProfileService(MemberRepository memberRepository,
+                          PostRepository postRepository) {
         this.memberRepository = memberRepository;
+        this.postRepository = postRepository;
     }
 
     @Transactional
@@ -42,5 +49,12 @@ public class ProfileService {
         Member member = memberRepository.findById(authInfo.getId())
                 .orElseThrow(MemberNotFoundException::new);
         return NicknameResponse.of(member);
+    }
+
+    public MyPostsResponse findMyPosts(Pageable pageable, AuthInfo authInfo) {
+        Member member = memberRepository.findById(authInfo.getId())
+                .orElseThrow(MemberNotFoundException::new);
+        Page<Post> posts = postRepository.findPostsByMemberOrderByCreatedAtDesc(pageable, member);
+        return MyPostsResponse.ofPosts(posts.getContent(), posts.getTotalPages());
     }
 }

--- a/backend/sokdak/src/main/resources/static/index.html
+++ b/backend/sokdak/src/main/resources/static/index.html
@@ -502,8 +502,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_신고">9. 신고</a></li>
 <li><a href="#_프로필">10. 프로필</a>
 <ul class="sectlevel2">
-<li><a href="#_닉네임_검색">10.1. 닉네임 검색</a></li>
+<li><a href="#_닉네임_조회">10.1. 닉네임 조회</a></li>
 <li><a href="#_닉네임_변경">10.2. 닉네임 변경</a></li>
+<li><a href="#_내가_쓴_글_조회">10.3. 내가 쓴 글 조회</a></li>
 </ul>
 </li>
 </ul>
@@ -1439,14 +1440,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 462
+Content-Length: 463
 
 {
   "posts" : [ {
     "id" : 1,
     "title" : "제목1",
     "content" : "본문1",
-    "createdAt" : "2022-08-09T17:29:13.615401",
+    "createdAt" : "2022-08-09T22:09:28.881022",
     "likeCount" : 0,
     "commentCount" : 0,
     "modified" : false,
@@ -1455,7 +1456,7 @@ Content-Length: 462
     "id" : 2,
     "title" : "제목2",
     "content" : "본문2",
-    "createdAt" : "2022-08-09T17:29:13.61543",
+    "createdAt" : "2022-08-09T22:09:28.881074",
     "likeCount" : 0,
     "commentCount" : 0,
     "modified" : false,
@@ -1492,7 +1493,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 311
+Content-Length: 312
 
 {
   "id" : 1,
@@ -1505,7 +1506,7 @@ Content-Length: 311
     "id" : 1,
     "name" : "gogo"
   } ],
-  "createdAt" : "2022-08-09T17:29:13.83979",
+  "createdAt" : "2022-08-09T22:09:29.094193",
   "likeCount" : 0,
   "like" : false,
   "authorized" : true,
@@ -1836,14 +1837,14 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 415
+Content-Length: 416
 
 {
   "comments" : [ {
     "id" : 1,
     "nickname" : "조시1",
     "content" : "댓글1",
-    "createdAt" : "2022-08-09T17:28:58.52939",
+    "createdAt" : "2022-08-09T22:09:13.790534",
     "blocked" : false,
     "postWriter" : false,
     "authorized" : false
@@ -1851,7 +1852,7 @@ Content-Length: 415
     "id" : 2,
     "nickname" : "조시2",
     "content" : "댓글2",
-    "createdAt" : "2022-08-09T17:28:58.529419",
+    "createdAt" : "2022-08-09T22:09:13.790575",
     "blocked" : false,
     "postWriter" : true,
     "authorized" : false
@@ -2047,7 +2048,7 @@ Content-Length: 143
 <h2 id="_프로필"><a class="link" href="#_프로필">10. 프로필</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_닉네임_검색"><a class="link" href="#_닉네임_검색">10.1. 닉네임 검색</a></h3>
+<h3 id="_닉네임_조회"><a class="link" href="#_닉네임_조회">10.1. 닉네임 조회</a></h3>
 <div class="sect3">
 <h4 id="_성공_20"><a class="link" href="#_성공_20">10.1.1. 성공</a></h4>
 <div class="sect4">
@@ -2057,6 +2058,7 @@ Content-Length: 143
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/nickname HTTP/1.1
 Content-Type: application/json
 Content-Type: application/json
+Authorization: Bearer chris
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2068,7 +2070,13 @@ Host: localhost:8080</code></pre>
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Vary: Origin
 Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers</code></pre>
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 34
+
+{
+  "nickname" : "chrisNickname"
+}</code></pre>
 </div>
 </div>
 </div>
@@ -2185,13 +2193,103 @@ Content-Length: 56
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_내가_쓴_글_조회"><a class="link" href="#_내가_쓴_글_조회">10.3. 내가 쓴 글 조회</a></h3>
+<div class="sect3">
+<h4 id="_성공_22"><a class="link" href="#_성공_22">10.3.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_해당_페이지의_글이_존재할_경우"><a class="link" href="#_해당_페이지의_글이_존재할_경우">해당 페이지의 글이 존재할 경우</a></h5>
+<div class="sect5">
+<h6 id="_해당_페이지의_글이_존재할_경우_http_request"><a class="link" href="#_해당_페이지의_글이_존재할_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /posts/me?size=2&amp;page=0 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: Bearer any
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_해당_페이지의_글이_존재할_경우_http_response"><a class="link" href="#_해당_페이지의_글이_존재할_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 463
+
+{
+  "posts" : [ {
+    "id" : 2,
+    "title" : "제목2",
+    "content" : "본문2",
+    "createdAt" : "2022-08-09T22:09:06.919439",
+    "likeCount" : 0,
+    "commentCount" : 0,
+    "modified" : false,
+    "blocked" : false
+  }, {
+    "id" : 1,
+    "title" : "제목",
+    "content" : "본문",
+    "createdAt" : "2022-08-09T22:09:06.91936",
+    "likeCount" : 0,
+    "commentCount" : 0,
+    "modified" : false,
+    "blocked" : false
+  } ],
+  "totalPageCount" : 5
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_해당_페이지의_글이_없을_경우"><a class="link" href="#_해당_페이지의_글이_없을_경우">해당 페이지의 글이 없을 경우</a></h5>
+<div class="sect5">
+<h6 id="_해당_페이지의_글이_없을_경우_http_request"><a class="link" href="#_해당_페이지의_글이_없을_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /posts/me?size=2&amp;page=99 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: Bearer any
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_해당_페이지의_글이_없을_경우_http_response"><a class="link" href="#_해당_페이지의_글이_없을_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 43
+
+{
+  "posts" : [ ],
+  "totalPageCount" : 5
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-08-09 17:23:47 +0900
+Last updated 2022-08-09 21:52:32 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/repository/PostRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/repository/PostRepositoryTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 
@@ -37,7 +38,7 @@ class PostRepositoryTest extends RepositoryTest {
     void setUp() {
         member = memberRepository
                 .findByUsernameValueAndPasswordValue(Encryptor.encrypt(VALID_USERNAME), VALID_ENCRYPTED_PASSWORD)
-                .get();
+                .orElseThrow();
 
         post1 = Post.builder()
                 .title("제목1")
@@ -97,8 +98,19 @@ class PostRepositoryTest extends RepositoryTest {
     @Test
     void findPostWithMember() {
         Post foundPost = postRepository.findById(post1.getId())
-                .get();
+                .orElseThrow();
 
         assertThat(foundPost.getMember()).isNotNull();
+    }
+
+    @DisplayName("특점 멤버의 글을 시간순으로 가져오는지 확인")
+    @Test
+    void findPostsByMember() {
+        Page<Post> result = postRepository.findPostsByMemberOrderByCreatedAtDesc(PageRequest.of(0, 2), member);
+
+        assertAll(
+                () -> assertThat(result.getContent()).containsExactly(post5,post4),
+                () -> assertThat(result.getTotalPages()).isEqualTo(3)
+        );
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/profile/acceptance/ProfileAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/profile/acceptance/ProfileAcceptanceTest.java
@@ -14,14 +14,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.wooteco.sokdak.auth.dto.LoginRequest;
-import com.wooteco.sokdak.profile.dto.NicknameResponse;
-import com.wooteco.sokdak.profile.dto.NicknameUpdateRequest;
-import com.wooteco.sokdak.util.AcceptanceTest;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
-import com.wooteco.sokdak.profile.dto.EditedNicknameRequest;
 import com.wooteco.sokdak.profile.dto.MyPostsResponse;
 import com.wooteco.sokdak.profile.dto.NicknameResponse;
+import com.wooteco.sokdak.profile.dto.NicknameUpdateRequest;
 import com.wooteco.sokdak.util.AcceptanceTest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -31,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 public class ProfileAcceptanceTest extends AcceptanceTest {
+
+    private static final String WRONG_PAGE = "5";
 
     @DisplayName("닉네임을 수정할 수 있다.")
     @Test
@@ -91,7 +88,7 @@ public class ProfileAcceptanceTest extends AcceptanceTest {
         httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, token);
         httpPostWithAuthorization(NEW_POST_REQUEST2, CREATE_POST_URI, token);
 
-        ExtractableResponse<Response> response = httpGetWithAuthorization("/posts/me?size=3&page=5", token);
+        ExtractableResponse<Response> response = httpGetWithAuthorization("/posts/me?size=3&page=" + WRONG_PAGE, token);
         MyPostsResponse postsResponse = toMyPostsResponse(response);
 
         assertAll(

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/profile/acceptance/ProfileAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/profile/acceptance/ProfileAcceptanceTest.java
@@ -3,6 +3,12 @@ package com.wooteco.sokdak.profile.acceptance;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpGetWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPatchWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPost;
+import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPostWithAuthorization;
+import static com.wooteco.sokdak.util.fixture.PostFixture.CREATE_POST_URI;
+import static com.wooteco.sokdak.util.fixture.PostFixture.NEW_POST_REQUEST;
+import static com.wooteco.sokdak.util.fixture.PostFixture.NEW_POST_REQUEST2;
+import static com.wooteco.sokdak.util.fixture.PostFixture.POSTS_ELEMENT_RESPONSE_1;
+import static com.wooteco.sokdak.util.fixture.PostFixture.POSTS_ELEMENT_RESPONSE_2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -13,6 +19,13 @@ import com.wooteco.sokdak.profile.dto.NicknameUpdateRequest;
 import com.wooteco.sokdak.util.AcceptanceTest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import com.wooteco.sokdak.profile.dto.EditedNicknameRequest;
+import com.wooteco.sokdak.profile.dto.MyPostsResponse;
+import com.wooteco.sokdak.profile.dto.NicknameResponse;
+import com.wooteco.sokdak.util.AcceptanceTest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -52,6 +65,42 @@ public class ProfileAcceptanceTest extends AcceptanceTest {
         );
     }
 
+    @DisplayName("내가 쓴 글을 볼 수 있다.")
+    @Test
+    void searchMyPosts() {
+        String token = getToken();
+        httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, token);
+        httpPostWithAuthorization(NEW_POST_REQUEST2, CREATE_POST_URI, token);
+
+        ExtractableResponse<Response> response = httpGetWithAuthorization("/posts/me?size=3&page=0", token);
+        MyPostsResponse myPostsResponse = toMyPostsResponse(response);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(myPostsResponse.getPosts().size()).isEqualTo(2),
+                () -> assertThat(myPostsResponse.getPosts()).usingRecursiveComparison()
+                        .comparingOnlyFields("title", "content")
+                        .isEqualTo(List.of(POSTS_ELEMENT_RESPONSE_2, POSTS_ELEMENT_RESPONSE_1))
+        );
+    }
+
+    @DisplayName("내가 쓴 글을 조회 시 잘못된 페이지로 접근하면 0개의 글이 조회되고 1개의 페이지가 카운트된다")
+    @Test
+    void searchMyPosts_Exception_NoPage() {
+        String token = getToken();
+        httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, token);
+        httpPostWithAuthorization(NEW_POST_REQUEST2, CREATE_POST_URI, token);
+
+        ExtractableResponse<Response> response = httpGetWithAuthorization("/posts/me?size=3&page=5", token);
+        MyPostsResponse postsResponse = toMyPostsResponse(response);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(postsResponse.getPosts()).isEmpty(),
+                () -> assertThat(postsResponse.getTotalPageCount()).isEqualTo(1)
+        );
+    }
+
     private String getToken() {
         LoginRequest loginRequest = new LoginRequest("chris", "Abcd123!@");
         return httpPost(loginRequest, "/login").header(AUTHORIZATION);
@@ -61,5 +110,11 @@ public class ProfileAcceptanceTest extends AcceptanceTest {
         return getWithAuthorization.body()
                 .jsonPath()
                 .getObject(".", NicknameResponse.class);
+    }
+
+    private MyPostsResponse toMyPostsResponse(ExtractableResponse<Response> response) {
+        return response.body()
+                .jsonPath()
+                .getObject(".", MyPostsResponse.class);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/profile/controller/ProfileControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/profile/controller/ProfileControllerTest.java
@@ -1,6 +1,8 @@
 package com.wooteco.sokdak.profile.controller;
 
 import static com.wooteco.sokdak.util.fixture.MemberFixture.AUTH_INFO;
+import static com.wooteco.sokdak.util.fixture.PostFixture.POSTS_ELEMENT_RESPONSE_1;
+import static com.wooteco.sokdak.util.fixture.PostFixture.POSTS_ELEMENT_RESPONSE_2;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.doNothing;
@@ -10,17 +12,23 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 
 import com.wooteco.sokdak.member.exception.InvalidNicknameException;
-import com.wooteco.sokdak.profile.dto.NicknameUpdateRequest;
+import com.wooteco.sokdak.profile.dto.MyPostsResponse;
 import com.wooteco.sokdak.profile.dto.NicknameResponse;
+import com.wooteco.sokdak.profile.dto.NicknameUpdateRequest;
 import com.wooteco.sokdak.profile.exception.DuplicateNicknameException;
 import com.wooteco.sokdak.util.ControllerTest;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 public class ProfileControllerTest extends ControllerTest {
+
+    private static final int WRONG_PAGE = 99;
 
     @BeforeEach
     void setUpArgumentResolver() {
@@ -37,7 +45,7 @@ public class ProfileControllerTest extends ControllerTest {
     void findNickname() {
         doReturn(new NicknameResponse("chrisNickname"))
                 .when(profileService)
-                .findNickname(refEq(AUTH_INFO));
+                .findNickname(any());
 
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -104,5 +112,44 @@ public class ProfileControllerTest extends ControllerTest {
                 .assertThat()
                 .apply(document("member/patch/nickname/fail/invalidFormat"))
                 .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("내가 쓴 글 조회 시 200 반환")
+    @Test
+    void searchMyPosts() {
+        PageRequest pageRequest = PageRequest.of(0, 2);
+        MyPostsResponse myPostsResponse = new MyPostsResponse(
+                List.of(POSTS_ELEMENT_RESPONSE_2, POSTS_ELEMENT_RESPONSE_1),
+                5);
+        doReturn(myPostsResponse)
+                .when(profileService)
+                .findMyPosts(refEq(pageRequest), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(AUTHORIZATION, "Bearer any")
+                .when().get("/posts/me?size=2&page=0")
+                .then().log().all()
+                .assertThat()
+                .apply(document("member/find/posts/success/postIn"))
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @DisplayName("내가 쓴 글의 없는 페이지 조회 시 200 반환")
+    @Test
+    void searchMyPosts_Exception_NoPage() {
+        PageRequest pageRequest = PageRequest.of(WRONG_PAGE, 2);
+        doReturn(new MyPostsResponse(Collections.emptyList(), 5))
+                .when(profileService)
+                .findMyPosts(refEq(pageRequest), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(AUTHORIZATION, "Bearer any")
+                .when().get("/posts/me?size=2&page=" + WRONG_PAGE)
+                .then().log().all()
+                .assertThat()
+                .apply(document("member/find/posts/success/noPost"))
+                .statusCode(HttpStatus.OK.value());
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/profile/service/ProfileServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/profile/service/ProfileServiceTest.java
@@ -3,16 +3,25 @@ package com.wooteco.sokdak.profile.service;
 import static com.wooteco.sokdak.util.fixture.MemberFixture.AUTH_INFO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.exception.InvalidNicknameException;
+import com.wooteco.sokdak.member.exception.MemberNotFoundException;
 import com.wooteco.sokdak.member.repository.MemberRepository;
+import com.wooteco.sokdak.post.domain.Post;
+import com.wooteco.sokdak.post.dto.PostsElementResponse;
+import com.wooteco.sokdak.post.repository.PostRepository;
+import com.wooteco.sokdak.profile.dto.MyPostsResponse;
 import com.wooteco.sokdak.profile.dto.NicknameUpdateRequest;
 import com.wooteco.sokdak.profile.exception.DuplicateNicknameException;
 import com.wooteco.sokdak.util.IntegrationTest;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 
 class ProfileServiceTest extends IntegrationTest {
 
@@ -21,6 +30,12 @@ class ProfileServiceTest extends IntegrationTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    private static final int WRONG_PAGE = 99;
+
 
     @DisplayName("닉네임 수정 기능")
     @Test
@@ -37,7 +52,7 @@ class ProfileServiceTest extends IntegrationTest {
     void editNickname_Exception_Duplicate() {
         NicknameUpdateRequest nicknameUpdateRequest = new NicknameUpdateRequest("hunchNickname");
 
-        assertThatThrownBy(() -> profileService.editNickname(nicknameUpdateRequest,AUTH_INFO))
+        assertThatThrownBy(() -> profileService.editNickname(nicknameUpdateRequest, AUTH_INFO))
                 .isInstanceOf(DuplicateNicknameException.class);
     }
 
@@ -46,7 +61,58 @@ class ProfileServiceTest extends IntegrationTest {
     void editNickname_Exception_InvalidFormat() {
         NicknameUpdateRequest nicknameUpdateRequest = new NicknameUpdateRequest("");
 
-        assertThatThrownBy(() -> profileService.editNickname(nicknameUpdateRequest,AUTH_INFO))
+        assertThatThrownBy(() -> profileService.editNickname(nicknameUpdateRequest, AUTH_INFO))
                 .isInstanceOf(InvalidNicknameException.class);
+    }
+
+    @DisplayName("내가 쓴 글 조회 기능")
+    @Test
+    void findMyPosts() {
+        Member member = memberRepository.findById(AUTH_INFO.getId())
+                .orElseThrow(MemberNotFoundException::new);
+        Post post1 = Post.builder()
+                .title("제목")
+                .content("본문")
+                .member(member)
+                .build();
+        postRepository.save(post1);
+        Post post2 = Post.builder()
+                .title("제목2")
+                .content("본문2")
+                .member(member)
+                .build();
+        postRepository.save(post2);
+
+        MyPostsResponse myPosts = profileService.findMyPosts(PageRequest.of(0, 1), AUTH_INFO);
+
+        assertAll(
+                () -> assertThat(myPosts.getPosts()).usingRecursiveComparison()
+                        .comparingOnlyFields("title", "content")
+                        .isEqualTo(List.of(PostsElementResponse.from(post2))),
+                () -> assertThat(myPosts.getTotalPageCount()).isEqualTo(2)
+        );
+    }
+
+    @DisplayName("없는 페이지로 요청이 올 시 빈 배열 반환")
+    @Test
+    void findMyPosts_Exception_WrongPage() {
+        Member member = memberRepository.findById(AUTH_INFO.getId())
+                .orElseThrow(MemberNotFoundException::new);
+        Post post = Post.builder()
+                .title("제목")
+                .content("본문")
+                .writerNickname(member.getNickname())
+                .member(member)
+                .likes(new ArrayList<>())
+                .comments(new ArrayList<>())
+                .build();
+        postRepository.save(post);
+
+        MyPostsResponse myPosts = profileService.findMyPosts(PageRequest.of(WRONG_PAGE, 3), AUTH_INFO);
+
+        assertAll(
+                () -> assertThat(myPosts.getPosts()).hasSize(0),
+                () -> assertThat(myPosts.getTotalPageCount()).isEqualTo(1)
+        );
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/PostFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/PostFixture.java
@@ -4,6 +4,8 @@ import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPostWithAuth
 import static com.wooteco.sokdak.util.fixture.ReportFixture.getToken;
 
 import com.wooteco.sokdak.post.dto.NewPostRequest;
+import com.wooteco.sokdak.post.dto.PostsElementResponse;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
@@ -22,8 +24,29 @@ public class PostFixture {
     public static final String INVALID_POST_TITLE = "A".repeat(51);
     public static final String INVALID_POST_CONTENT = "A".repeat(5001);
 
+    public static final PostsElementResponse POSTS_ELEMENT_RESPONSE_1 = PostsElementResponse.builder()
+            .id(1L)
+            .title("제목")
+            .content("본문")
+            .createdAt(LocalDateTime.now())
+            .likeCount(0)
+            .commentCount(0)
+            .modified(false)
+            .build();
+    public static final PostsElementResponse POSTS_ELEMENT_RESPONSE_2 = PostsElementResponse.builder()
+            .id(2L)
+            .title("제목2")
+            .content("본문2")
+            .createdAt(LocalDateTime.now())
+            .likeCount(0)
+            .commentCount(0)
+            .modified(false)
+            .build();
+
     public static final NewPostRequest NEW_POST_REQUEST =
             new NewPostRequest("제목", "본문", false, List.of("태그1", "태그2"));
+    public static final NewPostRequest NEW_POST_REQUEST2 =
+            new NewPostRequest("제목2", "본문2", false, List.of("태그1", "태그2"));
 
     public static Long addPostAndGetPostId() {
         NewPostRequest newPostRequest = new NewPostRequest(VALID_POST_TITLE, VALID_POST_CONTENT, false,


### PR DESCRIPTION
### 구현기능

프로필 페이지에서 내가 쓴 글 목록을 조회할 수 있다.
resolved: #392 

### 세부 구현기능
- [x] 내가 쓴 글들 목록을 생성시간 내림차순으로 볼 수 있다.
- [x] 작성글이 없는 경우 총 1페이지로 나온다
- [x] 잘못된 페이지로 이동한 경우 총 페이지 수는 그대로 나오며, 빈 목록이 조회된다.

### 관련 이슈
