### PR TITLE
fix: 깨지는 FE 테스트 해결

### DIFF
--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -2,6 +2,7 @@ import { setupServer } from 'msw/node';
 
 import { STORAGE_KEY } from './constants/localStorage';
 
+import commentHandlers from './mocks/handlers/comments';
 import hashtagsHandlers from './mocks/handlers/hashtags';
 import memberHandler from './mocks/handlers/members';
 import postHandlers from './mocks/handlers/posts';
@@ -9,7 +10,7 @@ import MockIntersectionObserver from '@/__test__/fixture';
 import '@testing-library/jest-dom';
 import { cleanup } from '@testing-library/react';
 
-const server = setupServer(...memberHandler, ...postHandlers, ...hashtagsHandlers);
+const server = setupServer(...memberHandler, ...postHandlers, ...hashtagsHandlers, ...commentHandlers);
 
 const originalError = console.error;
 


### PR DESCRIPTION
### 설명

<img width="500" alt="스크린샷 2022-08-11 오후 1 49 56" src="https://user-images.githubusercontent.com/52737532/184066540-2f57ddda-38d9-40a6-8dff-8cb4ab4fd338.png">

대댓글 구현 이후 댓글 관련 테스트가 깨진다. 

### 세부 구현기능

- [x] 누락된 댓글 핸들러를 추가한다. 

### 관련 이슈

close #433 
