### PR TITLE
feat: 대댓글 기능 구현

### DIFF
--- a/frontend/src/constants/queries.ts
+++ b/frontend/src/constants/queries.ts
@@ -20,6 +20,7 @@ export const MUTATION_KEY = {
   REPORT_COMMENT: 'report-comment',
   DELETE_COMMENT: 'delete-comment',
   POST_COMMENT: 'post-comment',
+  CREATE_REPLY: 'create-reply',
 };
 
 export default QUERY_KEYS;

--- a/frontend/src/constants/scroll.ts
+++ b/frontend/src/constants/scroll.ts
@@ -1,0 +1,6 @@
+const SCROLL = {
+  COMMENT_HEIGHT: 100,
+  REPLY_FORM_HEIGHT: 150,
+};
+
+export default SCROLL;

--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -5,7 +5,7 @@ export const postList: Post[] = [
     createdAt: '2022-07-19T19:55:31.016376300',
     content: '날씨는 참 좋네요.',
     likeCount: 19,
-    commentCount: 16,
+    commentCount: 18,
     like: false,
     modified: false,
     hashtags: [
@@ -360,6 +360,7 @@ interface CommentListType extends CommentType {
   postId: number;
   blocked: boolean;
   postWriter: boolean;
+  replies: Omit<CommentListType, 'replies' | 'postId'>[];
 }
 
 export const commentList: CommentListType[] = [
@@ -373,6 +374,26 @@ export const commentList: CommentListType[] = [
     authorized: true,
     blocked: false,
     postWriter: true,
+    replies: [
+      {
+        id: 17,
+        nickname: '테스트 계정',
+        content: '비가 너무 많이 오네요 ~',
+        createdAt: '2022-08-09T07:55:31.016376300',
+        authorized: true,
+        postWriter: true,
+        blocked: false,
+      },
+      {
+        id: 18,
+        nickname: '신난 리액트',
+        content: '재택 계속 해줘 ~ ',
+        createdAt: '2022-08-09T08:55:31.016376300',
+        authorized: true,
+        postWriter: true,
+        blocked: false,
+      },
+    ],
   },
   {
     id: 2,
@@ -383,6 +404,7 @@ export const commentList: CommentListType[] = [
     authorized: true,
     blocked: false,
     postWriter: true,
+    replies: [],
   },
   {
     id: 3,
@@ -393,6 +415,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: true,
     postWriter: false,
+    replies: [],
   },
   {
     id: 4,
@@ -403,6 +426,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    replies: [],
   },
   {
     id: 5,
@@ -413,6 +437,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    replies: [],
   },
   {
     id: 6,
@@ -423,6 +448,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    replies: [],
   },
   {
     id: 7,
@@ -433,6 +459,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    replies: [],
   },
   {
     id: 8,
@@ -443,6 +470,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: true,
     postWriter: false,
+    replies: [],
   },
   {
     id: 9,
@@ -453,6 +481,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    replies: [],
   },
   {
     id: 10,
@@ -463,6 +492,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    replies: [],
   },
   {
     id: 11,
@@ -473,6 +503,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    replies: [],
   },
   {
     id: 12,
@@ -483,6 +514,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    replies: [],
   },
   {
     id: 13,
@@ -493,6 +525,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    replies: [],
   },
   {
     id: 14,
@@ -503,6 +536,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    replies: [],
   },
   {
     id: 15,
@@ -513,6 +547,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    replies: [],
   },
   {
     id: 16,
@@ -523,6 +558,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    replies: [],
   },
 ];
 

--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -5,7 +5,7 @@ export const postList: Post[] = [
     createdAt: '2022-07-19T19:55:31.016376300',
     content: '날씨는 참 좋네요.',
     likeCount: 19,
-    commentCount: 18,
+    commentCount: 19,
     like: false,
     modified: false,
     hashtags: [
@@ -410,7 +410,7 @@ export const commentList: CommentListType[] = [
     postWriter: true,
     replies: [
       {
-        id: 18,
+        id: 19,
         nickname: '신난 200',
         content: '재택 계속 해줘 ~ ',
         createdAt: '2022-08-09T08:55:31.016376300',

--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -364,7 +364,7 @@ interface CommentListType extends CommentType {
 }
 
 export const commentListTable = {
-  id: 18,
+  id: 19,
 };
 
 export const commentList: CommentListType[] = [
@@ -408,7 +408,17 @@ export const commentList: CommentListType[] = [
     authorized: true,
     blocked: false,
     postWriter: true,
-    replies: [],
+    replies: [
+      {
+        id: 18,
+        nickname: '신난 200',
+        content: '재택 계속 해줘 ~ ',
+        createdAt: '2022-08-09T08:55:31.016376300',
+        authorized: false,
+        postWriter: false,
+        blocked: false,
+      },
+    ],
   },
   {
     id: 3,

--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -358,10 +358,14 @@ export const validMemberEmail: { email: string; isSignedUp: boolean; code: strin
 
 interface CommentListType extends CommentType {
   postId: number;
-  blocked: boolean;
-  postWriter: boolean;
+  blocked: boolean | null;
+  postWriter: boolean | null;
   replies: Omit<CommentListType, 'replies' | 'postId'>[];
 }
+
+export const commentListTable = {
+  id: 18,
+};
 
 export const commentList: CommentListType[] = [
   {

--- a/frontend/src/hooks/queries/comment/useComments.ts
+++ b/frontend/src/hooks/queries/comment/useComments.ts
@@ -5,11 +5,16 @@ import { AxiosError, AxiosResponse } from 'axios';
 import authFetcher from '@/apis';
 import QUERY_KEYS from '@/constants/queries';
 
-interface CommentResponse extends CommentType {
+interface CommentList extends CommentType {
   id: number;
   blocked: boolean;
   postWriter: boolean;
-  replies: Omit<CommentResponse, 'replies'>[];
+  replies: Omit<CommentList, 'replies'>[];
+}
+
+interface CommentResponse {
+  comments: CommentList[];
+  totalCount: number;
 }
 
 const useComments = ({
@@ -17,15 +22,10 @@ const useComments = ({
   options,
 }: {
   storeCode: QueryKey;
-  options?: UseQueryOptions<
-    AxiosResponse<Record<'comments', CommentResponse[]>>,
-    AxiosError,
-    CommentResponse[],
-    QueryKey[]
-  >;
+  options?: UseQueryOptions<AxiosResponse<CommentResponse>, AxiosError, CommentResponse, QueryKey[]>;
 }) =>
   useQuery([QUERY_KEYS.COMMENTS, storeCode], ({ queryKey: [, id] }) => authFetcher.get(`/posts/${id}/comments`), {
-    select: data => data.data.comments,
+    select: data => data.data,
     ...options,
   });
 

--- a/frontend/src/hooks/queries/comment/useComments.ts
+++ b/frontend/src/hooks/queries/comment/useComments.ts
@@ -9,6 +9,7 @@ interface CommentResponse extends CommentType {
   id: number;
   blocked: boolean;
   postWriter: boolean;
+  replies: Omit<CommentResponse, 'replies'>[];
 }
 
 const useComments = ({

--- a/frontend/src/hooks/queries/comment/useCreateReply.ts
+++ b/frontend/src/hooks/queries/comment/useCreateReply.ts
@@ -1,0 +1,38 @@
+import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
+
+import { AxiosError, AxiosResponse } from 'axios';
+
+import authFetcher from '@/apis';
+import QUERY_KEYS, { MUTATION_KEY } from '@/constants/queries';
+
+interface RequestProps {
+  commentId: number | string;
+  content: string;
+  anonymous: boolean;
+}
+
+const useCreateReply = (options?: UseMutationOptions<AxiosResponse, AxiosError<ErrorResponse>, RequestProps>) => {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    ({ commentId, content, anonymous }): Promise<AxiosResponse> =>
+      authFetcher.post(`comments/${commentId}/reply`, {
+        content,
+        anonymous,
+      }),
+    {
+      ...options,
+      onSuccess: (data, variables, context) => {
+        queryClient.refetchQueries(QUERY_KEYS.COMMENTS);
+        queryClient.refetchQueries(QUERY_KEYS.POSTS);
+
+        if (options && options.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+      },
+      mutationKey: MUTATION_KEY.POST_COMMENT,
+    },
+  );
+};
+
+export default useCreateReply;

--- a/frontend/src/hooks/queries/comment/useCreateReply.ts
+++ b/frontend/src/hooks/queries/comment/useCreateReply.ts
@@ -30,7 +30,7 @@ const useCreateReply = (options?: UseMutationOptions<AxiosResponse, AxiosError<E
           options.onSuccess(data, variables, context);
         }
       },
-      mutationKey: MUTATION_KEY.POST_COMMENT,
+      mutationKey: MUTATION_KEY.CREATE_REPLY,
     },
   );
 };

--- a/frontend/src/hooks/queries/comment/useDeleteComment.ts
+++ b/frontend/src/hooks/queries/comment/useDeleteComment.ts
@@ -25,7 +25,7 @@ const useDeleteComment = (
     },
     {
       onSuccess: () => {
-        queryClient.resetQueries(QUERY_KEYS.COMMENTS);
+        queryClient.refetchQueries(QUERY_KEYS.COMMENTS);
         showSnackbar(SNACKBAR_MESSAGE.SUCCESS_DELETE_COMMENT);
       },
       mutationKey: MUTATION_KEY.DELETE_COMMENT,

--- a/frontend/src/mocks/handlers/comments/index.ts
+++ b/frontend/src/mocks/handlers/comments/index.ts
@@ -97,8 +97,6 @@ const commentHandlers = [
       }
     }
 
-    console.log(commentList);
-
     if (!isCommentExist) {
       return res(ctx.status(400), ctx.json({ message: '해당 댓글이 존재하지 않습니다.' }));
     }

--- a/frontend/src/mocks/handlers/comments/index.ts
+++ b/frontend/src/mocks/handlers/comments/index.ts
@@ -42,12 +42,14 @@ const commentHandlers = [
   }),
 
   rest.post<{ message: string }>('/comments/:id/report', (req, res, ctx) => {
-    const { id } = req.params;
+    const id = Number(req.params.id);
     const { message } = req.body;
-    if (reportCommentList.some(({ commentId }) => commentId === Number(id))) {
+
+    if (reportCommentList.some(({ commentId }) => commentId === id)) {
       return res(ctx.status(400), ctx.json({ message: '이미 신고한 댓글입니다.' }));
     }
-    reportCommentList.push({ commentId: Number(id), message });
+    reportCommentList.push({ commentId: id, message });
+
     return res(ctx.status(201));
   }),
 

--- a/frontend/src/mocks/handlers/comments/index.ts
+++ b/frontend/src/mocks/handlers/comments/index.ts
@@ -1,6 +1,6 @@
 import { rest } from 'msw';
 
-import { commentList, postList, reportCommentList } from '@/dummy';
+import { commentList, commentListTable, postList, reportCommentList } from '@/dummy';
 
 const commentHandlers = [
   rest.get('/posts/:id/comments', (req, res, ctx) => {
@@ -23,8 +23,11 @@ const commentHandlers = [
       return res(ctx.status(400), ctx.json({ message: '해당 글이 존재하지 않습니다.' }));
     }
 
+    targetPost.commentCount += 1;
+    commentListTable.id += 1;
+
     commentList.push({
-      id: commentList.length + 1,
+      id: commentListTable.id,
       content,
       createdAt: new Date().toISOString(),
       nickname: anonymous ? '짜증난 파이썬' : '테스트 계정',
@@ -34,7 +37,6 @@ const commentHandlers = [
       postWriter: targetPost.authorized,
       replies: [],
     });
-    targetPost.commentCount += 1;
 
     return res(ctx.status(204));
   }),
@@ -50,13 +52,54 @@ const commentHandlers = [
   }),
 
   rest.delete('/comments/:id', (req, res, ctx) => {
-    const { id } = req.params;
-    const targetCommentIdx = commentList.findIndex(comment => comment.id === Number(id));
+    let isCommentExist = false;
+    const id = Number(req.params.id);
 
-    if (targetCommentIdx === -1) {
+    for (const comment of commentList) {
+      const { postId } = comment;
+
+      const post = postList.find(post => post.id === postId)!;
+      post.commentCount -= 1;
+
+      if (comment.id === id && comment.replies.length > 0) {
+        comment.nickname = null;
+        comment.content = null;
+        comment.createdAt = null;
+        comment.authorized = null;
+        comment.postWriter = null;
+        comment.blocked = null;
+        isCommentExist = true;
+
+        break;
+      }
+
+      if (comment.id === id) {
+        commentList.splice(commentList.indexOf(comment), 1);
+        isCommentExist = true;
+
+        break;
+      }
+
+      for (const reply of comment.replies) {
+        if (reply.id === id) {
+          comment.replies.splice(comment.replies.indexOf(reply), 1);
+          isCommentExist = true;
+
+          break;
+        }
+      }
+
+      if (comment.replies.length <= 0 && !comment.content) {
+        commentList.splice(commentList.indexOf(comment), 1);
+
+        break;
+      }
+    }
+
+    if (!isCommentExist) {
       return res(ctx.status(400), ctx.json({ message: '해당 댓글이 존재하지 않습니다.' }));
     }
-    commentList.splice(targetCommentIdx, 1);
+
     return res(ctx.status(204));
   }),
 
@@ -68,18 +111,20 @@ const commentHandlers = [
       return res(ctx.status(400), ctx.json({ message: '대댓글은 1자 이상 255자 이하입니다.' }));
     }
 
-    const targetPost = postList.find(post => post.id === id);
+    const parentComment = commentList.find(comment => comment.id === id)!;
+    const targetPost = postList.find(post => post.id === parentComment.postId);
 
     if (!targetPost) {
       return res(ctx.status(400), ctx.json({ message: '해당 글이 존재하지 않습니다.' }));
     }
 
     targetPost.commentCount += 1;
+    commentListTable.id += 1;
 
     const targetCommentReplies = commentList.find(comment => comment.id === id)?.replies!;
 
     targetCommentReplies.push({
-      id: targetPost.commentCount,
+      id: commentListTable.id,
       nickname: anonymous ? '짜증난 파이썬' : '테스트 계정',
       content,
       createdAt: new Date().toISOString(),

--- a/frontend/src/mocks/handlers/comments/index.ts
+++ b/frontend/src/mocks/handlers/comments/index.ts
@@ -1,0 +1,95 @@
+import { rest } from 'msw';
+
+import { commentList, postList, reportCommentList } from '@/dummy';
+
+const commentHandlers = [
+  rest.get('/posts/:id/comments', (req, res, ctx) => {
+    const params = req.params;
+    const id = Number(params.id);
+
+    const targetCommentList = commentList.filter(comment => comment.postId === id);
+
+    return res(ctx.status(200), ctx.json({ comments: targetCommentList }));
+  }),
+
+  rest.post<{ content: string; anonymous: boolean }>('/posts/:id/comments', (req, res, ctx) => {
+    const params = req.params;
+    const id = Number(params.id);
+    const { content, anonymous } = req.body;
+
+    const targetPost = postList.find(post => post.id === id);
+
+    if (!targetPost) {
+      return res(ctx.status(400), ctx.json({ message: '해당 글이 존재하지 않습니다.' }));
+    }
+
+    commentList.push({
+      id: commentList.length + 1,
+      content,
+      createdAt: new Date().toISOString(),
+      nickname: anonymous ? '짜증난 파이썬' : '테스트 계정',
+      postId: id,
+      authorized: true,
+      blocked: false,
+      postWriter: targetPost.authorized,
+      replies: [],
+    });
+    targetPost.commentCount += 1;
+
+    return res(ctx.status(204));
+  }),
+
+  rest.post<{ message: string }>('/comments/:id/report', (req, res, ctx) => {
+    const { id } = req.params;
+    const { message } = req.body;
+    if (reportCommentList.some(({ commentId }) => commentId === Number(id))) {
+      return res(ctx.status(400), ctx.json({ message: '이미 신고한 댓글입니다.' }));
+    }
+    reportCommentList.push({ commentId: Number(id), message });
+    return res(ctx.status(201));
+  }),
+
+  rest.delete('/comments/:id', (req, res, ctx) => {
+    const { id } = req.params;
+    const targetCommentIdx = commentList.findIndex(comment => comment.id === Number(id));
+
+    if (targetCommentIdx === -1) {
+      return res(ctx.status(400), ctx.json({ message: '해당 댓글이 존재하지 않습니다.' }));
+    }
+    commentList.splice(targetCommentIdx, 1);
+    return res(ctx.status(204));
+  }),
+
+  rest.post<{ content: string; anonymous: boolean }>('/comments/:id/reply', (req, res, ctx) => {
+    const id = Number(req.params.id);
+    const { content, anonymous } = req.body;
+
+    if (content.length < 1 || content.length > 255) {
+      return res(ctx.status(400), ctx.json({ message: '대댓글은 1자 이상 255자 이하입니다.' }));
+    }
+
+    const targetPost = postList.find(post => post.id === id);
+
+    if (!targetPost) {
+      return res(ctx.status(400), ctx.json({ message: '해당 글이 존재하지 않습니다.' }));
+    }
+
+    targetPost.commentCount += 1;
+
+    const targetCommentReplies = commentList.find(comment => comment.id === id)?.replies!;
+
+    targetCommentReplies.push({
+      id: targetPost.commentCount,
+      nickname: anonymous ? '짜증난 파이썬' : '테스트 계정',
+      content,
+      createdAt: new Date().toISOString(),
+      authorized: true,
+      blocked: false,
+      postWriter: targetPost.authorized,
+    });
+
+    return res(ctx.status(201));
+  }),
+];
+
+export default commentHandlers;

--- a/frontend/src/mocks/handlers/posts/index.ts
+++ b/frontend/src/mocks/handlers/posts/index.ts
@@ -1,6 +1,6 @@
 import { rest } from 'msw';
 
-import { hashtagList, commentList, postList, boardList, reportList, reportCommentList } from '@/dummy';
+import { hashtagList, postList, boardList, reportList } from '@/dummy';
 
 const postHandlers = [
   rest.post<Pick<Post, 'title' | 'content'> & { hashtags: string[]; anonymous: boolean }>(
@@ -159,40 +159,6 @@ const postHandlers = [
     return res(ctx.status(204));
   }),
 
-  rest.get('/posts/:id/comments', (req, res, ctx) => {
-    const params = req.params;
-    const id = Number(params.id);
-
-    const targetCommentList = commentList.filter(comment => comment.postId === id);
-    return res(ctx.status(200), ctx.json({ comments: targetCommentList }));
-  }),
-
-  rest.post<{ content: string; anonymous: boolean }>('/posts/:id/comments', (req, res, ctx) => {
-    const params = req.params;
-    const id = Number(params.id);
-    const { content, anonymous } = req.body;
-
-    const targetPost = postList.find(post => post.id === id);
-
-    if (!targetPost) {
-      return res(ctx.status(400), ctx.json({ message: '해당 글이 존재하지 않습니다.' }));
-    }
-
-    commentList.push({
-      id: commentList.length + 1,
-      content,
-      createdAt: new Date().toISOString(),
-      nickname: anonymous ? '짜증난 파이썬' : '테스트 계정',
-      postId: id,
-      authorized: true,
-      blocked: false,
-      postWriter: targetPost.authorized,
-    });
-    targetPost.commentCount += 1;
-
-    return res(ctx.status(204));
-  }),
-
   rest.get('/boards/contents', (req, res, ctx) => {
     const boards = boardList.map(board => {
       return {
@@ -263,27 +229,6 @@ const postHandlers = [
       message,
     });
     return res(ctx.status(201));
-  }),
-
-  rest.post<{ message: string }>('/comments/:id/report', (req, res, ctx) => {
-    const { id } = req.params;
-    const { message } = req.body;
-    if (reportCommentList.some(({ commentId }) => commentId === Number(id))) {
-      return res(ctx.status(400), ctx.json({ message: '이미 신고한 댓글입니다.' }));
-    }
-    reportCommentList.push({ commentId: Number(id), message });
-    return res(ctx.status(201));
-  }),
-
-  rest.delete('/comments/:id', (req, res, ctx) => {
-    const { id } = req.params;
-    const targetCommentIdx = commentList.findIndex(comment => comment.id === Number(id));
-
-    if (targetCommentIdx === -1) {
-      return res(ctx.status(400), ctx.json({ message: '해당 댓글이 존재하지 않습니다.' }));
-    }
-    commentList.splice(targetCommentIdx, 1);
-    return res(ctx.status(204));
   }),
 
   rest.get('/boards', (req, res, ctx) => {

--- a/frontend/src/mocks/worker.ts
+++ b/frontend/src/mocks/worker.ts
@@ -1,7 +1,8 @@
 import { setupWorker } from 'msw';
 
+import commentHandlers from './handlers/comments';
 import hashtagsHandlers from './handlers/hashtags';
 import memberHandler from './handlers/members';
 import postHandlers from './handlers/posts';
 
-export const worker = setupWorker(...postHandlers, ...memberHandler, ...hashtagsHandlers);
+export const worker = setupWorker(...postHandlers, ...memberHandler, ...hashtagsHandlers, ...commentHandlers);

--- a/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
@@ -9,17 +9,15 @@ export const Container = styled.div`
   background-color: white;
 `;
 
-export const BlockContainer = styled.div`
+export const EmptyComment = styled.div`
   width: 100%;
   border-top: 0.5px solid ${props => props.theme.colors.gray_150};
+  border-bottom: 0.5px solid ${props => props.theme.colors.gray_150};
+  margin-bottom: -0.5px;
   cursor: default;
-  padding: 3em 0;
-`;
-
-export const BlockedContent = styled.p`
+  padding: 3.5em 0.5em;
   color: ${props => props.theme.colors.gray_200};
   font-size: 12px;
-  margin-left: 10px;
 `;
 
 export const CommentHeader = styled.div`

--- a/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
@@ -1,4 +1,14 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
+
+const leaveComment = keyframes`
+  from {
+    background-color: #fafafa;
+  }
+  to {
+    background-color: white;
+  }
+`;
 
 export const Container = styled.div`
   width: calc(100%-1em);
@@ -7,6 +17,7 @@ export const Container = styled.div`
   border-bottom: 0.5px solid ${props => props.theme.colors.gray_150};
   margin-bottom: -0.5px;
   background-color: white;
+  animation: ${leaveComment} 0.7s;
 `;
 
 export const EmptyComment = styled.div`

--- a/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
@@ -4,6 +4,9 @@ export const Container = styled.div`
   width: calc(100%-1em);
   padding: 1em 0.5em;
   border-top: 0.5px solid ${props => props.theme.colors.gray_150};
+  border-bottom: 0.5px solid ${props => props.theme.colors.gray_150};
+  margin-bottom: -0.5px;
+  background-color: white;
 `;
 
 export const BlockContainer = styled.div`
@@ -25,6 +28,14 @@ export const CommentHeader = styled.div`
   justify-content: space-between;
   align-items: center;
   margin-bottom: 1em;
+`;
+
+export const ButtonContainer = styled.div``;
+
+export const ReplyButton = styled.button`
+  background-color: transparent;
+  color: ${props => props.theme.colors.gray_200};
+  font-size: 0.6rem;
 `;
 
 export const DeleteButton = styled.button`

--- a/frontend/src/pages/PostPage/components/CommentBox/index.tsx
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.tsx
@@ -9,16 +9,35 @@ import * as Styled from './index.styles';
 
 import timeConverter from '@/utils/timeConverter';
 
+import ReplyForm from '../ReplyForm';
 import ReportModal from '../ReportModal';
+
+const Mode = {
+  COMMENTS: 'comments',
+  REPLIES: 'replies',
+} as const;
 
 interface CommentBoxProps extends CommentType {
   blocked: boolean;
   postWriter: boolean;
+  mode?: typeof Mode[keyof typeof Mode];
+  className?: string;
 }
 
-const CommentBox = ({ id, nickname, content, createdAt, authorized, blocked, postWriter }: CommentBoxProps) => {
+const CommentBox = ({
+  id,
+  nickname,
+  content,
+  createdAt,
+  authorized,
+  blocked,
+  postWriter,
+  mode = Mode.COMMENTS,
+  className,
+}: CommentBoxProps) => {
   const [isReportModalOpen, handleReportModal] = useReducer(state => !state, false);
   const [isDeleteModalOpen, handleDeleteModal] = useReducer(state => !state, false);
+  const [isReplyFormOpen, handleReplyForm] = useReducer(state => !state, false);
 
   const { mutate: deleteComment } = useDeleteComment();
   const { mutate: reportComment } = useReportComment({
@@ -49,28 +68,31 @@ const CommentBox = ({ id, nickname, content, createdAt, authorized, blocked, pos
 
   return (
     <>
-      <Styled.Container>
+      <Styled.Container className={className}>
         <Styled.CommentHeader>
           <Styled.Nickname>
             {nickname} {postWriter && <Styled.PostWriter>작성자</Styled.PostWriter>}
           </Styled.Nickname>
-          {authorized ? (
-            <Styled.DeleteButton onClick={handleClickDeleteButton}>삭제</Styled.DeleteButton>
-          ) : (
-            <Styled.ReportButton onClick={handleClickReportButton}>🚨</Styled.ReportButton>
-          )}
+          <Styled.ButtonContainer>
+            {mode === Mode.COMMENTS && <Styled.ReplyButton onClick={handleReplyForm}>답글</Styled.ReplyButton>}
+            {authorized ? (
+              <Styled.DeleteButton onClick={handleClickDeleteButton}>삭제</Styled.DeleteButton>
+            ) : (
+              <Styled.ReportButton onClick={handleClickReportButton}>🚨</Styled.ReportButton>
+            )}
+          </Styled.ButtonContainer>
         </Styled.CommentHeader>
         <Styled.Content>{content}</Styled.Content>
         <Styled.Date>{timeConverter(createdAt)}</Styled.Date>
       </Styled.Container>
+
+      {isReplyFormOpen && <ReplyForm commentId={id} />}
       {isDeleteModalOpen && (
         <ConfirmModal
           title="삭제"
           notice="해당 댓글을 삭제하시겠습니까?"
           handleCancel={handleClickDeleteButton}
-          handleConfirm={() => {
-            deleteComment({ id });
-          }}
+          handleConfirm={() => deleteComment({ id })}
         />
       )}
       <ReportModal isModalOpen={isReportModalOpen} onClose={handleReportModal} submitReport={submitReportComment} />

--- a/frontend/src/pages/PostPage/components/CommentBox/index.tsx
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.tsx
@@ -58,12 +58,12 @@ const CommentBox = ({
     reportComment({ id, message });
   };
 
+  if (!content) {
+    return <Styled.EmptyComment>작성자에 의해 삭제된 댓글 입니다.</Styled.EmptyComment>;
+  }
+
   if (blocked) {
-    return (
-      <Styled.BlockContainer>
-        <Styled.BlockedContent>신고에 의해 블라인드 처리되었습니다</Styled.BlockedContent>
-      </Styled.BlockContainer>
-    );
+    return <Styled.EmptyComment>신고에 의해 블라인드 처리되었습니다.</Styled.EmptyComment>;
   }
 
   return (
@@ -83,7 +83,7 @@ const CommentBox = ({
           </Styled.ButtonContainer>
         </Styled.CommentHeader>
         <Styled.Content>{content}</Styled.Content>
-        <Styled.Date>{timeConverter(createdAt)}</Styled.Date>
+        <Styled.Date>{timeConverter(createdAt!)}</Styled.Date>
       </Styled.Container>
 
       {isReplyFormOpen && <ReplyForm commentId={id} />}

--- a/frontend/src/pages/PostPage/components/CommentInput/index.tsx
+++ b/frontend/src/pages/PostPage/components/CommentInput/index.tsx
@@ -8,6 +8,7 @@ import useSnackbar from '@/hooks/useSnackbar';
 import * as Styled from './index.styles';
 
 import SNACKBAR_MESSAGE from '@/constants/snackbar';
+import scrollToCurrent from '@/utils/scrollToCurrent';
 
 interface CommentInputProps {
   amount: number;
@@ -23,7 +24,7 @@ const CommentInput = ({ amount = 0, id }: CommentInputProps) => {
   const { mutate } = usePostComments({
     onSuccess: () => {
       formElement.current?.reset();
-      document.body.scrollIntoView({ behavior: 'smooth', block: 'end' });
+      scrollToCurrent(document.body.scrollHeight - document.documentElement.scrollTop);
     },
   });
 

--- a/frontend/src/pages/PostPage/components/CommentList/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/CommentList/index.styles.ts
@@ -1,3 +1,4 @@
+import CommentBox from '../CommentBox';
 import styled from '@emotion/styled';
 
 export const Container = styled.div`
@@ -10,4 +11,11 @@ export const Container = styled.div`
 export const CommentsContainer = styled.div`
   width: 100%;
   margin-top: 50px;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const ReplyBox = styled(CommentBox)`
+  width: 85%;
+  align-self: flex-end;
 `;

--- a/frontend/src/pages/PostPage/components/CommentList/index.tsx
+++ b/frontend/src/pages/PostPage/components/CommentList/index.tsx
@@ -16,19 +16,23 @@ const CommentList = ({ id }: CommentListProps) => {
   const { data } = useComments({ storeCode: id });
 
   return (
-    <Styled.Container>
-      <CommentInput amount={data?.length!} id={id} />
-      <Styled.CommentsContainer>
-        {data?.map(comment => (
-          <Fragment key={comment.id}>
-            <CommentBox {...comment} />
-            {comment.replies.map(reply => (
-              <Styled.ReplyBox key={reply.id} mode="replies" {...reply} />
+    <>
+      {data && (
+        <Styled.Container>
+          <CommentInput amount={data.totalCount} id={id} />
+          <Styled.CommentsContainer>
+            {data.comments.map(comment => (
+              <Fragment key={comment.id}>
+                <CommentBox {...comment} />
+                {comment.replies.map(reply => (
+                  <Styled.ReplyBox key={reply.id} mode="replies" {...reply} />
+                ))}
+              </Fragment>
             ))}
-          </Fragment>
-        ))}
-      </Styled.CommentsContainer>
-    </Styled.Container>
+          </Styled.CommentsContainer>
+        </Styled.Container>
+      )}
+    </>
   );
 };
 

--- a/frontend/src/pages/PostPage/components/CommentList/index.tsx
+++ b/frontend/src/pages/PostPage/components/CommentList/index.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react';
+
 import CommentBox from '@/pages/PostPage/components/CommentBox';
 
 import useComments from '@/hooks/queries/comment/useComments';
@@ -18,16 +20,12 @@ const CommentList = ({ id }: CommentListProps) => {
       <CommentInput amount={data?.length!} id={id} />
       <Styled.CommentsContainer>
         {data?.map(comment => (
-          <CommentBox
-            key={comment.id}
-            id={Number(comment.id)}
-            authorized={comment.authorized}
-            nickname={comment.nickname}
-            content={comment.content}
-            createdAt={comment.createdAt}
-            blocked={comment.blocked}
-            postWriter={comment.postWriter}
-          />
+          <Fragment key={comment.id}>
+            <CommentBox {...comment} />
+            {comment.replies.map(reply => (
+              <Styled.ReplyBox key={reply.id} mode="replies" {...reply} />
+            ))}
+          </Fragment>
         ))}
       </Styled.CommentsContainer>
     </Styled.Container>

--- a/frontend/src/pages/PostPage/components/ReplyForm/index.stories.tsx
+++ b/frontend/src/pages/PostPage/components/ReplyForm/index.stories.tsx
@@ -1,0 +1,21 @@
+import { withRouter } from 'storybook-addon-react-router-v6';
+
+import ReplyForm from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Components/ReplyInput',
+  component: ReplyForm,
+  decorators: [withRouter],
+} as ComponentMeta<typeof ReplyForm>;
+
+const Template: ComponentStory<typeof ReplyForm> = args => (
+  <div style={{ width: '314px' }}>
+    <ReplyForm {...args} />
+  </div>
+);
+
+export const ReplyInputTemplate: ComponentStory<typeof ReplyForm> = Template.bind({});
+ReplyInputTemplate.args = {
+  commentId: 1,
+};

--- a/frontend/src/pages/PostPage/components/ReplyForm/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/ReplyForm/index.styles.ts
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled';
+
+export const Form = styled.form`
+  width: 100%;
+  padding-top: 24px;
+  background-color: ${props => props.theme.colors.gray_5};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-sizing: border-box;
+  margin-bottom: -0.5px;
+  z-index: 5;
+`;
+
+export const Input = styled.textarea`
+  width: 288px;
+  height: 80px;
+  border: 0.5px solid ${props => props.theme.colors.gray_400};
+  padding: 10px;
+  box-sizing: border-box;
+
+  ::placeholder {
+    font-size: 12px;
+  }
+`;
+
+export const Controller = styled.div`
+  width: 288px;
+  height: 40px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 10px 0;
+`;
+
+export const SubmitButton = styled.button`
+  width: 60px;
+  height: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 11px;
+  background-color: ${props => props.theme.colors.sub};
+  color: white;
+  border-radius: 3px;
+`;

--- a/frontend/src/pages/PostPage/components/ReplyForm/index.tsx
+++ b/frontend/src/pages/PostPage/components/ReplyForm/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import CheckBox from '@/components/CheckBox';
 
@@ -6,6 +6,8 @@ import useCreateReply from '@/hooks/queries/comment/useCreateReply';
 import useSnackbar from '@/hooks/useSnackbar';
 
 import * as Styled from './index.styles';
+
+import scrollToCurrent from '@/utils/scrollToCurrent';
 
 interface ReplyFormProps {
   commentId: string | number;
@@ -20,6 +22,7 @@ const ReplyForm = ({ commentId }: ReplyFormProps) => {
   const { mutate: postReply } = useCreateReply({
     onSuccess: () => {
       setContent('');
+      scrollToCurrent(100);
     },
   });
 
@@ -28,6 +31,12 @@ const ReplyForm = ({ commentId }: ReplyFormProps) => {
 
     postReply({ commentId, content, anonymous });
   };
+
+  useEffect(() => {
+    scrollToCurrent(150);
+
+    return () => scrollToCurrent(-150);
+  }, []);
 
   return (
     <Styled.Form onSubmit={handleSubmit}>

--- a/frontend/src/pages/PostPage/components/ReplyForm/index.tsx
+++ b/frontend/src/pages/PostPage/components/ReplyForm/index.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 
 import CheckBox from '@/components/CheckBox';
 
-import usePostReply from '@/hooks/queries/comment/usePostReply';
+import useCreateReply from '@/hooks/queries/comment/useCreateReply';
+import useSnackbar from '@/hooks/useSnackbar';
 
 import * as Styled from './index.styles';
 
@@ -11,19 +12,36 @@ interface ReplyFormProps {
 }
 
 const ReplyForm = ({ commentId }: ReplyFormProps) => {
+  const { showSnackbar } = useSnackbar();
+
   const [content, setContent] = useState('');
   const [anonymous, setAnonymous] = useState(true);
 
-  const { mutate: postReply } = usePostReply({});
+  const { mutate: postReply } = useCreateReply({
+    onSuccess: () => {
+      setContent('');
+    },
+  });
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
     postReply({ commentId, content, anonymous });
   };
 
   return (
     <Styled.Form onSubmit={handleSubmit}>
-      <Styled.Input value={content} onChange={e => setContent(e.target.value)} placeholder="댓글을 작성하세요." />
+      <Styled.Input
+        value={content}
+        onChange={e => setContent(e.target.value)}
+        placeholder="댓글을 작성하세요."
+        maxLength={255}
+        onInvalid={(e: React.FormEvent<HTMLTextAreaElement> & { target: HTMLTextAreaElement }) => {
+          e.preventDefault();
+          showSnackbar(e.target.placeholder);
+        }}
+        required
+      />
       <Styled.Controller>
         <CheckBox isChecked={anonymous} setIsChecked={setAnonymous} labelText="익명" />
         <Styled.SubmitButton>작성</Styled.SubmitButton>

--- a/frontend/src/pages/PostPage/components/ReplyForm/index.tsx
+++ b/frontend/src/pages/PostPage/components/ReplyForm/index.tsx
@@ -7,6 +7,7 @@ import useSnackbar from '@/hooks/useSnackbar';
 
 import * as Styled from './index.styles';
 
+import SCROLL from '@/constants/scroll';
 import scrollToCurrent from '@/utils/scrollToCurrent';
 
 interface ReplyFormProps {
@@ -22,7 +23,7 @@ const ReplyForm = ({ commentId }: ReplyFormProps) => {
   const { mutate: postReply } = useCreateReply({
     onSuccess: () => {
       setContent('');
-      scrollToCurrent(100);
+      scrollToCurrent(SCROLL.COMMENT_HEIGHT);
     },
   });
 
@@ -33,9 +34,9 @@ const ReplyForm = ({ commentId }: ReplyFormProps) => {
   };
 
   useEffect(() => {
-    scrollToCurrent(150);
+    scrollToCurrent(SCROLL.REPLY_FORM_HEIGHT);
 
-    return () => scrollToCurrent(-150);
+    return () => scrollToCurrent(-SCROLL.REPLY_FORM_HEIGHT);
   }, []);
 
   return (

--- a/frontend/src/pages/PostPage/components/ReplyForm/index.tsx
+++ b/frontend/src/pages/PostPage/components/ReplyForm/index.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+import CheckBox from '@/components/CheckBox';
+
+import usePostReply from '@/hooks/queries/comment/usePostReply';
+
+import * as Styled from './index.styles';
+
+interface ReplyFormProps {
+  commentId: string | number;
+}
+
+const ReplyForm = ({ commentId }: ReplyFormProps) => {
+  const [content, setContent] = useState('');
+  const [anonymous, setAnonymous] = useState(true);
+
+  const { mutate: postReply } = usePostReply({});
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    postReply({ commentId, content, anonymous });
+  };
+
+  return (
+    <Styled.Form onSubmit={handleSubmit}>
+      <Styled.Input value={content} onChange={e => setContent(e.target.value)} placeholder="댓글을 작성하세요." />
+      <Styled.Controller>
+        <CheckBox isChecked={anonymous} setIsChecked={setAnonymous} labelText="익명" />
+        <Styled.SubmitButton>작성</Styled.SubmitButton>
+      </Styled.Controller>
+    </Styled.Form>
+  );
+};
+
+export default ReplyForm;

--- a/frontend/src/style/theme.ts
+++ b/frontend/src/style/theme.ts
@@ -2,6 +2,7 @@ const theme = {
   colors: {
     main: '#3BFF99',
     sub: '#33D2A4',
+    gray_5: '#fafafa',
     gray_10: '#F5F5F5',
     gray_50: '#e8e8e8',
     gray_100: '#eeeeee30',

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -1,0 +1,3 @@
+interface ErrorResponse {
+  message: string;
+}

--- a/frontend/src/types/comment.d.ts
+++ b/frontend/src/types/comment.d.ts
@@ -1,7 +1,7 @@
 interface CommentType {
   id: number;
-  nickname: string;
-  content: string;
-  createdAt: string;
-  authorized: boolean;
+  nickname: string | null;
+  content: string | null;
+  createdAt: string | null;
+  authorized: boolean | null;
 }

--- a/frontend/src/types/style.d.ts
+++ b/frontend/src/types/style.d.ts
@@ -5,6 +5,7 @@ declare module '@emotion/react' {
     colors: {
       main: string;
       sub: string;
+      gray_5: string;
       gray_10: string;
       gray_50: string;
       gray_100: string;

--- a/frontend/src/utils/scrollToCurrent.ts
+++ b/frontend/src/utils/scrollToCurrent.ts
@@ -1,8 +1,12 @@
 const scrollToCurrent = (current: number) => {
+  document.body.style.height = document.body.scrollHeight + current + 'px';
+
   window.scrollTo({
     top: document.documentElement.scrollTop + current,
     behavior: 'smooth',
   });
+
+  document.body.style.height = document.body.scrollHeight - current + 'px';
 };
 
 export default scrollToCurrent;

--- a/frontend/src/utils/scrollToCurrent.ts
+++ b/frontend/src/utils/scrollToCurrent.ts
@@ -1,0 +1,8 @@
+const scrollToCurrent = (current: number) => {
+  window.scrollTo({
+    top: document.documentElement.scrollTop + current,
+    behavior: 'smooth',
+  });
+};
+
+export default scrollToCurrent;

--- a/frontend/src/utils/scrollToCurrent.ts
+++ b/frontend/src/utils/scrollToCurrent.ts
@@ -6,7 +6,7 @@ const scrollToCurrent = (current: number) => {
     behavior: 'smooth',
   });
 
-  document.body.style.height = document.body.scrollHeight - current + 'px';
+  document.body.style.height = 'fit-content';
 };
 
 export default scrollToCurrent;


### PR DESCRIPTION
### 구현기능

댓글에 대한 답글을 작성할 수 있는 대댓글 기능을 구현한다. 

### 세부 구현기능

- [x] 해당 글에 존재하는 대댓글을 화면에 표시한다. 
  - [x] 대댓글을 위한 dummy 데이터를 만든다. 
- [x] API 명세를 참고하여 msw mocking을 구현한다. 
  - [x] 대댓글 등록
  - [x] 대댓글 삭제
  - [x] 대댓글 신고 
- [x] 대댓글을 달 수 있는 form을 나타나게 해주는 버튼을 구현한다. 
- [x] 대댓글을 달 수 있는 form을 제작한다.

### 주의사항

- [x] 부모 댓글 삭제시 자식 댓글은 삭제가 되어선 안된다. 
- [x] 댓글 작성 후 입력 폼을 비운다. 
- [x] 댓글 총 개수에는 대댓글 수까지 포함되어야 한다. ([API 명세 변경](https://www.notion.so/API-226d95e22c554cd295bebc5240c4533a#a40d5dff27cb4212a1874ebef8a0b47e))
- [x] 적절한 애니매이션을 추가한다. 

### 예외

- [x] 내용이 1자 미만 255자를 초과한 경우 

### 관련 이슈

- 순회 중단이 필요할 경우 `forEach`는 적절하지 않다. 배열이라면 `for of`를 사용할 것
- `commentCount`와 comment의 id는 분리되어야 한다. (commentId는 계속 증가하지만, count는 감소할 수 있음)
- resetQuery와 refetchQuery의 차이 (스크롤 초기화)

close #401 
