### PR TITLE
refactor: 정적 팩토리 메소드명 변경 #423

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/domain/Hashtags.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/domain/Hashtags.java
@@ -11,14 +11,7 @@ public class Hashtags {
         this.value = value;
     }
 
-    public static Hashtags ofNames(List<String> names) {
-        List<Hashtag> hashtags = names.stream()
-                .map(name -> Hashtag.builder().name(name).build())
-                .collect(Collectors.toList());
-        return new Hashtags(hashtags);
-    }
-
-    public static Hashtags ofPostHashtags(List<PostHashtag> postHashtags) {
+    public static Hashtags of(List<PostHashtag> postHashtags) {
         List<Hashtag> hashtags = postHashtags.stream()
                 .map(PostHashtag::getHashtag)
                 .collect(Collectors.toList());

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/service/HashtagService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/hashtag/service/HashtagService.java
@@ -48,7 +48,7 @@ public class HashtagService {
     }
 
     public Hashtags findHashtagsByPostId(Long postId) {
-        return Hashtags.ofPostHashtags(postHashtagRepository.findAllByPostId(postId));
+        return Hashtags.of(postHashtagRepository.findAllByPostId(postId));
     }
 
     @Transactional

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/MyPostsResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/dto/MyPostsResponse.java
@@ -19,7 +19,7 @@ public class MyPostsResponse {
         this.totalPageCount = totalPageCount;
     }
 
-    public static MyPostsResponse ofPosts(List<Post> posts, int totalPageCount) {
+    public static MyPostsResponse of(List<Post> posts, int totalPageCount) {
         List<PostsElementResponse> postsElementResponses = posts.stream()
                 .map(PostsElementResponse::from)
                 .collect(Collectors.toList());

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -101,7 +101,7 @@ public class PostService {
         Member member = memberRepository.findById(authInfo.getId())
                 .orElseThrow(MemberNotFoundException::new);
         Page<Post> posts = postRepository.findPostsByMemberOrderByCreatedAtDesc(pageable, member);
-        return MyPostsResponse.ofPosts(posts.getContent(), posts.getTotalPages());
+        return MyPostsResponse.of(posts.getContent(), posts.getTotalPages());
     }
 
     @Transactional


### PR DESCRIPTION
### 구현기능
resolved: #423 

### 세부 구현기능
정적 팩토리 메소드명 변경 of으로 변경

### 관련 이슈
하나의 클래스에 같은 형태의 파라미터의 정적 팩토리메소드가 여러 개 있을 경우 이름 변경하지 않음