### PR TITLE
fix: 알림 delete시 데이터 동기화 문제 수정

### DIFF
--- a/frontend/src/hooks/queries/notification/useDeleteNotification.ts
+++ b/frontend/src/hooks/queries/notification/useDeleteNotification.ts
@@ -1,4 +1,4 @@
-import { InfiniteData, useMutation, UseMutationOptions, useQueryClient } from 'react-query';
+import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
 
 import { AxiosError, AxiosResponse } from 'axios';
 
@@ -17,22 +17,8 @@ const useDeleteNotification = (
 
   return useMutation(({ id }) => authFetcher.delete(`/notifications/${id}`), {
     ...options,
-    onSuccess: (_, variables) => {
-      queryClient.getQueryData(QUERY_KEYS.NOTIFICATIONS);
-      queryClient.setQueryData<InfiniteData<AxiosResponse<{ notifications: Notice[]; lastPage: boolean }>>>(
-        [QUERY_KEYS.NOTIFICATIONS, SIZE.NOTIFICATION_LOAD],
-        data =>
-          ({
-            pageParams: data?.pageParams,
-            pages: data?.pages.map(page => ({
-              ...page,
-              data: {
-                ...page.data,
-                notifications: page.data.notifications.filter(notice => notice.id !== variables.id),
-              },
-            })),
-          } as InfiniteData<AxiosResponse<{ notifications: Notice[]; lastPage: boolean }>>),
-      );
+    onSuccess: () => {
+      queryClient.refetchQueries([QUERY_KEYS.NOTIFICATIONS, SIZE.NOTIFICATION_LOAD]);
     },
     mutationKey: MUTATION_KEY.DELETE_NOTIFICATION,
   });


### PR DESCRIPTION
### 구현기능

- 알림 삭제시 서버와의 데이터 동기화 문제 때문에 발생하는 데이터 Fetching 오류 해결

### 세부 구현기능

- 알림 delete시 setqueriesData -> refetchQueries로 변경

### 관련 이슈

close #470 
