### PR TITLE
feat: admin api 구현

### DIFF
--- a/backend/sokdak/src/docs/asciidoc/index.adoc
+++ b/backend/sokdak/src/docs/asciidoc/index.adoc
@@ -213,3 +213,46 @@ operation::notification/findNotifications/success[snippets='http-request,http-re
 
 operation::notification/deleteNotifications/success[snippets='http-request,http-response']
 
+== 관리자
+
+=== 관리자 페이지에서 글 삭제하기
+==== 성공
+operation::admin/post/delete/success[snippets='http-request,http-response']
+==== 실패
+===== 관리자가 아닐 경우
+operation::admin/post/delete/fail/noAdmin[snippets='http-request,http-response']
+
+=== 관리자 페이지에서 글 블락하기
+==== 성공
+operation::admin/post/add/postReports/success[snippets='http-request,http-response']
+==== 실패
+===== 관리자가 아닐 경우
+operation::admin/post/add/postReports/fail/noAdmin[snippets='http-request,http-response']
+
+=== 관리자 페이지에서 글 블락 복구하기
+==== 성공
+operation::admin/post/delete/postReports/success[snippets='http-request,http-response']
+==== 실패
+===== 관리자가 아닐 경우
+operation::admin/post/delete/postReports/fail/noAdmin[snippets='http-request,http-response']
+
+=== 관리자 페이지에서 글 신고 목록 조회하기
+==== 성공
+operation::admin/post/find/postReports/success[snippets='http-request,http-response']
+==== 실패
+===== 관리자가 아닐 경우
+operation::admin/post/find/postReports/fail/noAdmin[snippets='http-request,http-response']
+
+=== 관리자 페이지에서 티켓 조회하기
+==== 성공
+operation::admin/tickets/find/success[snippets='http-request,http-response']
+==== 실패
+===== 관리자가 아닐 경우
+operation::admin/tickets/find/fail/noAdmin[snippets='http-request,http-response']
+
+=== 관리자 페이지에서 티켓 저장하기
+==== 성공
+operation::admin/tickets/save/success[snippets='http-request,http-response']
+==== 실패
+===== 관리자가 아닐 경우
+operation::admin/tickets/save/fail/noAdmin[snippets='http-request,http-response']

--- a/backend/sokdak/src/docs/asciidoc/index.adoc
+++ b/backend/sokdak/src/docs/asciidoc/index.adoc
@@ -256,3 +256,10 @@ operation::admin/tickets/save/success[snippets='http-request,http-response']
 ==== 실패
 ===== 관리자가 아닐 경우
 operation::admin/tickets/save/fail/noAdmin[snippets='http-request,http-response']
+
+=== 관리자 페이지에서 티켓 사용여부 수정하기
+==== 성공
+operation::admin/tickets/update/success[snippets='http-request,http-response']
+==== 실패
+===== 관리자가 아닐 경우
+operation::admin/tickets/update/fail/noAdmin[snippets='http-request,http-response']

--- a/backend/sokdak/src/docs/asciidoc/index.adoc
+++ b/backend/sokdak/src/docs/asciidoc/index.adoc
@@ -224,24 +224,24 @@ operation::admin/post/delete/fail/noAdmin[snippets='http-request,http-response']
 
 === 관리자 페이지에서 글 블락하기
 ==== 성공
-operation::admin/post/add/postReports/success[snippets='http-request,http-response']
+operation::admin/post/add/postreports/success[snippets='http-request,http-response']
 ==== 실패
 ===== 관리자가 아닐 경우
-operation::admin/post/add/postReports/fail/noAdmin[snippets='http-request,http-response']
+operation::admin/post/add/postreports/fail/noAdmin[snippets='http-request,http-response']
 
 === 관리자 페이지에서 글 블락 복구하기
 ==== 성공
-operation::admin/post/delete/postReports/success[snippets='http-request,http-response']
+operation::admin/post/delete/postreports/success[snippets='http-request,http-response']
 ==== 실패
 ===== 관리자가 아닐 경우
-operation::admin/post/delete/postReports/fail/noAdmin[snippets='http-request,http-response']
+operation::admin/post/delete/postreports/fail/noAdmin[snippets='http-request,http-response']
 
 === 관리자 페이지에서 글 신고 목록 조회하기
 ==== 성공
-operation::admin/post/find/postReports/success[snippets='http-request,http-response']
+operation::admin/post/find/postreports/success[snippets='http-request,http-response']
 ==== 실패
 ===== 관리자가 아닐 경우
-operation::admin/post/find/postReports/fail/noAdmin[snippets='http-request,http-response']
+operation::admin/post/find/postreports/fail/noAdmin[snippets='http-request,http-response']
 
 === 관리자 페이지에서 티켓 조회하기
 ==== 성공

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/SokdakApplication.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/SokdakApplication.java
@@ -9,5 +9,4 @@ public class SokdakApplication {
     public static void main(String[] args) {
         SpringApplication.run(SokdakApplication.class, args);
     }
-
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/controller/AdminController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/controller/AdminController.java
@@ -31,7 +31,6 @@ public class AdminController {
         return ResponseEntity.ok().build();
     }
 
-
     @PostMapping("/email")
     public ResponseEntity<Void> registerEmail(@Login AuthInfo authInfo,
                                               @RequestBody EmailsAddRequest emailsAddRequest) {
@@ -76,5 +75,10 @@ public class AdminController {
         adminService.saveTicket(authInfo, ticketRequest);
         return ResponseEntity.ok().build();
     }
-}
 
+    @PostMapping("/tickets/used")
+    public ResponseEntity<Void> updateTicket(@Login AuthInfo authInfo, @RequestBody TicketRequest ticketRequest) {
+        adminService.changeTicketUsedState(authInfo, ticketRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/controller/AdminController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/controller/AdminController.java
@@ -10,8 +10,10 @@ import com.wooteco.sokdak.support.token.Login;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -76,7 +78,7 @@ public class AdminController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/tickets/used")
+    @PatchMapping("/tickets")
     public ResponseEntity<Void> updateTicket(@Login AuthInfo authInfo, @RequestBody TicketRequest ticketRequest) {
         adminService.changeTicketUsedState(authInfo, ticketRequest);
         return ResponseEntity.ok().build();

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/controller/AdminController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/controller/AdminController.java
@@ -1,11 +1,16 @@
 package com.wooteco.sokdak.admin.controller;
 
 import com.wooteco.sokdak.admin.dto.EmailsAddRequest;
+import com.wooteco.sokdak.admin.dto.PostReportsResponse;
+import com.wooteco.sokdak.admin.dto.TicketRequest;
+import com.wooteco.sokdak.admin.dto.TicketsResponse;
 import com.wooteco.sokdak.admin.service.AdminService;
 import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.support.token.Login;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,9 +33,48 @@ public class AdminController {
 
 
     @PostMapping("/email")
-    public ResponseEntity<Void> registerEmail(@Login AuthInfo authInfo, @RequestBody EmailsAddRequest emailsAddRequest) {
+    public ResponseEntity<Void> registerEmail(@Login AuthInfo authInfo,
+                                              @RequestBody EmailsAddRequest emailsAddRequest) {
         adminService.registerEmail(authInfo, emailsAddRequest);
 
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/posts/{id}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long id, @Login AuthInfo authInfo) {
+        adminService.deletePost(id, authInfo);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/posts/{id}/postReports/{postReportCount}")
+    public ResponseEntity<Void> BlockPost(@PathVariable Long id, @PathVariable Long postReportCount,
+                                          @Login AuthInfo authInfo) {
+        adminService.blockPost(id, postReportCount, authInfo);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/posts/{id}/postReports")
+    public ResponseEntity<Void> unBlockPost(@PathVariable Long id, @Login AuthInfo authInfo) {
+        adminService.unBlockPost(id, authInfo);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/postReports")
+    public ResponseEntity<PostReportsResponse> findAllPostReports(@Login AuthInfo authInfo) {
+        PostReportsResponse postReportsResponse = adminService.findAllPostReport(authInfo);
+        return ResponseEntity.ok().body(postReportsResponse);
+    }
+
+    @GetMapping("/tickets")
+    public ResponseEntity<TicketsResponse> findAllTickets(@Login AuthInfo authInfo) {
+        TicketsResponse allTicket = adminService.findAllTickets(authInfo);
+        return ResponseEntity.ok().body(allTicket);
+    }
+
+    @PostMapping("/tickets")
+    public ResponseEntity<Void> saveTicket(@Login AuthInfo authInfo, @RequestBody TicketRequest ticketRequest) {
+        adminService.saveTicket(authInfo, ticketRequest);
+        return ResponseEntity.ok().build();
+    }
 }
+

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/controller/AdminController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/controller/AdminController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -62,7 +61,7 @@ public class AdminController {
 
     @GetMapping("/postreports")
     public ResponseEntity<PostReportsResponse> findAllPostReports(@Login AuthInfo authInfo) {
-        PostReportsResponse postReportsResponse = adminService.findAllPostReport(authInfo);
+        PostReportsResponse postReportsResponse = adminService.findAllPostReports(authInfo);
         return ResponseEntity.ok().body(postReportsResponse);
     }
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/controller/AdminController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/controller/AdminController.java
@@ -45,20 +45,20 @@ public class AdminController {
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/posts/{id}/postReports/{postReportCount}")
-    public ResponseEntity<Void> BlockPost(@PathVariable Long id, @PathVariable Long postReportCount,
+    @PostMapping("/posts/{id}/postreports/{postReportCount}")
+    public ResponseEntity<Void> blockPost(@PathVariable Long id, @PathVariable Long postReportCount,
                                           @Login AuthInfo authInfo) {
         adminService.blockPost(id, postReportCount, authInfo);
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/posts/{id}/postReports")
-    public ResponseEntity<Void> unBlockPost(@PathVariable Long id, @Login AuthInfo authInfo) {
-        adminService.unBlockPost(id, authInfo);
+    @DeleteMapping("/posts/{id}/postreports")
+    public ResponseEntity<Void> unblockPost(@PathVariable Long id, @Login AuthInfo authInfo) {
+        adminService.unblockPost(id, authInfo);
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/postReports")
+    @GetMapping("/postreports")
     public ResponseEntity<PostReportsResponse> findAllPostReports(@Login AuthInfo authInfo) {
         PostReportsResponse postReportsResponse = adminService.findAllPostReport(authInfo);
         return ResponseEntity.ok().body(postReportsResponse);

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/EmailsAddRequest.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/EmailsAddRequest.java
@@ -10,7 +10,7 @@ public class EmailsAddRequest {
     @NotBlank(message = "추가할 이메일을 입력해주세요.")
     private List<String> emails;
 
-    public EmailsAddRequest() {
+    protected EmailsAddRequest() {
     }
 
     public EmailsAddRequest(List<String> emails) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/EmailsAddRequest.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/EmailsAddRequest.java
@@ -1,10 +1,13 @@
 package com.wooteco.sokdak.admin.dto;
 
 import java.util.List;
+import javax.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class EmailsAddRequest {
+
+    @NotBlank(message = "추가할 이메일을 입력해주세요.")
     private List<String> emails;
 
     public EmailsAddRequest() {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/PostReportElement.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/PostReportElement.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 @Getter
 public class PostReportElement {
+
     private Long id;
     private Long postId;
     private Long reporterId;

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/PostReportElement.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/PostReportElement.java
@@ -14,6 +14,9 @@ public class PostReportElement {
     private String reportMessage;
     private LocalDateTime createdAt;
 
+    protected PostReportElement(){
+    }
+
     @Builder
     public PostReportElement(Long id, Long postId, Long reporterId, String reportMessage, LocalDateTime createdAt) {
         this.id = id;

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/PostReportElement.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/PostReportElement.java
@@ -1,0 +1,34 @@
+package com.wooteco.sokdak.admin.dto;
+
+import com.wooteco.sokdak.report.domain.PostReport;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PostReportElement {
+    private Long id;
+    private Long postId;
+    private Long reporterId;
+    private String reportMessage;
+    private LocalDateTime createdAt;
+
+    @Builder
+    public PostReportElement(Long id, Long postId, Long reporterId, String reportMessage, LocalDateTime createdAt) {
+        this.id = id;
+        this.postId = postId;
+        this.reporterId = reporterId;
+        this.reportMessage = reportMessage;
+        this.createdAt = createdAt;
+    }
+
+    public static PostReportElement of(PostReport postReport) {
+        return PostReportElement.builder()
+                .id(postReport.getId())
+                .postId(postReport.getPost().getId())
+                .reporterId(postReport.getReporter().getId())
+                .reportMessage(postReport.getReportMessage())
+                .createdAt(postReport.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/PostReportsResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/PostReportsResponse.java
@@ -1,0 +1,21 @@
+package com.wooteco.sokdak.admin.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PostReportsResponse {
+
+    private List<PostReportElement> postReports;
+
+    protected PostReportsResponse() {
+    }
+
+    public PostReportsResponse(List<PostReportElement> postReports) {
+        this.postReports = postReports;
+    }
+
+    public static PostReportsResponse of(List<PostReportElement> postReportElements) {
+        return new PostReportsResponse(postReportElements);
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketElement.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketElement.java
@@ -1,0 +1,28 @@
+package com.wooteco.sokdak.admin.dto;
+
+import com.wooteco.sokdak.auth.domain.Ticket;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class TicketElement {
+
+    private final Long id;
+    private final String serialNumber;
+    private final boolean used;
+
+    @Builder
+    public TicketElement(Long id, String serialNumber, boolean used) {
+        this.id = id;
+        this.serialNumber = serialNumber;
+        this.used = used;
+    }
+
+    public static TicketElement of(Ticket ticket) {
+        return TicketElement.builder()
+                .id(ticket.getId())
+                .serialNumber(ticket.getSerialNumber())
+                .used(ticket.isUsed())
+                .build();
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketElement.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketElement.java
@@ -7,9 +7,12 @@ import lombok.Getter;
 @Getter
 public class TicketElement {
 
-    private final Long id;
-    private final String serialNumber;
-    private final boolean used;
+    private Long id;
+    private String serialNumber;
+    private boolean used;
+
+    protected TicketElement() {
+    }
 
     @Builder
     public TicketElement(Long id, String serialNumber, boolean used) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketRequest.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketRequest.java
@@ -1,13 +1,16 @@
 package com.wooteco.sokdak.admin.dto;
 
 import com.wooteco.sokdak.auth.domain.Ticket;
+import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class TicketRequest {
 
+    @NotBlank(message = "이메일을 입력해주세요.")
     private final String serialNumber;
+    @NotBlank(message = "사용 여부를 입력해주세요.")
     private final boolean used;
 
     @Builder

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketRequest.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketRequest.java
@@ -9,9 +9,12 @@ import lombok.Getter;
 public class TicketRequest {
 
     @NotBlank(message = "이메일을 입력해주세요.")
-    private final String serialNumber;
+    private String serialNumber;
     @NotBlank(message = "사용 여부를 입력해주세요.")
-    private final boolean used;
+    private boolean used;
+
+    protected TicketRequest(){
+    }
 
     @Builder
     public TicketRequest(String serialNumber, boolean used) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketRequest.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketRequest.java
@@ -1,0 +1,32 @@
+package com.wooteco.sokdak.admin.dto;
+
+import com.wooteco.sokdak.auth.domain.Ticket;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class TicketRequest {
+
+    private final String serialNumber;
+    private final boolean used;
+
+    @Builder
+    public TicketRequest(String serialNumber, boolean used) {
+        this.serialNumber = serialNumber;
+        this.used = used;
+    }
+
+    public static TicketRequest of(Ticket ticket) {
+        return TicketRequest.builder()
+                .serialNumber(ticket.getSerialNumber())
+                .used(ticket.isUsed())
+                .build();
+    }
+
+    public Ticket toTicket(){
+        return Ticket.builder()
+                .serialNumber(serialNumber)
+                .used(used)
+                .build();
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketsResponse.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketsResponse.java
@@ -1,0 +1,21 @@
+package com.wooteco.sokdak.admin.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class TicketsResponse {
+
+    private List<TicketElement> tickets;
+
+    protected TicketsResponse() {
+    }
+
+    public TicketsResponse(List<TicketElement> tickets) {
+        this.tickets = tickets;
+    }
+
+    public static TicketsResponse of(List<TicketElement> tickets) {
+        return new TicketsResponse(tickets);
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/exception/NoAdminException.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/exception/NoAdminException.java
@@ -1,8 +1,8 @@
 package com.wooteco.sokdak.admin.exception;
 
-import com.wooteco.sokdak.advice.UnauthorizedException;
+import com.wooteco.sokdak.advice.ForbiddenException;
 
-public class NoAdminException extends UnauthorizedException {
+public class NoAdminException extends ForbiddenException {
 
     private static final String MESSAGE = "관리자만 접근 가능합니다.";
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/exception/NoAdminException.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/exception/NoAdminException.java
@@ -1,0 +1,12 @@
+package com.wooteco.sokdak.admin.exception;
+
+import com.wooteco.sokdak.advice.UnauthorizedException;
+
+public class NoAdminException extends UnauthorizedException {
+
+    private static final String MESSAGE = "관리자만 접근 가능합니다.";
+
+    public NoAdminException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
@@ -92,7 +92,7 @@ public class AdminService {
     }
 
     @Transactional
-    public void unBlockPost(Long id, AuthInfo authInfo) {
+    public void unblockPost(Long id, AuthInfo authInfo) {
         validateRole(authInfo);
 
         Post post = postRepository.findById(id)

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
@@ -1,31 +1,57 @@
 package com.wooteco.sokdak.admin.service;
 
 import com.wooteco.sokdak.admin.dto.EmailsAddRequest;
+import com.wooteco.sokdak.admin.dto.PostReportElement;
+import com.wooteco.sokdak.admin.dto.PostReportsResponse;
+import com.wooteco.sokdak.admin.dto.TicketElement;
+import com.wooteco.sokdak.admin.dto.TicketRequest;
+import com.wooteco.sokdak.admin.dto.TicketsResponse;
+import com.wooteco.sokdak.admin.exception.NoAdminException;
 import com.wooteco.sokdak.advice.UnauthorizedException;
 import com.wooteco.sokdak.auth.domain.Ticket;
 import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.auth.service.Encryptor;
+import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.domain.RoleType;
 import com.wooteco.sokdak.member.repository.TicketRepository;
+import com.wooteco.sokdak.post.domain.Post;
+import com.wooteco.sokdak.post.exception.PostNotFoundException;
+import com.wooteco.sokdak.post.repository.PostRepository;
+import com.wooteco.sokdak.post.service.PostService;
+import com.wooteco.sokdak.report.domain.PostReport;
+import com.wooteco.sokdak.report.dto.ReportRequest;
+import com.wooteco.sokdak.report.repository.PostReportRepository;
+import com.wooteco.sokdak.report.service.PostReportService;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class AdminService {
 
     private final TicketRepository ticketRepository;
+    private final PostService postService;
+    private final PostReportService postReportService;
+    private final PostRepository postRepository;
+    private final PostReportRepository postReportRepository;
 
-    public AdminService(TicketRepository ticketRepository) {
+    public AdminService(TicketRepository ticketRepository, PostService postService,
+                        PostReportService postReportService,
+                        PostRepository postRepository,
+                        PostReportRepository postReportRepository) {
         this.ticketRepository = ticketRepository;
+        this.postService = postService;
+        this.postReportService = postReportService;
+        this.postRepository = postRepository;
+        this.postReportRepository = postReportRepository;
     }
 
     @Transactional
     public void registerEmail(AuthInfo authInfo, EmailsAddRequest emailsAddRequest) {
-        if (authInfo.getRole().equals(RoleType.USER.getName())) {
-            throw new UnauthorizedException("이메일 등록은 관리자만 가능합니다.");
-        }
+        validateRole(authInfo);
 
         List<String> emails = emailsAddRequest.getEmails();
 
@@ -39,6 +65,71 @@ public class AdminService {
                         .build();
                 ticketRepository.save(ticket);
             }
+        }
+    }
+
+    @Transactional
+    public void deletePost(Long id, AuthInfo authInfo) {
+        validateRole(authInfo);
+
+        Post post = postRepository.findById(id)
+                .orElseThrow(PostNotFoundException::new);
+        Member member = post.getMember();
+        postService.deletePost(id, getAuthInfo(member));
+    }
+
+    @Transactional
+    public void blockPost(Long id, Long postReportCount, AuthInfo authInfo) {
+        validateRole(authInfo);
+
+        Post post = postRepository.findById(id)
+                .orElseThrow(PostNotFoundException::new);
+        ReportRequest reportRequest = new ReportRequest("adminBlocked");
+        for (long i = 1; i <= postReportCount; i++) {
+            AuthInfo dummyAuthInfo = new AuthInfo(i, RoleType.ADMIN.getName(), "관리자");
+            postReportService.reportPost(post.getId(), reportRequest, dummyAuthInfo);
+        }
+    }
+
+    @Transactional
+    public void unBlockPost(Long id, AuthInfo authInfo) {
+        validateRole(authInfo);
+
+        Post post = postRepository.findById(id)
+                .orElseThrow(PostNotFoundException::new);
+        postReportRepository.deleteAllPostReportByPostId(post.getId());
+    }
+
+    public PostReportsResponse findAllPostReport(AuthInfo authInfo) {
+        validateRole(authInfo);
+
+        List<PostReport> postReports = postReportRepository.findAll();
+        return PostReportsResponse.of(postReports.stream()
+                .map(PostReportElement::of)
+                .collect(Collectors.toList()));
+    }
+
+    public TicketsResponse findAllTickets(AuthInfo authInfo) {
+        validateRole(authInfo);
+        List<Ticket> tickets = ticketRepository.findAll();
+        return TicketsResponse.of(tickets.stream()
+                .map(TicketElement::of)
+                .collect(Collectors.toList()));
+    }
+
+    @Transactional
+    public void saveTicket(AuthInfo authInfo, TicketRequest ticketRequest) {
+        validateRole(authInfo);
+        ticketRepository.save(ticketRequest.toTicket());
+    }
+
+    private AuthInfo getAuthInfo(Member member) {
+        return new AuthInfo(member.getId(), RoleType.USER.getName(), member.getNickname());
+    }
+
+    private void validateRole(AuthInfo authInfo) {
+        if (!authInfo.getRole().equals(RoleType.ADMIN.getName())) {
+            throw new NoAdminException();
         }
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
@@ -7,12 +7,12 @@ import com.wooteco.sokdak.admin.dto.TicketElement;
 import com.wooteco.sokdak.admin.dto.TicketRequest;
 import com.wooteco.sokdak.admin.dto.TicketsResponse;
 import com.wooteco.sokdak.admin.exception.NoAdminException;
-import com.wooteco.sokdak.advice.UnauthorizedException;
 import com.wooteco.sokdak.auth.domain.Ticket;
 import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.auth.service.Encryptor;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.domain.RoleType;
+import com.wooteco.sokdak.member.exception.SerialNumberNotFoundException;
 import com.wooteco.sokdak.member.repository.TicketRepository;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.exception.PostNotFoundException;
@@ -121,6 +121,14 @@ public class AdminService {
     public void saveTicket(AuthInfo authInfo, TicketRequest ticketRequest) {
         validateRole(authInfo);
         ticketRepository.save(ticketRequest.toTicket());
+    }
+
+    @Transactional
+    public void changeTicketUsedState(AuthInfo authInfo, TicketRequest ticketRequest) {
+        validateRole(authInfo);
+        Ticket ticket = ticketRepository.findBySerialNumber(ticketRequest.getSerialNumber())
+                .orElseThrow(SerialNumberNotFoundException::new);
+        ticket.updateUsed(ticketRequest.isUsed());
     }
 
     private AuthInfo getAuthInfo(Member member) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
@@ -100,7 +100,7 @@ public class AdminService {
         postReportRepository.deleteAllPostReportByPostId(post.getId());
     }
 
-    public PostReportsResponse findAllPostReport(AuthInfo authInfo) {
+    public PostReportsResponse findAllPostReports(AuthInfo authInfo) {
         validateRole(authInfo);
 
         List<PostReport> postReports = postReportRepository.findAll();

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/domain/Ticket.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/domain/Ticket.java
@@ -30,6 +30,10 @@ public class Ticket {
         this.used = used;
     }
 
+    public void updateUsed(boolean used) {
+        this.used = used;
+    }
+
     public void use() {
         this.used = true;
     }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/util/TimeConfig.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/util/TimeConfig.java
@@ -1,6 +1,7 @@
 package com.wooteco.sokdak.member.util;
 
 import java.time.Clock;
+import java.time.LocalDateTime;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/report/repository/PostReportRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/report/repository/PostReportRepository.java
@@ -1,9 +1,14 @@
 package com.wooteco.sokdak.report.repository;
 
 import com.wooteco.sokdak.report.domain.PostReport;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostReportRepository extends JpaRepository<PostReport, Long> {
 
     int countByPostId(Long postId);
+
+    void deleteAllPostReportByPostId(Long id);
+
+    List<PostReport> findAllByPostId(Long id);
 }

--- a/backend/sokdak/src/main/resources/static/index.html
+++ b/backend/sokdak/src/main/resources/static/index.html
@@ -1,0 +1,2992 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.10">
+<title>속닥속닥 API 명세</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment @import statement to use as custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite::before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+:not(pre)>code.nobreak{word-wrap:normal}
+:not(pre)>code.nowrap{white-space:nowrap}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
+pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
+pre.pygments .lineno::before{content:"";margin-right:-.125em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
+table.tableblock{max-width:100%;border-collapse:separate}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+</head>
+<body class="book toc2 toc-left">
+<div id="header">
+<h1>속닥속닥 API 명세</h1>
+<div class="details">
+<span id="revnumber">version 0.0.1-SNAPSHOT</span>
+</div>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_메인페이지">1. 메인페이지</a>
+<ul class="sectlevel2">
+<li><a href="#_메인페이지_조회">1.1. 메인페이지 조회</a></li>
+</ul>
+</li>
+<li><a href="#_회원가입">2. 회원가입</a>
+<ul class="sectlevel2">
+<li><a href="#_이메일_인증">2.1. 이메일 인증</a></li>
+<li><a href="#_인증번호_확인">2.2. 인증번호 확인</a></li>
+<li><a href="#_아이디_중복_확인">2.3. 아이디 중복 확인</a></li>
+<li><a href="#_닉네임_중복_확인">2.4. 닉네임 중복 확인</a></li>
+<li><a href="#_회원가입_2">2.5. 회원가입</a></li>
+</ul>
+</li>
+<li><a href="#_로그인로그아웃">3. 로그인/로그아웃</a>
+<ul class="sectlevel2">
+<li><a href="#_로그인">3.1. 로그인</a></li>
+<li><a href="#_로그아웃">3.2. 로그아웃</a></li>
+<li><a href="#_리프레시">3.3. 리프레시</a></li>
+</ul>
+</li>
+<li><a href="#_게시판_관리">4. 게시판 관리</a>
+<ul class="sectlevel2">
+<li><a href="#_게시판_목록_조회">4.1. 게시판 목록 조회</a></li>
+</ul>
+</li>
+<li><a href="#_글_관리">5. 글 관리</a>
+<ul class="sectlevel2">
+<li><a href="#_글_작성하기">5.1. 글 작성하기</a></li>
+<li><a href="#_글_목록_조회">5.2. 글 목록 조회</a></li>
+<li><a href="#_글_상세_보기">5.3. 글 상세 보기</a></li>
+<li><a href="#_글_수정하기">5.4. 글 수정하기</a></li>
+<li><a href="#_글_삭제하기">5.5. 글 삭제하기</a></li>
+</ul>
+</li>
+<li><a href="#_댓글_관리">6. 댓글 관리</a>
+<ul class="sectlevel2">
+<li><a href="#_댓글_작성">6.1. 댓글 작성</a></li>
+<li><a href="#_대댓글_작성">6.2. 대댓글 작성</a></li>
+<li><a href="#_댓글_목록_조회">6.3. 댓글 목록 조회</a></li>
+<li><a href="#_댓글_삭제">6.4. 댓글 삭제</a></li>
+</ul>
+</li>
+<li><a href="#_추천">7. 추천</a>
+<ul class="sectlevel2">
+<li><a href="#_게시글_추천">7.1. 게시글 추천</a></li>
+</ul>
+</li>
+<li><a href="#_해시태그">8. 해시태그</a>
+<ul class="sectlevel2">
+<li><a href="#_해시태그로_검색">8.1. 해시태그로 검색</a></li>
+<li><a href="#_해시태그_목록_조회">8.2. 해시태그 목록 조회</a></li>
+</ul>
+</li>
+<li><a href="#_신고">9. 신고</a></li>
+<li><a href="#_프로필">10. 프로필</a>
+<ul class="sectlevel2">
+<li><a href="#_닉네임_조회">10.1. 닉네임 조회</a></li>
+<li><a href="#_닉네임_변경">10.2. 닉네임 변경</a></li>
+<li><a href="#_내가_쓴_글_조회">10.3. 내가 쓴 글 조회</a></li>
+<li><a href="#_새로_등록된_알림이_있는지_조회">10.4. 새로 등록된 알림이 있는지 조회</a></li>
+<li><a href="#_알림_조회">10.5. 알림 조회</a></li>
+<li><a href="#_알림_삭제">10.6. 알림 삭제</a></li>
+</ul>
+</li>
+<li><a href="#_관리자">11. 관리자</a>
+<ul class="sectlevel2">
+<li><a href="#_관리자_페이지에서_글_삭제하기">11.1. 관리자 페이지에서 글 삭제하기</a></li>
+<li><a href="#_관리자_페이지에서_글_블락하기">11.2. 관리자 페이지에서 글 블락하기</a></li>
+<li><a href="#_관리자_페이지에서_글_블락_복구하기">11.3. 관리자 페이지에서 글 블락 복구하기</a></li>
+<li><a href="#_관리자_페이지에서_글_신고_목록_조회하기">11.4. 관리자 페이지에서 글 신고 목록 조회하기</a></li>
+<li><a href="#_관리자_페이지에서_티켓_조회하기">11.5. 관리자 페이지에서 티켓 조회하기</a></li>
+<li><a href="#_관리자_페이지에서_티켓_저장하기">11.6. 관리자 페이지에서 티켓 저장하기</a></li>
+<li><a href="#_관리자_페이지에서_티켓_사용여부_수정하기">11.7. 관리자 페이지에서 티켓 사용여부 수정하기</a></li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="_메인페이지"><a class="link" href="#_메인페이지">1. 메인페이지</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_메인페이지_조회"><a class="link" href="#_메인페이지_조회">1.1. 메인페이지 조회</a></h3>
+<div class="sect3">
+<h4 id="_성공"><a class="link" href="#_성공">1.1.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_http_request"><a class="link" href="#_성공_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /boards/contents HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_http_response"><a class="link" href="#_성공_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_회원가입"><a class="link" href="#_회원가입">2. 회원가입</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_이메일_인증"><a class="link" href="#_이메일_인증">2.1. 이메일 인증</a></h3>
+<div class="sect3">
+<h4 id="_성공_2"><a class="link" href="#_성공_2">2.1.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_2_http_request"><a class="link" href="#_성공_2_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/signup/email HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 32
+Host: localhost:8080
+
+{
+  "email" : "test@gmail.com"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_2_http_response"><a class="link" href="#_성공_2_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패"><a class="link" href="#_실패">2.1.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_우테코_크루가_아닌_경우"><a class="link" href="#_우테코_크루가_아닌_경우">우테코 크루가 아닌 경우</a></h5>
+<div class="sect5">
+<h6 id="_우테코_크루가_아닌_경우_http_request"><a class="link" href="#_우테코_크루가_아닌_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/signup/email HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 32
+Host: localhost:8080
+
+{
+  "email" : "test@gmail.com"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_우테코_크루가_아닌_경우_http_response"><a class="link" href="#_우테코_크루가_아닌_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 65
+
+{
+  "message" : "우아한테크코스 크루가 아닙니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_가입한_우테코_크루인_경우"><a class="link" href="#_가입한_우테코_크루인_경우">가입한 우테코 크루인 경우</a></h5>
+<div class="sect5">
+<h6 id="_가입한_우테코_크루인_경우_http_request"><a class="link" href="#_가입한_우테코_크루인_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/signup/email HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 32
+Host: localhost:8080
+
+{
+  "email" : "test@gmail.com"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_가입한_우테코_크루인_경우_http_response"><a class="link" href="#_가입한_우테코_크루인_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 53
+
+{
+  "message" : "이미 가입된 크루입니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_인증번호_확인"><a class="link" href="#_인증번호_확인">2.2. 인증번호 확인</a></h3>
+<div class="sect3">
+<h4 id="_성공_3"><a class="link" href="#_성공_3">2.2.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_3_http_request"><a class="link" href="#_성공_3_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/signup/email/verification HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 53
+Host: localhost:8080
+
+{
+  "email" : "test@gmail.com",
+  "code" : "a1b2c3"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_3_http_response"><a class="link" href="#_성공_3_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_2"><a class="link" href="#_실패_2">2.2.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_잘못되었거나_만료된_인증번호인_경우"><a class="link" href="#_잘못되었거나_만료된_인증번호인_경우">잘못되었거나 만료된 인증번호인 경우</a></h5>
+<div class="sect5">
+<h6 id="_잘못되었거나_만료된_인증번호인_경우_http_request"><a class="link" href="#_잘못되었거나_만료된_인증번호인_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/signup/email/verification HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 53
+Host: localhost:8080
+
+{
+  "email" : "test@gmail.com",
+  "code" : "a1b2c3"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_잘못되었거나_만료된_인증번호인_경우_http_response"><a class="link" href="#_잘못되었거나_만료된_인증번호인_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 52
+
+{
+  "message" : "잘못된 인증번호입니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_아이디_중복_확인"><a class="link" href="#_아이디_중복_확인">2.3. 아이디 중복 확인</a></h3>
+<div class="sect3">
+<h4 id="_성공_4"><a class="link" href="#_성공_4">2.3.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_고유한_아이디인_경우"><a class="link" href="#_고유한_아이디인_경우">고유한 아이디인 경우</a></h5>
+<div class="sect5">
+<h6 id="_고유한_아이디인_경우_http_request"><a class="link" href="#_고유한_아이디인_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/signup/exists?username=testName HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_고유한_아이디인_경우_http_response"><a class="link" href="#_고유한_아이디인_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 21
+
+{
+  "unique" : true
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_중복된_아이디인_경우"><a class="link" href="#_중복된_아이디인_경우">중복된 아이디인 경우</a></h5>
+<div class="sect5">
+<h6 id="_중복된_아이디인_경우_http_request"><a class="link" href="#_중복된_아이디인_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/signup/exists?username=testName HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_중복된_아이디인_경우_http_response"><a class="link" href="#_중복된_아이디인_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 22
+
+{
+  "unique" : false
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_닉네임_중복_확인"><a class="link" href="#_닉네임_중복_확인">2.4. 닉네임 중복 확인</a></h3>
+<div class="sect3">
+<h4 id="_성공_5"><a class="link" href="#_성공_5">2.4.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_고유한_닉네임인_경우"><a class="link" href="#_고유한_닉네임인_경우">고유한 닉네임인 경우</a></h5>
+<div class="sect5">
+<h6 id="_고유한_닉네임인_경우_http_request"><a class="link" href="#_고유한_닉네임인_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/signup/exists?nickname=testNickname HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_고유한_닉네임인_경우_http_response"><a class="link" href="#_고유한_닉네임인_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 21
+
+{
+  "unique" : true
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_중복된_닉네임인_경우"><a class="link" href="#_중복된_닉네임인_경우">중복된 닉네임인 경우</a></h5>
+<div class="sect5">
+<h6 id="_중복된_닉네임인_경우_http_request"><a class="link" href="#_중복된_닉네임인_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/signup/exists?nickname=testNickname HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_중복된_닉네임인_경우_http_response"><a class="link" href="#_중복된_닉네임인_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 22
+
+{
+  "unique" : false
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_회원가입_2"><a class="link" href="#_회원가입_2">2.5. 회원가입</a></h3>
+<div class="sect3">
+<h4 id="_성공_6"><a class="link" href="#_성공_6">2.5.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_6_http_request"><a class="link" href="#_성공_6_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/signup HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 177
+Host: localhost:8080
+
+{
+  "email" : "test@gmail.com",
+  "username" : "username",
+  "nickname" : "nickname",
+  "code" : "a1b1c1",
+  "password" : "password1!",
+  "passwordConfirmation" : "password1!"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_6_http_response"><a class="link" href="#_성공_6_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 201 Created
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_3"><a class="link" href="#_실패_3">2.5.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_비밀번호_확인이_다른_경우"><a class="link" href="#_비밀번호_확인이_다른_경우">비밀번호 확인이 다른 경우</a></h5>
+<div class="sect5">
+<h6 id="_비밀번호_확인이_다른_경우_http_request"><a class="link" href="#_비밀번호_확인이_다른_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/signup HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 177
+Host: localhost:8080
+
+{
+  "email" : "test@gmail.com",
+  "username" : "username",
+  "nickname" : "nickname",
+  "code" : "a1b1c1",
+  "password" : "password1!",
+  "passwordConfirmation" : "password2!"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_비밀번호_확인이_다른_경우_http_response"><a class="link" href="#_비밀번호_확인이_다른_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 85
+
+{
+  "message" : "비밀번호와 비밀번호 확인이 일치하지 않습니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_우아한테크코스_회원이_아닐_경우"><a class="link" href="#_우아한테크코스_회원이_아닐_경우">우아한테크코스 회원이 아닐 경우</a></h5>
+<div class="sect5">
+<h6 id="_우아한테크코스_회원이_아닐_경우_http_request"><a class="link" href="#_우아한테크코스_회원이_아닐_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/signup HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 182
+Host: localhost:8080
+
+{
+  "email" : "noWooteco@gmail.com",
+  "username" : "username",
+  "nickname" : "nickname",
+  "code" : "a1b1c1",
+  "password" : "password1!",
+  "passwordConfirmation" : "password1!"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_우아한테크코스_회원이_아닐_경우_http_response"><a class="link" href="#_우아한테크코스_회원이_아닐_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 65
+
+{
+  "message" : "우아한테크코스 크루가 아닙니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_이미_가입한_회원일_경우"><a class="link" href="#_이미_가입한_회원일_경우">이미 가입한 회원일 경우</a></h5>
+<div class="sect5">
+<h6 id="_이미_가입한_회원일_경우_http_request"><a class="link" href="#_이미_가입한_회원일_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/signup HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 186
+Host: localhost:8080
+
+{
+  "email" : "alreadySignUp@gmail.com",
+  "username" : "username",
+  "nickname" : "nickname",
+  "code" : "a1b1c1",
+  "password" : "password1!",
+  "passwordConfirmation" : "password1!"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_이미_가입한_회원일_경우_http_response"><a class="link" href="#_이미_가입한_회원일_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 53
+
+{
+  "message" : "이미 가입된 크루입니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_인증번호가_틀렸을_경우"><a class="link" href="#_인증번호가_틀렸을_경우">인증번호가 틀렸을 경우</a></h5>
+<div class="sect5">
+<h6 id="_인증번호가_틀렸을_경우_http_request"><a class="link" href="#_인증번호가_틀렸을_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/signup HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 177
+Host: localhost:8080
+
+{
+  "email" : "test@gmail.com",
+  "username" : "username",
+  "nickname" : "nickname",
+  "code" : "NoCode",
+  "password" : "password1!",
+  "passwordConfirmation" : "password1!"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_인증번호가_틀렸을_경우_http_response"><a class="link" href="#_인증번호가_틀렸을_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 52
+
+{
+  "message" : "잘못된 인증번호입니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_이미_존재하는_아이디일_경우"><a class="link" href="#_이미_존재하는_아이디일_경우">이미 존재하는 아이디일 경우</a></h5>
+<div class="sect5">
+<h6 id="_이미_존재하는_아이디일_경우_http_request"><a class="link" href="#_이미_존재하는_아이디일_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/signup HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 189
+Host: localhost:8080
+
+{
+  "email" : "alreadySignUp@gmail.com",
+  "username" : "username",
+  "nickname" : "AlreadyNick",
+  "code" : "a1b1c1",
+  "password" : "password1!",
+  "passwordConfirmation" : "password1!"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_이미_존재하는_아이디일_경우_http_response"><a class="link" href="#_이미_존재하는_아이디일_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 65
+
+{
+  "message" : "비정상적인 회원가입 절차입니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_이미_존재하는_닉네임일_경우"><a class="link" href="#_이미_존재하는_닉네임일_경우">이미 존재하는 닉네임일 경우</a></h5>
+<div class="sect5">
+<h6 id="_이미_존재하는_닉네임일_경우_http_request"><a class="link" href="#_이미_존재하는_닉네임일_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/signup HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 189
+Host: localhost:8080
+
+{
+  "email" : "alreadySignUp@gmail.com",
+  "username" : "username",
+  "nickname" : "AlreadyNick",
+  "code" : "a1b1c1",
+  "password" : "password1!",
+  "passwordConfirmation" : "password1!"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_이미_존재하는_닉네임일_경우_http_response"><a class="link" href="#_이미_존재하는_닉네임일_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 65
+
+{
+  "message" : "비정상적인 회원가입 절차입니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_로그인로그아웃"><a class="link" href="#_로그인로그아웃">3. 로그인/로그아웃</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_로그인"><a class="link" href="#_로그인">3.1. 로그인</a></h3>
+<div class="sect3">
+<h4 id="_성공_7"><a class="link" href="#_성공_7">3.1.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_7_http_request"><a class="link" href="#_성공_7_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /login HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 54
+Host: localhost:8080
+
+{
+  "username" : "chris",
+  "password" : "Abcd123!@"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_7_http_response"><a class="link" href="#_성공_7_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Authorization: Bearer null
+Refresh-Token: Bearer null</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_4"><a class="link" href="#_실패_4">3.1.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_아이디나_비밀번호가_잘못되었을_경우"><a class="link" href="#_아이디나_비밀번호가_잘못되었을_경우">아이디나 비밀번호가 잘못되었을 경우</a></h5>
+<div class="sect5">
+<h6 id="_아이디나_비밀번호가_잘못되었을_경우_http_request"><a class="link" href="#_아이디나_비밀번호가_잘못되었을_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /login HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 72
+Host: localhost:8080
+
+{
+  "username" : "invalidUsername",
+  "password" : "invalidPassword1!"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_아이디나_비밀번호가_잘못되었을_경우_http_response"><a class="link" href="#_아이디나_비밀번호가_잘못되었을_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 70
+
+{
+  "message" : "아이디나 비밀번호가 잘못되었습니다"
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_로그아웃"><a class="link" href="#_로그아웃">3.2. 로그아웃</a></h3>
+<div class="sect3">
+<h4 id="_성공_8"><a class="link" href="#_성공_8">3.2.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_8_http_request"><a class="link" href="#_성공_8_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /logout HTTP/1.1
+Authorization: any
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_8_http_response"><a class="link" href="#_성공_8_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_리프레시"><a class="link" href="#_리프레시">3.3. 리프레시</a></h3>
+<div class="paragraph">
+<p>리프레시 관련 컨트롤러 테스트 구현 필요</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_게시판_관리"><a class="link" href="#_게시판_관리">4. 게시판 관리</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_게시판_목록_조회"><a class="link" href="#_게시판_목록_조회">4.1. 게시판 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_성공_9"><a class="link" href="#_성공_9">4.1.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_9_http_request"><a class="link" href="#_성공_9_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /boards HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_9_http_response"><a class="link" href="#_성공_9_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_글_관리"><a class="link" href="#_글_관리">5. 글 관리</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_글_작성하기"><a class="link" href="#_글_작성하기">5.1. 글 작성하기</a></h3>
+<div class="sect3">
+<h4 id="_성공_10"><a class="link" href="#_성공_10">5.1.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_10_http_request"><a class="link" href="#_성공_10_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /boards/1/posts HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Content-Length: 112
+Host: localhost:8080
+
+{
+  "title" : "제목",
+  "content" : "본문",
+  "anonymous" : false,
+  "hashtags" : [ "태그1", "태그2" ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_10_http_response"><a class="link" href="#_성공_10_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 201 Created
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Location: /posts/0</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_5"><a class="link" href="#_실패_5">5.1.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_제목에_내용이_없는_경우"><a class="link" href="#_제목에_내용이_없는_경우">제목에 내용이 없는 경우</a></h5>
+<div class="sect5">
+<h6 id="_제목에_내용이_없는_경우_http_request"><a class="link" href="#_제목에_내용이_없는_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /boards/1/posts HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Content-Length: 87
+Host: localhost:8080
+
+{
+  "title" : null,
+  "content" : "본문",
+  "anonymous" : false,
+  "hashtags" : [ ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_제목에_내용이_없는_경우_http_response"><a class="link" href="#_제목에_내용이_없는_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 71
+
+{
+  "message" : "제목은 1자 이상 50자 이하여야 합니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_본문에_내용이_없는_경우"><a class="link" href="#_본문에_내용이_없는_경우">본문에 내용이 없는 경우</a></h5>
+<div class="sect5">
+<h6 id="_본문에_내용이_없는_경우_http_request"><a class="link" href="#_본문에_내용이_없는_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /boards/1/posts HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Content-Length: 87
+Host: localhost:8080
+
+{
+  "title" : "제목",
+  "content" : null,
+  "anonymous" : false,
+  "hashtags" : [ ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_본문에_내용이_없는_경우_http_response"><a class="link" href="#_본문에_내용이_없는_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 73
+
+{
+  "message" : "본문은 1자 이상 5000자 이하여야 합니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_글_목록_조회"><a class="link" href="#_글_목록_조회">5.2. 글 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_성공_11"><a class="link" href="#_성공_11">5.2.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_11_http_request"><a class="link" href="#_성공_11_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /boards/1/posts?size=3&amp;page=0 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_11_http_response"><a class="link" href="#_성공_11_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 463
+
+{
+  "posts" : [ {
+    "id" : 1,
+    "title" : "제목1",
+    "content" : "본문1",
+    "createdAt" : "2022-08-16T15:02:29.953635",
+    "likeCount" : 0,
+    "commentCount" : 0,
+    "modified" : false,
+    "blocked" : false
+  }, {
+    "id" : 2,
+    "title" : "제목2",
+    "content" : "본문2",
+    "createdAt" : "2022-08-16T15:02:29.953857",
+    "likeCount" : 0,
+    "commentCount" : 0,
+    "modified" : false,
+    "blocked" : false
+  } ],
+  "lastPage" : true
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_글_상세_보기"><a class="link" href="#_글_상세_보기">5.3. 글 상세 보기</a></h3>
+<div class="sect3">
+<h4 id="_성공_12"><a class="link" href="#_성공_12">5.3.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_12_http_request"><a class="link" href="#_성공_12_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /posts/1 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_12_http_response"><a class="link" href="#_성공_12_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 312
+
+{
+  "id" : 1,
+  "boardId" : null,
+  "nickname" : null,
+  "title" : "제목1",
+  "content" : "본문1",
+  "blocked" : false,
+  "hashtags" : [ {
+    "id" : 1,
+    "name" : "gogo"
+  } ],
+  "createdAt" : "2022-08-16T15:02:30.228861",
+  "likeCount" : 0,
+  "like" : false,
+  "authorized" : true,
+  "modified" : false
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_6"><a class="link" href="#_실패_6">5.3.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_해당_게시물이_없는_경우"><a class="link" href="#_해당_게시물이_없는_경우">해당 게시물이 없는 경우</a></h5>
+<div class="sect5">
+<h6 id="_해당_게시물이_없는_경우_http_request"><a class="link" href="#_해당_게시물이_없는_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /posts/9999 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_해당_게시물이_없는_경우_http_response"><a class="link" href="#_해당_게시물이_없는_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 404 Not Found
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 57
+
+{
+  "message" : "게시물을 찾을 수 없습니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_글_수정하기"><a class="link" href="#_글_수정하기">5.4. 글 수정하기</a></h3>
+<div class="sect3">
+<h4 id="_성공_13"><a class="link" href="#_성공_13">5.4.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_13_http_request"><a class="link" href="#_성공_13_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /posts/1 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Content-Length: 94
+Host: localhost:8080
+
+{
+  "title" : "변경된 제목",
+  "content" : "변경된 본문",
+  "hashtags" : [ "tag" ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_13_http_response"><a class="link" href="#_성공_13_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_7"><a class="link" href="#_실패_7">5.4.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_게시물_수정_권한이_없는_경우"><a class="link" href="#_게시물_수정_권한이_없는_경우">게시물 수정 권한이 없는 경우</a></h5>
+<div class="sect5">
+<h6 id="_게시물_수정_권한이_없는_경우_http_request"><a class="link" href="#_게시물_수정_권한이_없는_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /posts/1 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Content-Length: 94
+Host: localhost:8080
+
+{
+  "title" : "변경된 제목",
+  "content" : "변경된 본문",
+  "hashtags" : [ "tag" ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_게시물_수정_권한이_없는_경우_http_response"><a class="link" href="#_게시물_수정_권한이_없는_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 43
+
+{
+  "message" : "권한이 없습니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_제목_혹은_본문에_내용이_없는_경우"><a class="link" href="#_제목_혹은_본문에_내용이_없는_경우">제목 혹은 본문에 내용이 없는 경우</a></h5>
+<div class="sect5">
+<h6 id="_제목_혹은_본문에_내용이_없는_경우_http_request"><a class="link" href="#_제목_혹은_본문에_내용이_없는_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /posts/1 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Content-Length: 80
+Host: localhost:8080
+
+{
+  "title" : null,
+  "content" : "변경된 본문",
+  "hashtags" : [ "tag" ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_제목_혹은_본문에_내용이_없는_경우_http_response"><a class="link" href="#_제목_혹은_본문에_내용이_없는_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 57
+
+{
+  "message" : "제목 혹은 본문이 없습니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_글_삭제하기"><a class="link" href="#_글_삭제하기">5.5. 글 삭제하기</a></h3>
+<div class="sect3">
+<h4 id="_성공_14"><a class="link" href="#_성공_14">5.5.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_14_http_request"><a class="link" href="#_성공_14_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /posts/1 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_14_http_response"><a class="link" href="#_성공_14_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_8"><a class="link" href="#_실패_8">5.5.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_게시물_삭제_권한이_없는_경우"><a class="link" href="#_게시물_삭제_권한이_없는_경우">게시물 삭제 권한이 없는 경우</a></h5>
+<div class="sect5">
+<h6 id="_게시물_삭제_권한이_없는_경우_http_request"><a class="link" href="#_게시물_삭제_권한이_없는_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /posts/1 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_게시물_삭제_권한이_없는_경우_http_response"><a class="link" href="#_게시물_삭제_권한이_없는_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 43
+
+{
+  "message" : "권한이 없습니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_댓글_관리"><a class="link" href="#_댓글_관리">6. 댓글 관리</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_댓글_작성"><a class="link" href="#_댓글_작성">6.1. 댓글 작성</a></h3>
+<div class="sect3">
+<h4 id="_성공_15"><a class="link" href="#_성공_15">6.1.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_15_http_request"><a class="link" href="#_성공_15_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /posts/1/comments HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Content-Length: 48
+Host: localhost:8080
+
+{
+  "content" : "댓글",
+  "anonymous" : true
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_15_http_response"><a class="link" href="#_성공_15_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 201 Created
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Location: /comments/0</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_9"><a class="link" href="#_실패_9">6.1.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_댓글_내용이_없는_경우"><a class="link" href="#_댓글_내용이_없는_경우">댓글 내용이 없는 경우</a></h5>
+<div class="sect5">
+<h6 id="_댓글_내용이_없는_경우_http_request"><a class="link" href="#_댓글_내용이_없는_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /posts/1/comments HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Content-Length: 44
+Host: localhost:8080
+Cookie: JSESSIONID=mySessionId
+
+{
+  "content" : null,
+  "anonymous" : true
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_댓글_내용이_없는_경우_http_response"><a class="link" href="#_댓글_내용이_없는_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 71
+
+{
+  "message" : "댓글은 1자 이상 50자 이하여야 합니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_대댓글_작성"><a class="link" href="#_대댓글_작성">6.2. 대댓글 작성</a></h3>
+<div class="sect3">
+<h4 id="_성공_16"><a class="link" href="#_성공_16">6.2.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_16_http_request"><a class="link" href="#_성공_16_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /comments/1/reply HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Content-Length: 51
+Host: localhost:8080
+
+{
+  "content" : "대댓글",
+  "anonymous" : true
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_16_http_response"><a class="link" href="#_성공_16_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 201 Created
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Location: /comments/0</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_댓글_목록_조회"><a class="link" href="#_댓글_목록_조회">6.3. 댓글 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_성공_17"><a class="link" href="#_성공_17">6.3.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_17_http_request"><a class="link" href="#_성공_17_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /posts/1/comments HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_17_http_response"><a class="link" href="#_성공_17_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 917
+
+{
+  "comments" : [ {
+    "id" : 1,
+    "nickname" : "조시1",
+    "content" : "댓글1",
+    "createdAt" : "2022-08-16T15:02:04.294781",
+    "blocked" : false,
+    "postWriter" : false,
+    "authorized" : false,
+    "replies" : [ {
+      "id" : 3,
+      "nickname" : "이스트1",
+      "content" : "대댓글1",
+      "createdAt" : "2022-08-16T15:02:04.294744",
+      "blocked" : false,
+      "postWriter" : false,
+      "authorized" : false
+    }, {
+      "id" : 4,
+      "nickname" : "이스트2",
+      "content" : "대댓글2",
+      "createdAt" : "2022-08-16T15:02:04.294772",
+      "blocked" : false,
+      "postWriter" : false,
+      "authorized" : false
+    } ]
+  }, {
+    "id" : 2,
+    "nickname" : "조시2",
+    "content" : "댓글2",
+    "createdAt" : "2022-08-16T15:02:04.294839",
+    "blocked" : false,
+    "postWriter" : true,
+    "authorized" : false,
+    "replies" : [ ]
+  } ],
+  "totalCount" : 4
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_댓글_삭제"><a class="link" href="#_댓글_삭제">6.4. 댓글 삭제</a></h3>
+<div class="sect3">
+<h4 id="_성공_18"><a class="link" href="#_성공_18">6.4.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_18_http_request"><a class="link" href="#_성공_18_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /comments/1 HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_18_http_response"><a class="link" href="#_성공_18_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_추천"><a class="link" href="#_추천">7. 추천</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_게시글_추천"><a class="link" href="#_게시글_추천">7.1. 게시글 추천</a></h3>
+<div class="paragraph">
+<p>게시글 추천 관련 컨트롤러 테스트 구현 필요</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_해시태그"><a class="link" href="#_해시태그">8. 해시태그</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_해시태그로_검색"><a class="link" href="#_해시태그로_검색">8.1. 해시태그로 검색</a></h3>
+<div class="sect3">
+<h4 id="_성공_19"><a class="link" href="#_성공_19">8.1.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_19_http_request"><a class="link" href="#_성공_19_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /posts?hashtag=%EC%86%8D%EB%8B%A5&amp;size=5&amp;page=0 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_19_http_response"><a class="link" href="#_성공_19_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 470
+
+{
+  "posts" : [ {
+    "id" : 3,
+    "title" : "제목",
+    "content" : "내용",
+    "createdAt" : "-999999999-01-01T00:00:00",
+    "likeCount" : 5,
+    "commentCount" : 2,
+    "modified" : false,
+    "blocked" : false
+  }, {
+    "id" : 2,
+    "title" : "제목2",
+    "content" : "내용2",
+    "createdAt" : "+999999999-12-31T23:59:59.999999999",
+    "likeCount" : 10,
+    "commentCount" : 4,
+    "modified" : false,
+    "blocked" : false
+  } ],
+  "lastPage" : true
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_10"><a class="link" href="#_실패_10">8.1.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_댓글_내용이_없는_경우_2"><a class="link" href="#_댓글_내용이_없는_경우_2">댓글 내용이 없는 경우</a></h5>
+<div class="sect5">
+<h6 id="_댓글_내용이_없는_경우_2_http_request"><a class="link" href="#_댓글_내용이_없는_경우_2_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /posts?hashtag=%EC%97%86%EB%8A%94%ED%83%9C%EA%B7%B8&amp;size=5&amp;page=0 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_댓글_내용이_없는_경우_2_http_response"><a class="link" href="#_댓글_내용이_없는_경우_2_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 404 Not Found
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 77
+
+{
+  "message" : "해당 이름의 해시태그를 찾을 수 없습니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_해시태그_목록_조회"><a class="link" href="#_해시태그_목록_조회">8.2. 해시태그 목록 조회</a></h3>
+<div class="sect3">
+<h4 id="_성공_20"><a class="link" href="#_성공_20">8.2.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_20_http_request"><a class="link" href="#_성공_20_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /hashtags/popular?include=%ED%83%9C%EA%B7%B8&amp;limit=3 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_20_http_response"><a class="link" href="#_성공_20_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 143
+
+{
+  "hashtags" : [ {
+    "id" : 1,
+    "name" : "태그1",
+    "count" : 5
+  }, {
+    "id" : 2,
+    "name" : "태그2",
+    "count" : 2
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_신고"><a class="link" href="#_신고">9. 신고</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>게시글/댓글 신고 관련 컨트롤러 테스트 구현 필요</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_프로필"><a class="link" href="#_프로필">10. 프로필</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_닉네임_조회"><a class="link" href="#_닉네임_조회">10.1. 닉네임 조회</a></h3>
+<div class="sect3">
+<h4 id="_성공_21"><a class="link" href="#_성공_21">10.1.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_21_http_request"><a class="link" href="#_성공_21_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/nickname HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: Bearer chris
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_21_http_response"><a class="link" href="#_성공_21_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 34
+
+{
+  "nickname" : "chrisNickname"
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_닉네임_변경"><a class="link" href="#_닉네임_변경">10.2. 닉네임 변경</a></h3>
+<div class="sect3">
+<h4 id="_성공_22"><a class="link" href="#_성공_22">10.2.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_22_http_request"><a class="link" href="#_성공_22_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /members/nickname HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: Bearer chris
+Content-Length: 31
+Host: localhost:8080
+
+{
+  "nickname" : "chrisNick2"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_22_http_response"><a class="link" href="#_성공_22_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_11"><a class="link" href="#_실패_11">10.2.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_이미_있는_닉네임인_경우"><a class="link" href="#_이미_있는_닉네임인_경우">이미 있는 닉네임인 경우</a></h5>
+<div class="sect5">
+<h6 id="_이미_있는_닉네임인_경우_http_request"><a class="link" href="#_이미_있는_닉네임인_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /members/nickname HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: Bearer chris
+Content-Length: 34
+Host: localhost:8080
+
+{
+  "nickname" : "hunchNickname"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_이미_있는_닉네임인_경우_http_response"><a class="link" href="#_이미_있는_닉네임인_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 59
+
+{
+  "message" : "이미 존재하는 닉네임입니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_잘못된_형식인_경우"><a class="link" href="#_잘못된_형식인_경우">잘못된 형식인 경우</a></h5>
+<div class="sect5">
+<h6 id="_잘못된_형식인_경우_http_request"><a class="link" href="#_잘못된_형식인_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /members/nickname HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: Bearer chris
+Content-Length: 21
+Host: localhost:8080
+
+{
+  "nickname" : ""
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_잘못된_형식인_경우_http_response"><a class="link" href="#_잘못된_형식인_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 56
+
+{
+  "message" : "잘못된 닉네임 형식입니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_내가_쓴_글_조회"><a class="link" href="#_내가_쓴_글_조회">10.3. 내가 쓴 글 조회</a></h3>
+<div class="sect3">
+<h4 id="_성공_23"><a class="link" href="#_성공_23">10.3.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_해당_페이지의_글이_존재할_경우"><a class="link" href="#_해당_페이지의_글이_존재할_경우">해당 페이지의 글이 존재할 경우</a></h5>
+<div class="sect5">
+<h6 id="_해당_페이지의_글이_존재할_경우_http_request"><a class="link" href="#_해당_페이지의_글이_존재할_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /posts/me?size=2&amp;page=0 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: Bearer any
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_해당_페이지의_글이_존재할_경우_http_response"><a class="link" href="#_해당_페이지의_글이_존재할_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 466
+
+{
+  "posts" : [ {
+    "id" : 2,
+    "title" : "제목2",
+    "content" : "본문2",
+    "createdAt" : "2022-08-16T15:02:29.953857",
+    "likeCount" : 0,
+    "commentCount" : 0,
+    "modified" : false,
+    "blocked" : false
+  }, {
+    "id" : 1,
+    "title" : "제목1",
+    "content" : "본문1",
+    "createdAt" : "2022-08-16T15:02:29.953635",
+    "likeCount" : 0,
+    "commentCount" : 0,
+    "modified" : false,
+    "blocked" : false
+  } ],
+  "totalPageCount" : 5
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_해당_페이지의_글이_없을_경우"><a class="link" href="#_해당_페이지의_글이_없을_경우">해당 페이지의 글이 없을 경우</a></h5>
+<div class="sect5">
+<h6 id="_해당_페이지의_글이_없을_경우_http_request"><a class="link" href="#_해당_페이지의_글이_없을_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /posts/me?size=2&amp;page=99 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: Bearer any
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_해당_페이지의_글이_없을_경우_http_response"><a class="link" href="#_해당_페이지의_글이_없을_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 43
+
+{
+  "posts" : [ ],
+  "totalPageCount" : 5
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_새로_등록된_알림이_있는지_조회"><a class="link" href="#_새로_등록된_알림이_있는지_조회">10.4. 새로 등록된 알림이 있는지 조회</a></h3>
+<div class="sect3">
+<h4 id="_성공_24"><a class="link" href="#_성공_24">10.4.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_24_http_request"><a class="link" href="#_성공_24_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /notifications/check HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_24_http_response"><a class="link" href="#_성공_24_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 24
+
+{
+  "existence" : true
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_알림_조회"><a class="link" href="#_알림_조회">10.5. 알림 조회</a></h3>
+<div class="sect3">
+<h4 id="_성공_25"><a class="link" href="#_성공_25">10.5.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_25_http_request"><a class="link" href="#_성공_25_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /notifications?size=2&amp;page=1 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: any
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_25_http_response"><a class="link" href="#_성공_25_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 347
+
+{
+  "notifications" : [ {
+    "id" : 1,
+    "content" : "게시글 제목",
+    "createdAt" : "2022-08-16T15:02:26.306277",
+    "type" : "POST_REPORT",
+    "postId" : 1
+  }, {
+    "id" : 1,
+    "content" : "게시글 제목",
+    "createdAt" : "2022-08-16T15:02:26.306341",
+    "type" : "NEW_COMMENT",
+    "postId" : 1
+  } ],
+  "lastPage" : true
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_알림_삭제"><a class="link" href="#_알림_삭제">10.6. 알림 삭제</a></h3>
+<div class="sect3">
+<h4 id="_삭제"><a class="link" href="#_삭제">10.6.1. 삭제</a></h4>
+<div class="sect4">
+<h5 id="_삭제_http_request"><a class="link" href="#_삭제_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /notifications/1 HTTP/1.1
+Authorization: any
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_삭제_http_response"><a class="link" href="#_삭제_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_관리자"><a class="link" href="#_관리자">11. 관리자</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_관리자_페이지에서_글_삭제하기"><a class="link" href="#_관리자_페이지에서_글_삭제하기">11.1. 관리자 페이지에서 글 삭제하기</a></h3>
+<div class="sect3">
+<h4 id="_성공_26"><a class="link" href="#_성공_26">11.1.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_26_http_request"><a class="link" href="#_성공_26_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /admin/posts/1 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer admin
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_26_http_response"><a class="link" href="#_성공_26_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_12"><a class="link" href="#_실패_12">11.1.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_관리자가_아닐_경우"><a class="link" href="#_관리자가_아닐_경우">관리자가 아닐 경우</a></h5>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_http_request"><a class="link" href="#_관리자가_아닐_경우_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /admin/posts/1 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer notAdmin
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_http_response"><a class="link" href="#_관리자가_아닐_경우_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 56
+
+{
+  "message" : "관리자만 접근 가능합니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_관리자_페이지에서_글_블락하기"><a class="link" href="#_관리자_페이지에서_글_블락하기">11.2. 관리자 페이지에서 글 블락하기</a></h3>
+<div class="sect3">
+<h4 id="_성공_27"><a class="link" href="#_성공_27">11.2.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_27_http_request"><a class="link" href="#_성공_27_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /admin/posts/1/postreports/5 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer admin
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_27_http_response"><a class="link" href="#_성공_27_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_13"><a class="link" href="#_실패_13">11.2.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_관리자가_아닐_경우_2"><a class="link" href="#_관리자가_아닐_경우_2">관리자가 아닐 경우</a></h5>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_2_http_request"><a class="link" href="#_관리자가_아닐_경우_2_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /admin/posts/1/postreports/5 HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer noAdmin
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_2_http_response"><a class="link" href="#_관리자가_아닐_경우_2_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 56
+
+{
+  "message" : "관리자만 접근 가능합니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_관리자_페이지에서_글_블락_복구하기"><a class="link" href="#_관리자_페이지에서_글_블락_복구하기">11.3. 관리자 페이지에서 글 블락 복구하기</a></h3>
+<div class="sect3">
+<h4 id="_성공_28"><a class="link" href="#_성공_28">11.3.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_28_http_request"><a class="link" href="#_성공_28_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /admin/posts/1/postreports HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer admin
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_28_http_response"><a class="link" href="#_성공_28_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_14"><a class="link" href="#_실패_14">11.3.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_관리자가_아닐_경우_3"><a class="link" href="#_관리자가_아닐_경우_3">관리자가 아닐 경우</a></h5>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_3_http_request"><a class="link" href="#_관리자가_아닐_경우_3_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /admin/posts/1/postreports HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer noAdmin
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_3_http_response"><a class="link" href="#_관리자가_아닐_경우_3_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 56
+
+{
+  "message" : "관리자만 접근 가능합니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_관리자_페이지에서_글_신고_목록_조회하기"><a class="link" href="#_관리자_페이지에서_글_신고_목록_조회하기">11.4. 관리자 페이지에서 글 신고 목록 조회하기</a></h3>
+<div class="sect3">
+<h4 id="_성공_29"><a class="link" href="#_성공_29">11.4.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_29_http_request"><a class="link" href="#_성공_29_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /admin/postreports HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer admin
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_29_http_response"><a class="link" href="#_성공_29_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 309
+
+{
+  "postReports" : [ {
+    "id" : 1,
+    "postId" : 1,
+    "reporterId" : 1,
+    "reportMessage" : "비속어",
+    "createdAt" : "2022-08-16T15:01:28.26731"
+  }, {
+    "id" : 1,
+    "postId" : 1,
+    "reporterId" : 2,
+    "reportMessage" : "비속어",
+    "createdAt" : "2022-08-16T15:01:28.267348"
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_15"><a class="link" href="#_실패_15">11.4.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_관리자가_아닐_경우_4"><a class="link" href="#_관리자가_아닐_경우_4">관리자가 아닐 경우</a></h5>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_4_http_request"><a class="link" href="#_관리자가_아닐_경우_4_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /admin/postreports HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer noAdmin
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_4_http_response"><a class="link" href="#_관리자가_아닐_경우_4_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 56
+
+{
+  "message" : "관리자만 접근 가능합니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_관리자_페이지에서_티켓_조회하기"><a class="link" href="#_관리자_페이지에서_티켓_조회하기">11.5. 관리자 페이지에서 티켓 조회하기</a></h3>
+<div class="sect3">
+<h4 id="_성공_30"><a class="link" href="#_성공_30">11.5.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_30_http_request"><a class="link" href="#_성공_30_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /admin/tickets HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer admin
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_30_http_response"><a class="link" href="#_성공_30_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 162
+
+{
+  "tickets" : [ {
+    "id" : 1,
+    "serialNumber" : "123456",
+    "used" : false
+  }, {
+    "id" : 2,
+    "serialNumber" : "234567",
+    "used" : false
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_16"><a class="link" href="#_실패_16">11.5.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_관리자가_아닐_경우_5"><a class="link" href="#_관리자가_아닐_경우_5">관리자가 아닐 경우</a></h5>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_5_http_request"><a class="link" href="#_관리자가_아닐_경우_5_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /admin/tickets HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer noAdmin
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_5_http_response"><a class="link" href="#_관리자가_아닐_경우_5_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 56
+
+{
+  "message" : "관리자만 접근 가능합니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_관리자_페이지에서_티켓_저장하기"><a class="link" href="#_관리자_페이지에서_티켓_저장하기">11.6. 관리자 페이지에서 티켓 저장하기</a></h3>
+<div class="sect3">
+<h4 id="_성공_31"><a class="link" href="#_성공_31">11.6.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_31_http_request"><a class="link" href="#_성공_31_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /admin/tickets HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer admin
+Content-Length: 61
+Host: localhost:8080
+
+{
+  "id" : 2,
+  "serialNumber" : "234567",
+  "used" : false
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_31_http_response"><a class="link" href="#_성공_31_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_17"><a class="link" href="#_실패_17">11.6.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_관리자가_아닐_경우_6"><a class="link" href="#_관리자가_아닐_경우_6">관리자가 아닐 경우</a></h5>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_6_http_request"><a class="link" href="#_관리자가_아닐_경우_6_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /admin/tickets HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer noAdmin
+Content-Length: 61
+Host: localhost:8080
+
+{
+  "id" : 2,
+  "serialNumber" : "234567",
+  "used" : false
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_6_http_response"><a class="link" href="#_관리자가_아닐_경우_6_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 56
+
+{
+  "message" : "관리자만 접근 가능합니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_관리자_페이지에서_티켓_사용여부_수정하기"><a class="link" href="#_관리자_페이지에서_티켓_사용여부_수정하기">11.7. 관리자 페이지에서 티켓 사용여부 수정하기</a></h3>
+<div class="sect3">
+<h4 id="_성공_32"><a class="link" href="#_성공_32">11.7.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_성공_32_http_request"><a class="link" href="#_성공_32_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /admin/tickets HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer admin
+Content-Length: 61
+Host: localhost:8080
+
+{
+  "id" : 2,
+  "serialNumber" : "234567",
+  "used" : false
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_성공_32_http_response"><a class="link" href="#_성공_32_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_18"><a class="link" href="#_실패_18">11.7.2. 실패</a></h4>
+<div class="sect4">
+<h5 id="_관리자가_아닐_경우_7"><a class="link" href="#_관리자가_아닐_경우_7">관리자가 아닐 경우</a></h5>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_7_http_request"><a class="link" href="#_관리자가_아닐_경우_7_http_request">HTTP request</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /admin/tickets HTTP/1.1
+Content-Type: application/json
+Content-Type: application/json
+Authorization: bearer noAdmin
+Content-Length: 61
+Host: localhost:8080
+
+{
+  "id" : 2,
+  "serialNumber" : "234567",
+  "used" : false
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_관리자가_아닐_경우_7_http_response"><a class="link" href="#_관리자가_아닐_경우_7_http_response">HTTP response</a></h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 56
+
+{
+  "message" : "관리자만 접근 가능합니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Version 0.0.1-SNAPSHOT<br>
+Last updated 2022-08-16 14:22:28 +0900
+</div>
+</div>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
+<script>hljs.initHighlighting()</script>
+</body>
+</html>

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
@@ -1,8 +1,38 @@
 package com.wooteco.sokdak.admin.acceptance;
 
+import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.getAdminToken;
+import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpGetWithAuthorization;
+import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPostWithAuthorization;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wooteco.sokdak.admin.dto.PostReportElement;
 import com.wooteco.sokdak.util.AcceptanceTest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 public class AdminAcceptanceTest extends AcceptanceTest {
 
+    private static final int reportCount = 5;
 
+    @DisplayName("관리자 페이지에서 여러 DB 세팅을 할 수 있다...")
+    @Test
+    void adminGogo() {
+        String adminToken = getAdminToken();
+//      블락
+        httpPostWithAuthorization(new Object(), "admin/posts/1/postReports/" + reportCount, adminToken);
+//      블락목록 검색
+        ExtractableResponse<Response> response = httpGetWithAuthorization("admin/postReports",
+                adminToken);
+        List<PostReportElement> postReports = getPostReports(response);
+        assertThat(postReports).hasSize(reportCount);
+    }
+
+    private List<PostReportElement> getPostReports(ExtractableResponse<Response> response) {
+        return response.body()
+                .jsonPath()
+                .getList("postReports", PostReportElement.class);
+    }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
@@ -1,33 +1,96 @@
 package com.wooteco.sokdak.admin.acceptance;
 
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.getAdminToken;
+import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.getChrisToken;
+import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpDeleteWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpGetWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPostWithAuthorization;
+import static com.wooteco.sokdak.util.fixture.PostFixture.CREATE_POST_URI;
+import static com.wooteco.sokdak.util.fixture.PostFixture.NEW_POST_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.wooteco.sokdak.admin.dto.PostReportElement;
+import com.wooteco.sokdak.admin.dto.TicketElement;
+import com.wooteco.sokdak.admin.dto.TicketRequest;
 import com.wooteco.sokdak.util.AcceptanceTest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 
 public class AdminAcceptanceTest extends AcceptanceTest {
 
     private static final int reportCount = 5;
+    private static final String SERIAL_NUMBER = "test1@gmail.com";
 
-    @DisplayName("관리자 페이지에서 여러 DB 세팅을 할 수 있다...")
+    @DisplayName("관리자 페이지에서 특정 게시글을 삭제할 수 있다.")
     @Test
-    void adminGogo() {
+    void deletePost() {
+        String chrisToken = getChrisToken();
         String adminToken = getAdminToken();
-//      블락
-        httpPostWithAuthorization(new Object(), "admin/posts/1/postReports/" + reportCount, adminToken);
-//      블락목록 검색
-        ExtractableResponse<Response> response = httpGetWithAuthorization("admin/postReports",
-                adminToken);
-        List<PostReportElement> postReports = getPostReports(response);
-        assertThat(postReports).hasSize(reportCount);
+        httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, chrisToken);
+
+        httpDeleteWithAuthorization("admin/posts/1", adminToken);
+
+        ExtractableResponse<Response> actual = httpGetWithAuthorization("posts/1", adminToken);
+        assertAll(
+                () -> assertThat(actual.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value()),
+                () -> assertThat(actual.body().asString()).contains("게시물을 찾을 수 없습니다.")
+        );
+    }
+
+    @DisplayName("관리자 페이지에서 특정 글 블락 처리, 신고목록 조회, 블락 해제가 가능하다.")
+    @Test
+    void blockAndFindReportsAndUnBlockPost() {
+        String chrisToken = getChrisToken();
+        String adminToken = getAdminToken();
+        httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, chrisToken);
+
+        httpPostWithAuthorization("", "admin/posts/1/postReports/" + reportCount, adminToken);
+        ExtractableResponse<Response> response = httpGetWithAuthorization("admin/postReports", adminToken);
+        httpDeleteWithAuthorization("admin/posts/1/postReports", adminToken);
+        ExtractableResponse<Response> response2 = httpGetWithAuthorization("admin/postReports", adminToken);
+
+        assertAll(
+                () -> assertThat(getPostReports(response)).hasSize(reportCount),
+                () -> assertThat(getPostReports(response2)).isEmpty()
+        );
+    }
+
+    @DisplayName("관리자 페이지에서 티켓추가, 티켓목록 조회, 티켓 상태 변경이 가능하다.")
+    @Test
+    void saveAndFindAndUpdateTicket() {
+        String adminToken = getAdminToken();
+        TicketRequest initTicketRequest = TicketRequest.builder()
+                .serialNumber(SERIAL_NUMBER)
+                .used(false)
+                .build();
+        TicketRequest usedTicketRequest = TicketRequest.builder()
+                .serialNumber(SERIAL_NUMBER)
+                .used(true)
+                .build();
+        int lastTicketIndex = 7;
+
+        httpPostWithAuthorization(initTicketRequest, "admin/tickets", adminToken);
+        TicketElement initTicketElement = getTicketElements(httpGetWithAuthorization("admin/tickets", adminToken))
+                .get(lastTicketIndex);
+        httpPostWithAuthorization(usedTicketRequest, "admin/tickets/used", adminToken);
+        TicketElement usedTicketElement = getTicketElements(httpGetWithAuthorization("admin/tickets", adminToken))
+                .get(lastTicketIndex);
+
+        assertAll(
+                () -> assertThat(initTicketElement.isUsed()).isFalse(),
+                () -> assertThat(usedTicketElement.isUsed()).isTrue()
+        );
+    }
+
+    private List<TicketElement> getTicketElements(ExtractableResponse<Response> response) {
+        return response.body()
+                .jsonPath()
+                .getList("tickets", TicketElement.class);
     }
 
     private List<PostReportElement> getPostReports(ExtractableResponse<Response> response) {

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
@@ -1,0 +1,8 @@
+package com.wooteco.sokdak.admin.acceptance;
+
+import com.wooteco.sokdak.util.AcceptanceTest;
+
+public class AdminAcceptanceTest extends AcceptanceTest {
+
+
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
+@DisplayName("관리자 인수테스트")
 public class AdminAcceptanceTest extends AcceptanceTest {
 
     private static final int reportCount = 5;

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
@@ -4,6 +4,7 @@ import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.getAdminToken;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.getChrisToken;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpDeleteWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpGetWithAuthorization;
+import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPatchWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPostWithAuthorization;
 import static com.wooteco.sokdak.util.fixture.PostFixture.CREATE_POST_URI;
 import static com.wooteco.sokdak.util.fixture.PostFixture.NEW_POST_REQUEST;
@@ -77,7 +78,7 @@ public class AdminAcceptanceTest extends AcceptanceTest {
         httpPostWithAuthorization(initTicketRequest, "admin/tickets", adminToken);
         TicketElement initTicketElement = getTicketElements(httpGetWithAuthorization("admin/tickets", adminToken))
                 .get(lastTicketIndex);
-        httpPostWithAuthorization(usedTicketRequest, "admin/tickets/used", adminToken);
+        httpPatchWithAuthorization(usedTicketRequest, "admin/tickets", adminToken);
         TicketElement usedTicketElement = getTicketElements(httpGetWithAuthorization("admin/tickets", adminToken))
                 .get(lastTicketIndex);
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
@@ -44,15 +44,15 @@ public class AdminAcceptanceTest extends AcceptanceTest {
 
     @DisplayName("관리자 페이지에서 특정 글 블락 처리, 신고목록 조회, 블락 해제가 가능하다.")
     @Test
-    void blockAndFindReportsAndUnBlockPost() {
+    void blockAndFindReportsAndunblockPost() {
         String chrisToken = getChrisToken();
         String adminToken = getAdminToken();
         httpPostWithAuthorization(NEW_POST_REQUEST, CREATE_POST_URI, chrisToken);
 
-        httpPostWithAuthorization("", "admin/posts/1/postReports/" + reportCount, adminToken);
-        ExtractableResponse<Response> response = httpGetWithAuthorization("admin/postReports", adminToken);
-        httpDeleteWithAuthorization("admin/posts/1/postReports", adminToken);
-        ExtractableResponse<Response> response2 = httpGetWithAuthorization("admin/postReports", adminToken);
+        httpPostWithAuthorization("", "admin/posts/1/postreports/" + reportCount, adminToken);
+        ExtractableResponse<Response> response = httpGetWithAuthorization("admin/postreports", adminToken);
+        httpDeleteWithAuthorization("admin/posts/1/postreports", adminToken);
+        ExtractableResponse<Response> response2 = httpGetWithAuthorization("admin/postreports", adminToken);
 
         assertAll(
                 () -> assertThat(getPostReports(response)).hasSize(reportCount),

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/controller/AdminControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/controller/AdminControllerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
+@DisplayName("관리자 컨트롤러 테스트")
 class AdminControllerTest extends ControllerTest {
 
     @BeforeEach
@@ -149,7 +150,7 @@ class AdminControllerTest extends ControllerTest {
         List<PostReportElement> postReportElements = List.of(postReportElement, postReportElement2);
         doReturn(PostReportsResponse.of(postReportElements))
                 .when(adminService)
-                .findAllPostReport(any());
+                .findAllPostReports(any());
 
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -166,7 +167,7 @@ class AdminControllerTest extends ControllerTest {
     void findAllPostReports_Exception_NoAdmin() {
         doThrow(new NoAdminException())
                 .when(adminService)
-                .findAllPostReport(any());
+                .findAllPostReports(any());
 
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/controller/AdminControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/controller/AdminControllerTest.java
@@ -75,9 +75,9 @@ class AdminControllerTest extends ControllerTest {
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", "bearer admin")
-                .when().post("admin/posts/1/postReports/5")
+                .when().post("admin/posts/1/postreports/5")
                 .then().log().all()
-                .apply(document("admin/post/add/postReports/success"))
+                .apply(document("admin/post/add/postreports/success"))
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
 
@@ -91,41 +91,41 @@ class AdminControllerTest extends ControllerTest {
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", "bearer noAdmin")
-                .when().post("admin/posts/1/postReports/5")
+                .when().post("admin/posts/1/postreports/5")
                 .then().log().all()
-                .apply(document("admin/post/add/postReports/fail/noAdmin"))
+                .apply(document("admin/post/add/postreports/fail/noAdmin"))
                 .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 
     @DisplayName("관리자는 게시글 신고를 초기화한다.")
     @Test
-    void unBlockPost() {
+    void unblockPost() {
         doNothing()
                 .when(adminService)
-                .unBlockPost(any(), any());
+                .unblockPost(any(), any());
 
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", "bearer admin")
-                .when().delete("admin/posts/1/postReports")
+                .when().delete("admin/posts/1/postreports")
                 .then().log().all()
-                .apply(document("admin/post/delete/postReports/success"))
+                .apply(document("admin/post/delete/postreports/success"))
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
 
     @DisplayName("관리자가 아닐 경우 게시글 신고를 초기화할 수 없다.")
     @Test
-    void unBlockPost_Exception_NoAdmin() {
+    void unblockPost_Exception_NoAdmin() {
         doThrow(new NoAdminException())
                 .when(adminService)
-                .unBlockPost(any(), any());
+                .unblockPost(any(), any());
 
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", "bearer noAdmin")
-                .when().delete("admin/posts/1/postReports")
+                .when().delete("admin/posts/1/postreports")
                 .then().log().all()
-                .apply(document("admin/post/delete/postReports/fail/noAdmin"))
+                .apply(document("admin/post/delete/postreports/fail/noAdmin"))
                 .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 
@@ -154,10 +154,10 @@ class AdminControllerTest extends ControllerTest {
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", "bearer admin")
-                .when().get("admin/postReports")
+                .when().get("admin/postreports")
                 .then().log().all()
                 .assertThat()
-                .apply(document("admin/post/find/postReports/success"))
+                .apply(document("admin/post/find/postreports/success"))
                 .statusCode(HttpStatus.OK.value());
     }
 
@@ -171,10 +171,10 @@ class AdminControllerTest extends ControllerTest {
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", "bearer noAdmin")
-                .when().get("admin/postReports")
+                .when().get("admin/postreports")
                 .then().log().all()
                 .assertThat()
-                .apply(document("admin/post/find/postReports/fail/noAdmin"))
+                .apply(document("admin/post/find/postreports/fail/noAdmin"))
                 .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/controller/AdminControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/controller/AdminControllerTest.java
@@ -268,4 +268,50 @@ class AdminControllerTest extends ControllerTest {
                 .apply(document("admin/tickets/save/fail/noAdmin"))
                 .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
+
+    @DisplayName("관리자는 티켓을 수정한다.")
+    @Test
+    void updateTicket() {
+        TicketElement ticketElement = TicketElement.builder()
+                .id(2L)
+                .serialNumber("234567")
+                .used(false)
+                .build();
+        doNothing()
+                .when(adminService)
+                .changeTicketUsedState(any(), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer admin")
+                .body(ticketElement)
+                .when().post("admin/tickets/used")
+                .then().log().all()
+                .assertThat()
+                .apply(document("admin/tickets/update/success"))
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @DisplayName("관리자가 아닐 경우 티켓을 수정할 수 없다.")
+    @Test
+    void updateTicket_Exception_NoAdmin() {
+        TicketElement ticketElement = TicketElement.builder()
+                .id(2L)
+                .serialNumber("234567")
+                .used(false)
+                .build();
+        doThrow(new NoAdminException())
+                .when(adminService)
+                .changeTicketUsedState(any(), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer noAdmin")
+                .body(ticketElement)
+                .when().post("admin/tickets/used")
+                .then().log().all()
+                .assertThat()
+                .apply(document("admin/tickets/update/fail/noAdmin"))
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/controller/AdminControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/controller/AdminControllerTest.java
@@ -1,0 +1,271 @@
+package com.wooteco.sokdak.admin.controller;
+
+import static com.wooteco.sokdak.util.fixture.MemberFixture.AUTH_INFO;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+
+import com.wooteco.sokdak.admin.dto.PostReportElement;
+import com.wooteco.sokdak.admin.dto.PostReportsResponse;
+import com.wooteco.sokdak.admin.dto.TicketElement;
+import com.wooteco.sokdak.admin.dto.TicketsResponse;
+import com.wooteco.sokdak.admin.exception.NoAdminException;
+import com.wooteco.sokdak.util.ControllerTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class AdminControllerTest extends ControllerTest {
+
+    @BeforeEach
+    void setUpArgumentResolver() {
+        doReturn(true)
+                .when(authInterceptor)
+                .preHandle(any(), any(), any());
+        doReturn(AUTH_INFO)
+                .when(authenticationPrincipalArgumentResolver)
+                .resolveArgument(any(), any(), any(), any());
+    }
+
+    @DisplayName("관리자는 게시글을 삭제한다.")
+    @Test
+    void deletePost() {
+        doNothing()
+                .when(adminService)
+                .deletePost(any(), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer admin")
+                .when().delete("admin/posts/" + 1L)
+                .then().log().all()
+                .apply(document("admin/post/delete/success"))
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @DisplayName("관리자가 아닐 경우 게시글을 삭제할 수 없다.")
+    @Test
+    void deletePost_Exception_NoAdmin() {
+        doThrow(new NoAdminException())
+                .when(adminService)
+                .deletePost(any(), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer notAdmin")
+                .when().delete("admin/posts/" + 1L)
+                .then().log().all()
+                .apply(document("admin/post/delete/fail/noAdmin"))
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @DisplayName("관리자는 게시글을 블락한다.")
+    @Test
+    void blockPost() {
+        doNothing()
+                .when(adminService)
+                .blockPost(any(), any(), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer admin")
+                .when().post("admin/posts/1/postReports/5")
+                .then().log().all()
+                .apply(document("admin/post/add/postReports/success"))
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @DisplayName("관리자가 아닐 경우 게시글을 블락할 수 없다.")
+    @Test
+    void blockPost_Exception_NoAdmin() {
+        doThrow(new NoAdminException())
+                .when(adminService)
+                .blockPost(any(), any(), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer noAdmin")
+                .when().post("admin/posts/1/postReports/5")
+                .then().log().all()
+                .apply(document("admin/post/add/postReports/fail/noAdmin"))
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @DisplayName("관리자는 게시글 신고를 초기화한다.")
+    @Test
+    void unBlockPost() {
+        doNothing()
+                .when(adminService)
+                .unBlockPost(any(), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer admin")
+                .when().delete("admin/posts/1/postReports")
+                .then().log().all()
+                .apply(document("admin/post/delete/postReports/success"))
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @DisplayName("관리자가 아닐 경우 게시글 신고를 초기화할 수 없다.")
+    @Test
+    void unBlockPost_Exception_NoAdmin() {
+        doThrow(new NoAdminException())
+                .when(adminService)
+                .unBlockPost(any(), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer noAdmin")
+                .when().delete("admin/posts/1/postReports")
+                .then().log().all()
+                .apply(document("admin/post/delete/postReports/fail/noAdmin"))
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @DisplayName("관리자는 게시글 신고 목록을 조회한다.")
+    @Test
+    void findAllPostReports() {
+        PostReportElement postReportElement = PostReportElement.builder()
+                .postId(1L)
+                .reportMessage("비속어")
+                .createdAt(LocalDateTime.now())
+                .id(1L)
+                .reporterId(1L)
+                .build();
+        PostReportElement postReportElement2 = PostReportElement.builder()
+                .postId(1L)
+                .reportMessage("비속어")
+                .createdAt(LocalDateTime.now())
+                .id(1L)
+                .reporterId(2L)
+                .build();
+        List<PostReportElement> postReportElements = List.of(postReportElement, postReportElement2);
+        doReturn(PostReportsResponse.of(postReportElements))
+                .when(adminService)
+                .findAllPostReport(any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer admin")
+                .when().get("admin/postReports")
+                .then().log().all()
+                .assertThat()
+                .apply(document("admin/post/find/postReports/success"))
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @DisplayName("관리자가 아닌 경우 게시글 신고 목록을 조회할 수 없다.")
+    @Test
+    void findAllPostReports_Exception_NoAdmin() {
+        doThrow(new NoAdminException())
+                .when(adminService)
+                .findAllPostReport(any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer noAdmin")
+                .when().get("admin/postReports")
+                .then().log().all()
+                .assertThat()
+                .apply(document("admin/post/find/postReports/fail/noAdmin"))
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @DisplayName("관리자는 모든 티켓들을 조회한다.")
+    @Test
+    void findAllTickets() {
+        TicketElement ticketElement = TicketElement.builder()
+                .id(1L)
+                .serialNumber("123456")
+                .used(false)
+                .build();
+        TicketElement ticketElement2 = TicketElement.builder()
+                .id(2L)
+                .serialNumber("234567")
+                .used(false)
+                .build();
+        List<TicketElement> ticketElements = List.of(ticketElement, ticketElement2);
+        doReturn(TicketsResponse.of(ticketElements))
+                .when(adminService)
+                .findAllTickets(any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer admin")
+                .when().get("admin/tickets")
+                .then().log().all()
+                .assertThat()
+                .apply(document("admin/tickets/find/success"))
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @DisplayName("관리자가 아닌 경우 모든 티켓들을 조회할 수 없다.")
+    @Test
+    void findAllTickets_Exception_NoAdmin() {
+        doThrow(new NoAdminException())
+                .when(adminService)
+                .findAllTickets(any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer noAdmin")
+                .when().get("admin/tickets")
+                .then().log().all()
+                .assertThat()
+                .apply(document("admin/tickets/find/fail/noAdmin"))
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @DisplayName("관리자는 티켓을 저장한다.")
+    @Test
+    void saveTicket() {
+        TicketElement ticketElement = TicketElement.builder()
+                .id(2L)
+                .serialNumber("234567")
+                .used(false)
+                .build();
+        doNothing()
+                .when(adminService)
+                .saveTicket(any(), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer admin")
+                .body(ticketElement)
+                .when().post("admin/tickets")
+                .then().log().all()
+                .assertThat()
+                .apply(document("admin/tickets/save/success"))
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @DisplayName("관리자가 아닐 경우 티켓을 저장할 수 없다.")
+    @Test
+    void saveTicket_Exception_NoAdmin() {
+        TicketElement ticketElement = TicketElement.builder()
+                .id(2L)
+                .serialNumber("234567")
+                .used(false)
+                .build();
+        doThrow(new NoAdminException())
+                .when(adminService)
+                .saveTicket(any(), any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "bearer noAdmin")
+                .body(ticketElement)
+                .when().post("admin/tickets")
+                .then().log().all()
+                .assertThat()
+                .apply(document("admin/tickets/save/fail/noAdmin"))
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/controller/AdminControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/controller/AdminControllerTest.java
@@ -62,7 +62,7 @@ class AdminControllerTest extends ControllerTest {
                 .when().delete("admin/posts/" + 1L)
                 .then().log().all()
                 .apply(document("admin/post/delete/fail/noAdmin"))
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
+                .statusCode(HttpStatus.FORBIDDEN.value());
     }
 
     @DisplayName("관리자는 게시글을 블락한다.")
@@ -94,7 +94,7 @@ class AdminControllerTest extends ControllerTest {
                 .when().post("admin/posts/1/postreports/5")
                 .then().log().all()
                 .apply(document("admin/post/add/postreports/fail/noAdmin"))
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
+                .statusCode(HttpStatus.FORBIDDEN.value());
     }
 
     @DisplayName("관리자는 게시글 신고를 초기화한다.")
@@ -126,7 +126,7 @@ class AdminControllerTest extends ControllerTest {
                 .when().delete("admin/posts/1/postreports")
                 .then().log().all()
                 .apply(document("admin/post/delete/postreports/fail/noAdmin"))
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
+                .statusCode(HttpStatus.FORBIDDEN.value());
     }
 
     @DisplayName("관리자는 게시글 신고 목록을 조회한다.")
@@ -175,7 +175,7 @@ class AdminControllerTest extends ControllerTest {
                 .then().log().all()
                 .assertThat()
                 .apply(document("admin/post/find/postreports/fail/noAdmin"))
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
+                .statusCode(HttpStatus.FORBIDDEN.value());
     }
 
     @DisplayName("관리자는 모든 티켓들을 조회한다.")
@@ -220,7 +220,7 @@ class AdminControllerTest extends ControllerTest {
                 .then().log().all()
                 .assertThat()
                 .apply(document("admin/tickets/find/fail/noAdmin"))
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
+                .statusCode(HttpStatus.FORBIDDEN.value());
     }
 
     @DisplayName("관리자는 티켓을 저장한다.")
@@ -266,7 +266,7 @@ class AdminControllerTest extends ControllerTest {
                 .then().log().all()
                 .assertThat()
                 .apply(document("admin/tickets/save/fail/noAdmin"))
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
+                .statusCode(HttpStatus.FORBIDDEN.value());
     }
 
     @DisplayName("관리자는 티켓을 수정한다.")
@@ -285,7 +285,7 @@ class AdminControllerTest extends ControllerTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", "bearer admin")
                 .body(ticketElement)
-                .when().post("admin/tickets/used")
+                .when().patch("admin/tickets")
                 .then().log().all()
                 .assertThat()
                 .apply(document("admin/tickets/update/success"))
@@ -308,10 +308,10 @@ class AdminControllerTest extends ControllerTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", "bearer noAdmin")
                 .body(ticketElement)
-                .when().post("admin/tickets/used")
+                .when().patch("admin/tickets")
                 .then().log().all()
                 .assertThat()
                 .apply(document("admin/tickets/update/fail/noAdmin"))
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
+                .statusCode(HttpStatus.FORBIDDEN.value());
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/service/AdminServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/service/AdminServiceTest.java
@@ -1,0 +1,201 @@
+package com.wooteco.sokdak.admin.service;
+
+import static com.wooteco.sokdak.util.fixture.MemberFixture.AUTH_INFO;
+import static com.wooteco.sokdak.util.fixture.MemberFixture.AUTH_INFO_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wooteco.sokdak.admin.dto.PostReportsResponse;
+import com.wooteco.sokdak.admin.dto.TicketRequest;
+import com.wooteco.sokdak.admin.dto.TicketsResponse;
+import com.wooteco.sokdak.advice.UnauthorizedException;
+import com.wooteco.sokdak.auth.domain.Ticket;
+import com.wooteco.sokdak.board.domain.Board;
+import com.wooteco.sokdak.board.domain.PostBoard;
+import com.wooteco.sokdak.board.exception.BoardNotFoundException;
+import com.wooteco.sokdak.board.repository.BoardRepository;
+import com.wooteco.sokdak.board.repository.PostBoardRepository;
+import com.wooteco.sokdak.member.domain.Member;
+import com.wooteco.sokdak.member.exception.MemberNotFoundException;
+import com.wooteco.sokdak.member.repository.MemberRepository;
+import com.wooteco.sokdak.member.repository.TicketRepository;
+import com.wooteco.sokdak.post.domain.Post;
+import com.wooteco.sokdak.post.repository.PostRepository;
+import com.wooteco.sokdak.post.service.PostService;
+import com.wooteco.sokdak.report.repository.PostReportRepository;
+import com.wooteco.sokdak.util.IntegrationTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(propagation = Propagation.NEVER)
+class AdminServiceTest extends IntegrationTest {
+
+    private static final Long BLOCKED_COUNT = 5L;
+    @Autowired
+    private AdminService adminService;
+    @Autowired
+    private PostService postService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PostRepository postRepository;
+    @Autowired
+    private PostReportRepository postReportRepository;
+    @Autowired
+    private BoardRepository boardRepository;
+    @Autowired
+    private PostBoardRepository postBoardRepository;
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    private Post post;
+    private Board board;
+
+    @BeforeEach
+    public void setUp() {
+        Member member = memberRepository.findById(AUTH_INFO.getId())
+                .orElseThrow(MemberNotFoundException::new);
+        post = Post.builder()
+                .title("제목")
+                .content("본문")
+                .writerNickname(member.getNickname())
+                .member(member)
+                .likes(new ArrayList<>())
+                .comments(new ArrayList<>())
+                .build();
+        board = boardRepository.findById(2L)
+                .orElseThrow(BoardNotFoundException::new);
+    }
+
+    @DisplayName("관리자 권한으로 게시글 삭제 기능")
+    @Test
+    void deletePost() {
+        Long postId = postRepository.save(post).getId();
+
+        adminService.deletePost(postId, AUTH_INFO);
+
+        assertThat(postRepository.findById(postId)).isEmpty();
+    }
+
+    @DisplayName("관리자 권한이 아닐 시 게시글 삭제 예외 발생")
+    @Test
+    void deletePost_Exception_NoAdmin() {
+        Long postId = postRepository.save(post).getId();
+
+        assertThatThrownBy(() -> adminService.deletePost(postId, AUTH_INFO_USER))
+                .isInstanceOf(UnauthorizedException.class);
+
+        assertThat(postRepository.findById(postId)).isNotEmpty();
+    }
+
+    @DisplayName("관리자 권한으로 블라인드")
+    @Test
+    void blockPost() {
+        Post post = savePost();
+
+        adminService.blockPost(post.getId(), BLOCKED_COUNT, AUTH_INFO);
+
+        assertThat(postReportRepository.findAllByPostId(post.getId())).hasSize(Math.toIntExact(BLOCKED_COUNT));
+        assertThat(postService.findPost(post.getId(), AUTH_INFO).isBlocked()).isTrue();
+    }
+
+    @DisplayName("관리자 권한이 아닐 시 블라인드 불가")
+    @Test
+    void blockPost_Exception_NoAdmin() {
+        Post post = savePost();
+
+        assertThatThrownBy(() -> adminService.blockPost(post.getId(), BLOCKED_COUNT, AUTH_INFO_USER))
+                .isInstanceOf(UnauthorizedException.class);
+
+        assertThat(postReportRepository.findAllByPostId(post.getId())).isEmpty();
+        assertThat(postService.findPost(post.getId(), AUTH_INFO).isBlocked()).isFalse();
+    }
+
+    @DisplayName("관리자 권한으로 블라인드 해제")
+    @Test
+    void unBlockPost() {
+        Post post = savePost();
+        adminService.blockPost(post.getId(), BLOCKED_COUNT, AUTH_INFO);
+        boolean blocked = postService.findPost(post.getId(), AUTH_INFO).isBlocked();
+        assertThat(blocked).isTrue();
+
+        adminService.unBlockPost(post.getId(), AUTH_INFO);
+
+        assertThat(postReportRepository.findAllByPostId(post.getId())).isEmpty();
+        assertThat(postService.findPost(post.getId(), AUTH_INFO).isBlocked()).isFalse();
+    }
+
+    @DisplayName("관리자 권한이 아닐 시 블라인드 해제되지 않는다.")
+    @Test
+    void unBlockPost_Exception_NoAdmin() {
+        Post post = savePost();
+        adminService.blockPost(post.getId(), BLOCKED_COUNT, AUTH_INFO);
+
+        assertThatThrownBy(() -> adminService.unBlockPost(post.getId(), AUTH_INFO_USER))
+                .isInstanceOf(UnauthorizedException.class);
+
+        assertThat(postReportRepository.findAllByPostId(post.getId())).hasSize(Math.toIntExact(BLOCKED_COUNT));
+        assertThat(postService.findPost(post.getId(), AUTH_INFO).isBlocked()).isTrue();
+    }
+
+    @DisplayName("관리자 권한으로 모든 게시글 신고 조회")
+    @Test
+    void findAllPostReport() {
+        Post post = savePost();
+        adminService.blockPost(post.getId(), BLOCKED_COUNT, AUTH_INFO);
+
+        PostReportsResponse allPostReport = adminService.findAllPostReport(AUTH_INFO);
+        assertThat(allPostReport.getPostReports()).hasSize(Math.toIntExact(BLOCKED_COUNT));
+    }
+
+    @DisplayName("관리자 권한으로 모든 티켓 조회")
+    @Test
+    void findAllTickets() {
+        ticketRepository.deleteAll();
+        Ticket ticket1 = Ticket.builder()
+                .serialNumber("test1@gmail.com")
+                .used(false)
+                .build();
+        Ticket ticket2 = Ticket.builder()
+                .serialNumber("test2@gmail.com")
+                .used(false)
+                .build();
+        ticketRepository.save(ticket1);
+        ticketRepository.save(ticket2);
+
+        TicketsResponse tickets = adminService.findAllTickets(AUTH_INFO);
+        assertThat(tickets.getTickets()).usingRecursiveComparison()
+                .comparingOnlyFields("serialNumber", "used")
+                .isEqualTo(List.of(ticket1, ticket2));
+    }
+
+    @DisplayName("관리자 권한으로 티켓 추가")
+    @Test
+    void saveTicket() {
+        String serialNumber = "test1@gmail.com";
+        Ticket ticket = Ticket.builder()
+                .serialNumber(serialNumber)
+                .used(false)
+                .build();
+
+        adminService.saveTicket(AUTH_INFO, TicketRequest.of(ticket));
+
+        Ticket actual = ticketRepository.findBySerialNumber(serialNumber).orElseThrow();
+        assertThat(actual).usingRecursiveComparison()
+                .comparingOnlyFields("serialNumber", "used")
+                .isEqualTo(ticket);
+    }
+
+    private Post savePost() {
+        Post post = postRepository.save(this.post);
+        postBoardRepository.save(PostBoard.builder().post(post).board(board).build());
+        return post;
+    }
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/service/AdminServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/service/AdminServiceTest.java
@@ -128,13 +128,13 @@ class AdminServiceTest extends IntegrationTest {
 
     @DisplayName("관리자 권한으로 블라인드 해제")
     @Test
-    void unBlockPost() {
+    void unblockPost() {
         Post post = savePost();
         adminService.blockPost(post.getId(), BLOCKED_COUNT, AUTH_INFO_ADMIN);
         boolean blocked = postService.findPost(post.getId(), AUTH_INFO_ADMIN).isBlocked();
         assertThat(blocked).isTrue();
 
-        adminService.unBlockPost(post.getId(), AUTH_INFO_ADMIN);
+        adminService.unblockPost(post.getId(), AUTH_INFO_ADMIN);
 
         assertThat(postReportRepository.findAllByPostId(post.getId())).isEmpty();
         assertThat(postService.findPost(post.getId(), AUTH_INFO_ADMIN).isBlocked()).isFalse();
@@ -142,11 +142,11 @@ class AdminServiceTest extends IntegrationTest {
 
     @DisplayName("관리자 권한이 아닐 시 블라인드 해제되지 않는다.")
     @Test
-    void unBlockPost_Exception_NoAdmin() {
+    void unblockPost_Exception_NoAdmin() {
         Post post = savePost();
         adminService.blockPost(post.getId(), BLOCKED_COUNT, AUTH_INFO_ADMIN);
 
-        assertThatThrownBy(() -> adminService.unBlockPost(post.getId(), AUTH_INFO))
+        assertThatThrownBy(() -> adminService.unblockPost(post.getId(), AUTH_INFO))
                 .isInstanceOf(UnauthorizedException.class);
 
         assertThat(postReportRepository.findAllByPostId(post.getId())).hasSize(Math.toIntExact(BLOCKED_COUNT));

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/service/AdminServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/service/AdminServiceTest.java
@@ -9,7 +9,6 @@ import com.wooteco.sokdak.admin.dto.PostReportsResponse;
 import com.wooteco.sokdak.admin.dto.TicketRequest;
 import com.wooteco.sokdak.admin.dto.TicketsResponse;
 import com.wooteco.sokdak.admin.exception.NoAdminException;
-import com.wooteco.sokdak.advice.UnauthorizedException;
 import com.wooteco.sokdak.auth.domain.Ticket;
 import com.wooteco.sokdak.board.domain.Board;
 import com.wooteco.sokdak.board.domain.PostBoard;
@@ -40,7 +39,8 @@ class AdminServiceTest extends IntegrationTest {
 
     private static final Long BLOCKED_COUNT = 5L;
     private static final long WRITABLE_BOARD_ID = 2L;
-    private static final String SERIAL_NUMBER = "test1@gmail.com";
+    private static final String SERIAL_NUMBER = "234567";
+
     @Autowired
     private AdminService adminService;
     @Autowired
@@ -98,7 +98,7 @@ class AdminServiceTest extends IntegrationTest {
         Long postId = postRepository.save(post).getId();
 
         assertThatThrownBy(() -> adminService.deletePost(postId, AUTH_INFO))
-                .isInstanceOf(UnauthorizedException.class);
+                .isInstanceOf(NoAdminException.class);
 
         assertThat(postRepository.findById(postId)).isNotEmpty();
     }
@@ -120,7 +120,7 @@ class AdminServiceTest extends IntegrationTest {
         Post post = savePost();
 
         assertThatThrownBy(() -> adminService.blockPost(post.getId(), BLOCKED_COUNT, AUTH_INFO))
-                .isInstanceOf(UnauthorizedException.class);
+                .isInstanceOf(NoAdminException.class);
 
         assertThat(postReportRepository.findAllByPostId(post.getId())).isEmpty();
         assertThat(postService.findPost(post.getId(), AUTH_INFO_ADMIN).isBlocked()).isFalse();
@@ -140,14 +140,14 @@ class AdminServiceTest extends IntegrationTest {
         assertThat(postService.findPost(post.getId(), AUTH_INFO_ADMIN).isBlocked()).isFalse();
     }
 
-    @DisplayName("관리자 권한이 아닐 시 블라인드 해제되지 않는다.")
+    @DisplayName("관리자 권한이 아닐 시 블라인드 해제 예외 발생")
     @Test
     void unblockPost_Exception_NoAdmin() {
         Post post = savePost();
         adminService.blockPost(post.getId(), BLOCKED_COUNT, AUTH_INFO_ADMIN);
 
         assertThatThrownBy(() -> adminService.unblockPost(post.getId(), AUTH_INFO))
-                .isInstanceOf(UnauthorizedException.class);
+                .isInstanceOf(NoAdminException.class);
 
         assertThat(postReportRepository.findAllByPostId(post.getId())).hasSize(Math.toIntExact(BLOCKED_COUNT));
         assertThat(postService.findPost(post.getId(), AUTH_INFO_ADMIN).isBlocked()).isTrue();
@@ -163,7 +163,7 @@ class AdminServiceTest extends IntegrationTest {
         assertThat(allPostReport.getPostReports()).hasSize(Math.toIntExact(BLOCKED_COUNT));
     }
 
-    @DisplayName("관리자 권한이 아닐 시 모든 게시글 신고를 조회할 수 없다.")
+    @DisplayName("관리자 권한이 아닐 시 모든 게시글 신고를 조회 예외 발생")
     @Test
     void findAllPostReport_Exception_NoAdmin() {
         assertThatThrownBy(() -> adminService.findAllPostReport(AUTH_INFO))
@@ -191,7 +191,7 @@ class AdminServiceTest extends IntegrationTest {
                 .isEqualTo(List.of(ticket1, ticket2));
     }
 
-    @DisplayName("관리자 권한이 아닐 시 티켓을 조회할 수 없다.")
+    @DisplayName("관리자 권한이 아닐 시 티켓 조회 예외 발생")
     @Test
     void findAllTickets_Exception_NoAdmin() {
         assertThatThrownBy(() -> adminService.findAllTickets(AUTH_INFO))
@@ -209,7 +209,7 @@ class AdminServiceTest extends IntegrationTest {
                 .isEqualTo(ticket);
     }
 
-    @DisplayName("관리자 권한이 아닐 시 티켓을 추가할 수 없다.")
+    @DisplayName("관리자 권한이 아닐 시 티켓 추가 예외 발생")
     @Test
     void saveTicket_Exception_NoAdmin() {
         assertThatThrownBy(() -> adminService.saveTicket(AUTH_INFO, TicketRequest.of(ticket)))
@@ -233,7 +233,7 @@ class AdminServiceTest extends IntegrationTest {
         assertThat(actual.isUsed()).isTrue();
     }
 
-    @DisplayName("관리자 권한이 아닐 시 티켓 상태를 변경할 수 없다.")
+    @DisplayName("관리자 권한이 아닐 시 티켓 상태 변경 예외 발생")
     @Test
     void changeTicketUsedState_Exception_NoAdmin() {
         adminService.saveTicket(AUTH_INFO_ADMIN, TicketRequest.of(ticket));

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/acceptance/AuthAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/acceptance/AuthAcceptanceTest.java
@@ -8,6 +8,7 @@ import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_LOGIN_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.wooteco.sokdak.auth.domain.AuthCode;
@@ -123,6 +124,7 @@ class AuthAcceptanceTest extends AcceptanceTest {
         doReturn(Instant.now(FUTURE_CLOCK))
                 .when(clock)
                 .instant();
+
         ExtractableResponse<Response> response = httpPostWithAuthorization(new VerificationRequest(email, code),
                 "members/signup/email/verification", getChrisToken());
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/ControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/ControllerTest.java
@@ -3,6 +3,8 @@ package com.wooteco.sokdak.util;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 
+import com.wooteco.sokdak.admin.controller.AdminController;
+import com.wooteco.sokdak.admin.service.AdminService;
 import com.wooteco.sokdak.auth.controller.AuthController;
 import com.wooteco.sokdak.auth.service.AuthService;
 import com.wooteco.sokdak.auth.service.RefreshTokenService;
@@ -51,7 +53,8 @@ import org.springframework.web.context.WebApplicationContext;
         BoardController.class,
         HashtagController.class,
         NotificationController.class,
-        HashtagController.class
+        HashtagController.class,
+        AdminController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 public class ControllerTest {
@@ -105,6 +108,9 @@ public class ControllerTest {
 
     @MockBean
     protected RefreshTokenService refreshTokenService;
+
+    @MockBean
+    protected AdminService adminService;
 
     @BeforeEach
     void setRestDocs(WebApplicationContext webApplicationContext,

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/IntegrationTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/IntegrationTest.java
@@ -3,6 +3,8 @@ package com.wooteco.sokdak.util;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/HttpMethodFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/HttpMethodFixture.java
@@ -104,4 +104,9 @@ public class HttpMethodFixture {
         LoginRequest loginRequest = new LoginRequest("josh", "Abcd123!@");
         return httpPost(loginRequest, "/login").header(AUTHORIZATION);
     }
+
+    public static String getAdminToken() {
+        LoginRequest loginRequest = new LoginRequest("admin", "Abcd123!@");
+        return httpPost(loginRequest, "/login").header(AUTHORIZATION);
+    }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/HttpMethodFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/HttpMethodFixture.java
@@ -106,7 +106,7 @@ public class HttpMethodFixture {
     }
 
     public static String getAdminToken() {
-        LoginRequest loginRequest = new LoginRequest("admin", "Abcd123!@");
+        LoginRequest loginRequest = new LoginRequest("east", "Abcd123!@");
         return httpPost(loginRequest, "/login").header(AUTHORIZATION);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/MemberFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/MemberFixture.java
@@ -59,4 +59,5 @@ public class MemberFixture {
 
     public static final AuthInfo AUTH_INFO = new AuthInfo(1L, RoleType.USER.getName(), "chrisNickname");
     public static final AuthInfo AUTH_INFO2 = new AuthInfo(3L, RoleType.USER.getName(), "joshNickname");
+    public static final AuthInfo AUTH_INFO_ADMIN = new AuthInfo(3L, RoleType.ADMIN.getName(), "adminNickname");
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/PostFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/PostFixture.java
@@ -1,10 +1,16 @@
 package com.wooteco.sokdak.util.fixture;
 
 import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPostWithAuthorization;
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_NICKNAME;
 import static com.wooteco.sokdak.util.fixture.MemberFixture.getToken;
 
+import com.wooteco.sokdak.auth.dto.AuthInfo;
+import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
 import com.wooteco.sokdak.post.dto.PostsElementResponse;
+import com.wooteco.sokdak.report.dto.ReportRequest;
+import com.wooteco.sokdak.report.repository.PostReportRepository;
+import com.wooteco.sokdak.report.service.PostReportService;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/PostFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/PostFixture.java
@@ -30,6 +30,9 @@ public class PostFixture {
     public static final String INVALID_POST_TITLE = "A".repeat(51);
     public static final String INVALID_POST_CONTENT = "A".repeat(5001);
 
+    public static final Long BLOCKED_COUNT = 5L;
+    public static final String SERIAL_NUMBER = "asd23456";
+
     public static final PostsElementResponse POSTS_ELEMENT_RESPONSE_1 = PostsElementResponse.builder()
             .id(1L)
             .title("제목")


### PR DESCRIPTION
### 구현기능
admin 전용 api를 구현한다
resolved: #421 

### 세부 구현기능
- [x]  admin 계정일 경우 글 자유삭제가 가능하다

- [x]  admin 계정일 경우 블라인드된 글의 롤백이 가능하다
- [x]  admin 계정일 경우 글의 블라인드가 가능하다
- [x]  admin 계정일 경우 신고된 목록을 확인할 수 있다

- [x]  admin 계정일 경우 가입이 허가된 이메일 목록을 확인할 수 있다
- [x]  admin 계정일 경우 가입이 허가된 이메일을 저장할 수 있다
- [x]  admin 계정일 경우 가입이 허가된 이메일의 사용 여부를 수정할 수 있다

### 관련 이슈
