### PR TITLE
feat: 댓글 좋아요 UI 및 API 연결 구현

### DIFF
--- a/frontend/src/context/Auth.tsx
+++ b/frontend/src/context/Auth.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import React, { Dispatch, SetStateAction, useState } from 'react';
 
 import { STORAGE_KEY } from '@/constants/localStorage';
 import { parseJwt } from '@/utils/decodeJwt';
@@ -9,21 +9,23 @@ interface AuthContextValue {
   username: string;
   setUserName: Dispatch<SetStateAction<string>>;
 }
-
 const AuthContext = React.createContext<AuthContextValue>({} as AuthContextValue);
 
 export const AuthContextProvider = ({ children }: { children: React.ReactNode }) => {
-  const [isLogin, setIsLogin] = useState(false);
-  const [username, setUserName] = useState('');
-
-  useEffect(() => {
-    const accessToken = localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN);
-
+  const accessToken = localStorage.getItem(STORAGE_KEY.ACCESS_TOKEN);
+  const [isLogin, setIsLogin] = useState(() => {
     if (accessToken) {
-      setIsLogin(true);
-      setUserName(parseJwt(accessToken)?.nickname!);
+      return true;
     }
-  }, []);
+    return false;
+  });
+
+  const [username, setUserName] = useState(() => {
+    if (accessToken) {
+      return parseJwt(accessToken)?.nickname!;
+    }
+    return '';
+  });
 
   return <AuthContext.Provider value={{ isLogin, setIsLogin, username, setUserName }}>{children}</AuthContext.Provider>;
 };

--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -378,6 +378,7 @@ export const commentList: CommentListType[] = [
     authorized: true,
     blocked: false,
     postWriter: true,
+    like: false,
     likeCount: 3,
 
     replies: [
@@ -388,6 +389,7 @@ export const commentList: CommentListType[] = [
         createdAt: '2022-08-09T07:55:31.016376300',
         authorized: true,
         postWriter: true,
+        like: false,
         likeCount: 3,
         blocked: false,
       },
@@ -398,6 +400,7 @@ export const commentList: CommentListType[] = [
         createdAt: '2022-08-09T08:55:31.016376300',
         authorized: true,
         postWriter: true,
+        like: false,
         likeCount: 3,
         blocked: false,
       },
@@ -412,6 +415,7 @@ export const commentList: CommentListType[] = [
     authorized: true,
     blocked: false,
     postWriter: true,
+    like: false,
     likeCount: 3,
     replies: [
       {
@@ -421,6 +425,8 @@ export const commentList: CommentListType[] = [
         createdAt: '2022-08-09T08:55:31.016376300',
         authorized: false,
         postWriter: false,
+        like: false,
+
         likeCount: 5,
         blocked: false,
       },
@@ -435,6 +441,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: true,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },
@@ -447,6 +455,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },
@@ -459,6 +469,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },
@@ -471,6 +483,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },
@@ -483,6 +497,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },
@@ -495,6 +511,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: true,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },
@@ -507,6 +525,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },
@@ -519,6 +539,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },
@@ -531,6 +553,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },
@@ -543,6 +567,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },
@@ -555,6 +581,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },
@@ -567,6 +595,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },
@@ -579,6 +609,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },
@@ -591,6 +623,8 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    like: false,
+
     likeCount: 5,
     replies: [],
   },

--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -378,6 +378,8 @@ export const commentList: CommentListType[] = [
     authorized: true,
     blocked: false,
     postWriter: true,
+    likeCount: 3,
+
     replies: [
       {
         id: 17,
@@ -386,6 +388,7 @@ export const commentList: CommentListType[] = [
         createdAt: '2022-08-09T07:55:31.016376300',
         authorized: true,
         postWriter: true,
+        likeCount: 3,
         blocked: false,
       },
       {
@@ -395,6 +398,7 @@ export const commentList: CommentListType[] = [
         createdAt: '2022-08-09T08:55:31.016376300',
         authorized: true,
         postWriter: true,
+        likeCount: 3,
         blocked: false,
       },
     ],
@@ -408,6 +412,7 @@ export const commentList: CommentListType[] = [
     authorized: true,
     blocked: false,
     postWriter: true,
+    likeCount: 3,
     replies: [
       {
         id: 19,
@@ -416,6 +421,7 @@ export const commentList: CommentListType[] = [
         createdAt: '2022-08-09T08:55:31.016376300',
         authorized: false,
         postWriter: false,
+        likeCount: 5,
         blocked: false,
       },
     ],
@@ -429,6 +435,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: true,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
   {
@@ -440,6 +447,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
   {
@@ -451,6 +459,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
   {
@@ -462,6 +471,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
   {
@@ -473,6 +483,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
   {
@@ -484,6 +495,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: true,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
   {
@@ -495,6 +507,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
   {
@@ -506,6 +519,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
   {
@@ -517,6 +531,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
   {
@@ -528,6 +543,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
   {
@@ -539,6 +555,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
   {
@@ -550,6 +567,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
   {
@@ -561,6 +579,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
   {
@@ -572,6 +591,7 @@ export const commentList: CommentListType[] = [
     authorized: false,
     blocked: false,
     postWriter: false,
+    likeCount: 5,
     replies: [],
   },
 ];

--- a/frontend/src/hooks/queries/comment/useLikeComment.ts
+++ b/frontend/src/hooks/queries/comment/useLikeComment.ts
@@ -1,0 +1,59 @@
+import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
+
+import { AxiosResponse } from 'axios';
+
+import authFetcher from '@/apis';
+import QUERY_KEYS from '@/constants/queries';
+
+interface CommentList extends CommentType {
+  id: number;
+  blocked: boolean;
+  postWriter: boolean;
+  replies: Omit<CommentList, 'replies'>[];
+}
+
+interface CommentResponse {
+  comments: CommentList[];
+  totalCount: number;
+}
+
+const useLikeComment = (
+  options?: UseMutationOptions<
+    AxiosResponse<{ like: boolean; likeCount: number }>,
+    AxiosResponse<Error>,
+    { id: number }
+  >,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation(({ id }) => authFetcher.put(`/comments/${id}/like`), {
+    ...options,
+    onSuccess: (_, variables) => {
+      queryClient.setQueriesData<AxiosResponse<CommentResponse>>(QUERY_KEYS.COMMENTS, comment => {
+        const newData = {
+          ...comment,
+          data: {
+            totalCount: comment?.data.totalCount!,
+            comments: comment?.data.comments.map(comment => {
+              if (comment.id === variables.id) {
+                comment.like = !comment.like;
+                if (comment.like) comment.likeCount += 1;
+                if (!comment.like) comment.likeCount -= 1;
+              }
+              const targetReply = comment.replies.find(reply => reply.id === variables.id);
+              if (targetReply) {
+                targetReply.like = !targetReply.like;
+                if (targetReply.like) targetReply.likeCount += 1;
+                if (!targetReply.like) targetReply.likeCount -= 1;
+              }
+              return comment;
+            })!,
+          },
+        };
+        return newData as AxiosResponse<CommentResponse>;
+      });
+    },
+  });
+};
+
+export default useLikeComment;

--- a/frontend/src/mocks/handlers/comments/index.ts
+++ b/frontend/src/mocks/handlers/comments/index.ts
@@ -37,7 +37,9 @@ const commentHandlers = [
       postId: id,
       authorized: true,
       blocked: false,
+      like: false,
       postWriter: targetPost.authorized,
+      likeCount: 0,
       replies: [],
     });
 
@@ -131,10 +133,54 @@ const commentHandlers = [
       createdAt: new Date().toISOString(),
       authorized: true,
       blocked: false,
+      likeCount: 0,
+      like: false,
       postWriter: targetPost.authorized,
     });
 
     return res(ctx.status(201));
+  }),
+
+  rest.put('/comments/:id/like', (req, res, ctx) => {
+    const { id } = req.params;
+    const targetComment = commentList.find(comment => comment.id === Number(id));
+
+    if (!targetComment) {
+      const targetReply = commentList.flatMap(comment => comment.replies).find(reply => reply.id === Number(id));
+
+      if (!targetReply) return res(ctx.status(400), ctx.json({ message: '존재하지 않는 댓글입니다.' }));
+
+      targetReply.like = !targetReply.like;
+      if (targetReply.like) {
+        targetReply.likeCount += 1;
+      }
+      if (!targetReply.like) {
+        targetReply.likeCount -= 1;
+      }
+      return res(
+        ctx.status(200),
+        ctx.json({
+          like: targetReply.like,
+          likeCount: targetReply.likeCount,
+        }),
+      );
+    }
+
+    targetComment.like = !targetComment.like;
+    if (targetComment.like) {
+      targetComment.likeCount += 1;
+    }
+    if (!targetComment.like) {
+      targetComment.likeCount -= 1;
+    }
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        like: targetComment.like,
+        likeCount: targetComment.likeCount,
+      }),
+    );
   }),
 ];
 

--- a/frontend/src/pages/PostPage/components/CommentBox/index.stories.tsx
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.stories.tsx
@@ -2,7 +2,7 @@ import Comment from '.';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 export default {
-  title: 'Components/Comment',
+  title: 'Pages/PostPage/Comment',
   component: Comment,
 } as ComponentMeta<typeof Comment>;
 

--- a/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
@@ -81,3 +81,9 @@ export const Date = styled.p`
   margin: 10px 0;
   font-size: 10px;
 `;
+
+export const Footer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;

--- a/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
@@ -87,3 +87,14 @@ export const Footer = styled.div`
   justify-content: space-between;
   align-items: center;
 `;
+
+export const LikeContainer = styled.button<{ isLiked: boolean }>`
+  display: flex;
+  color: ${props => props.theme.colors.pink_300};
+  font-size: 0.7rem;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5em;
+  background-color: transparent;
+  color: ${props => (props.isLiked ? props.theme.colors.pink_300 : props.theme.colors.gray_300)};
+`;

--- a/frontend/src/pages/PostPage/components/CommentBox/index.tsx
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.tsx
@@ -1,17 +1,20 @@
 import { useReducer } from 'react';
 
 import ConfirmModal from '@/components/ConfirmModal';
-import LikeButton from '@/components/LikeButton';
 
 import useDeleteComment from '@/hooks/queries/comment/useDeleteComment';
+import useLikeComment from '@/hooks/queries/comment/useLikeComment';
 import useReportComment from '@/hooks/queries/comment/useReportComment';
 
 import * as Styled from './index.styles';
 
+import HeartImg from '@/assets/images/heart.svg';
+import countFormatter from '@/utils/countFormatter';
 import timeConverter from '@/utils/timeConverter';
 
 import ReplyForm from '../ReplyForm';
 import ReportModal from '../ReportModal';
+import { useTheme } from '@emotion/react';
 
 const Mode = {
   COMMENTS: 'comments',
@@ -34,11 +37,14 @@ const CommentBox = ({
   blocked,
   postWriter,
   mode = Mode.COMMENTS,
+  likeCount,
   className,
+  like,
 }: CommentBoxProps) => {
   const [isReportModalOpen, handleReportModal] = useReducer(state => !state, false);
   const [isDeleteModalOpen, handleDeleteModal] = useReducer(state => !state, false);
   const [isReplyFormOpen, handleReplyForm] = useReducer(state => !state, false);
+  const theme = useTheme();
 
   const { mutate: deleteComment } = useDeleteComment();
   const { mutate: reportComment } = useReportComment({
@@ -46,6 +52,7 @@ const CommentBox = ({
       handleReportModal();
     },
   });
+  const { mutate: likeComment } = useLikeComment();
 
   const handleClickReportButton = () => {
     handleReportModal();
@@ -57,6 +64,10 @@ const CommentBox = ({
 
   const submitReportComment = (message: string) => {
     reportComment({ id, message });
+  };
+
+  const handleLikeButton = () => {
+    likeComment({ id });
   };
 
   if (!content) {
@@ -86,7 +97,10 @@ const CommentBox = ({
         <Styled.Content>{content}</Styled.Content>
         <Styled.Footer>
           <Styled.Date>{timeConverter(createdAt!)}</Styled.Date>
-          <LikeButton isLiked={false} onClick={() => {}} likeCount={3}></LikeButton>
+          <Styled.LikeContainer isLiked={like} onClick={handleLikeButton}>
+            <HeartImg fill={theme.colors.pink_300} stroke={theme.colors.pink_300} width="12px" height="11px" />
+            {countFormatter(likeCount)}
+          </Styled.LikeContainer>
         </Styled.Footer>
       </Styled.Container>
 

--- a/frontend/src/pages/PostPage/components/CommentBox/index.tsx
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.tsx
@@ -45,6 +45,8 @@ const CommentBox = ({
   const [isDeleteModalOpen, handleDeleteModal] = useReducer(state => !state, false);
   const [isReplyFormOpen, handleReplyForm] = useReducer(state => !state, false);
   const theme = useTheme();
+  const strokeColor = like ? theme.colors.pink_300 : theme.colors.gray_300;
+  const fillColor = like ? theme.colors.pink_300 : 'white';
 
   const { mutate: deleteComment } = useDeleteComment();
   const { mutate: reportComment } = useReportComment({
@@ -98,7 +100,7 @@ const CommentBox = ({
         <Styled.Footer>
           <Styled.Date>{timeConverter(createdAt!)}</Styled.Date>
           <Styled.LikeContainer isLiked={like} onClick={handleLikeButton}>
-            <HeartImg fill={theme.colors.pink_300} stroke={theme.colors.pink_300} width="12px" height="11px" />
+            <HeartImg fill={fillColor} stroke={strokeColor} width="12px" height="11px" />
             {countFormatter(likeCount)}
           </Styled.LikeContainer>
         </Styled.Footer>

--- a/frontend/src/pages/PostPage/components/CommentBox/index.tsx
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.tsx
@@ -1,6 +1,7 @@
 import { useReducer } from 'react';
 
 import ConfirmModal from '@/components/ConfirmModal';
+import LikeButton from '@/components/LikeButton';
 
 import useDeleteComment from '@/hooks/queries/comment/useDeleteComment';
 import useReportComment from '@/hooks/queries/comment/useReportComment';
@@ -83,7 +84,10 @@ const CommentBox = ({
           </Styled.ButtonContainer>
         </Styled.CommentHeader>
         <Styled.Content>{content}</Styled.Content>
-        <Styled.Date>{timeConverter(createdAt!)}</Styled.Date>
+        <Styled.Footer>
+          <Styled.Date>{timeConverter(createdAt!)}</Styled.Date>
+          <LikeButton isLiked={false} onClick={() => {}} likeCount={3}></LikeButton>
+        </Styled.Footer>
       </Styled.Container>
 
       {isReplyFormOpen && <ReplyForm commentId={id} />}

--- a/frontend/src/types/comment.d.ts
+++ b/frontend/src/types/comment.d.ts
@@ -4,4 +4,5 @@ interface CommentType {
   content: string | null;
   createdAt: string | null;
   authorized: boolean | null;
+  likeCount: number;
 }

--- a/frontend/src/types/comment.d.ts
+++ b/frontend/src/types/comment.d.ts
@@ -5,4 +5,5 @@ interface CommentType {
   createdAt: string | null;
   authorized: boolean | null;
   likeCount: number;
+  like: boolean;
 }


### PR DESCRIPTION
### 구현기능

- 댓글 및 대댓글에 대한 좋아요 기능을 구현한다.

### 세부 구현기능

- [x] 댓글 및 대댓글에 대해 like, likeCount기반으로 좋아요에 대한 렌더링을 한다.
- [x] 댓글 및 대댓글에 좋아요 버튼을 누르면 좋아요가 반전된다.
- [x] mutate 후 캐싱된 데이터를 활용한다. 

### 관련 이슈

- setQuriesData()를 사용하여 로직이 상당히 복잡함.
- axios의 모든 config들을 캐싱해 놓을 필요가 있을까? #492

close #479 