### PR TITLE
feat: 프로필 페이지 구현 

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import MainPage from './pages/MainPage';
 import NotFoundPage from './pages/NotFoundPage';
 import NotificationPage from './pages/NotificationPage';
 import PostPage from './pages/PostPage';
+import ProfilePage from './pages/ProfilePage';
 import SignUpPage from './pages/SignUpPage';
 import UpdatePostPage from './pages/UpdatePostPage';
 
@@ -58,6 +59,7 @@ const App = () => {
         <Route path="*" element={<NotFoundPage />} />
         <Route element={<PrivateRoute />}>
           <Route path={PATH.CREATE_POST} element={<CreatePostPage />} />
+          <Route path={PATH.PROFILE} element={<ProfilePage />} />
           <Route path={PATH.NOTIFICATION} element={<NotificationPage />} />
         </Route>
         <Route element={<PublicRoute />}>

--- a/frontend/src/components/@shared/Dropdown/index.tsx
+++ b/frontend/src/components/@shared/Dropdown/index.tsx
@@ -64,7 +64,11 @@ const OptionList = ({ className, children }: DropdownProps) => {
     throw new Error('');
   }
 
-  return <Styled.DropdownList className={className}>{dropdown.open ? children : null}</Styled.DropdownList>;
+  return (
+    <Styled.DropdownList className={className} onClick={() => dropdown.setOpen(false)}>
+      {dropdown.open ? children : null}
+    </Styled.DropdownList>
+  );
 };
 
 Dropdown.Trigger = Trigger;

--- a/frontend/src/components/Header/index.styles.ts
+++ b/frontend/src/components/Header/index.styles.ts
@@ -87,7 +87,7 @@ export const optionStyle = css`
   font-size: 0.7rem;
 `;
 
-export const ProfileButton = styled.button`
+export const ProfileLink = styled(Link)`
   ${optionStyle}
   color: ${props => props.theme.colors.gray_150};
 `;

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -45,7 +45,7 @@ const Header = () => {
                 </Dropdown.Trigger>
                 <Dropdown.OptionList>
                   <Styled.OptionsContainer>
-                    <Styled.ProfileButton>프로필</Styled.ProfileButton>
+                    <Styled.ProfileLink to={PATH.PROFILE}>프로필</Styled.ProfileLink>
                     <Styled.LogoutButton onClick={handleClickLogout}>로그아웃</Styled.LogoutButton>
                   </Styled.OptionsContainer>
                 </Dropdown.OptionList>

--- a/frontend/src/components/Pagination/index.stories.tsx
+++ b/frontend/src/components/Pagination/index.stories.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import Pagination from '.';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
@@ -6,7 +8,14 @@ export default {
   component: Pagination,
 } as ComponentMeta<typeof Pagination>;
 
-const Template: ComponentStory<typeof Pagination> = () => <Pagination />;
+const Template: ComponentStory<typeof Pagination> = args => {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  return <Pagination {...args} currentPage={currentPage} setCurrentPage={setCurrentPage} />;
+};
 
 export const PaginationTemplate = Template.bind({});
-PaginationTemplate.args = {};
+PaginationTemplate.args = {
+  firstPage: 1,
+  lastPage: 11,
+};

--- a/frontend/src/components/Pagination/index.stories.tsx
+++ b/frontend/src/components/Pagination/index.stories.tsx
@@ -1,0 +1,12 @@
+import Pagination from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Components/Pagination',
+  component: Pagination,
+} as ComponentMeta<typeof Pagination>;
+
+const Template: ComponentStory<typeof Pagination> = () => <Pagination />;
+
+export const PaginationTemplate = Template.bind({});
+PaginationTemplate.args = {};

--- a/frontend/src/components/Pagination/index.styles.ts
+++ b/frontend/src/components/Pagination/index.styles.ts
@@ -6,8 +6,8 @@ export const Container = styled.div`
 
 export const Page = styled.button<{ isCurrentPage: boolean }>`
   background-color: transparent;
-  width: 20px;
-  height: 20px;
+  width: 30px;
+  height: 30px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/Pagination/index.styles.ts
+++ b/frontend/src/components/Pagination/index.styles.ts
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  display: flex;
+`;
+
+export const Page = styled.button<{ isCurrentPage: boolean }>`
+  background-color: transparent;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  font-weight: 800;
+  font-size: 14px;
+  color: ${props => (props.isCurrentPage ? props.theme.colors.sub : props.theme.colors.gray_200)};
+`;

--- a/frontend/src/components/Pagination/index.tsx
+++ b/frontend/src/components/Pagination/index.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+import * as Styled from './index.styles';
+
+const MAX_PAGE_LOAD = 8;
+const STANDARD = MAX_PAGE_LOAD / 2;
+const DISPLAY_STANDARD = STANDARD + 1;
+
+const Pagination = () => {
+  const firstPage = 1;
+  const lastPage = 11;
+  const pages = Array.from({ length: lastPage }, (_, i) => i + 1);
+  const [currentPage, setCurrentPage] = useState(firstPage);
+  const [currentPages, setCurrentPages] = useState<(number | string)[]>(pages);
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    const page = Number(e.currentTarget.innerText);
+
+    if (isNaN(page)) return;
+
+    setCurrentPage(page);
+  };
+
+  useEffect(() => {
+    switch (true) {
+      case lastPage < MAX_PAGE_LOAD:
+        break;
+
+      case lastPage - currentPage >= STANDARD && currentPage - firstPage >= STANDARD:
+        setCurrentPages([firstPage, '...', currentPage - 1, currentPage, currentPage + 1, '...', lastPage]);
+        break;
+
+      case lastPage - currentPage >= STANDARD:
+        setCurrentPages([...pages.slice(0, DISPLAY_STANDARD), '...', lastPage]);
+        break;
+
+      case currentPage - firstPage >= STANDARD:
+        setCurrentPages([firstPage, '...', ...pages.slice(-DISPLAY_STANDARD)]);
+        break;
+    }
+  }, [currentPage]);
+
+  return (
+    <Styled.Container>
+      {currentPages.map((page, index) => (
+        <Styled.Page key={index} onClick={handleClick} isCurrentPage={page === currentPage}>
+          {page}
+        </Styled.Page>
+      ))}
+    </Styled.Container>
+  );
+};
+
+export default Pagination;

--- a/frontend/src/components/Pagination/index.tsx
+++ b/frontend/src/components/Pagination/index.tsx
@@ -6,11 +6,16 @@ const MAX_PAGE_LOAD = 8;
 const STANDARD = MAX_PAGE_LOAD / 2;
 const DISPLAY_STANDARD = STANDARD + 1;
 
-const Pagination = () => {
-  const firstPage = 1;
-  const lastPage = 11;
+interface PaginationProps {
+  className?: string;
+  firstPage?: number;
+  lastPage: number;
+  currentPage: number;
+  setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const Pagination = ({ className, firstPage = 1, lastPage, currentPage, setCurrentPage }: PaginationProps) => {
   const pages = Array.from({ length: lastPage }, (_, i) => i + 1);
-  const [currentPage, setCurrentPage] = useState(firstPage);
   const [currentPages, setCurrentPages] = useState<(number | string)[]>(pages);
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -41,7 +46,7 @@ const Pagination = () => {
   }, [currentPage]);
 
   return (
-    <Styled.Container>
+    <Styled.Container className={className}>
       {currentPages.map((page, index) => (
         <Styled.Page key={index} onClick={handleClick} isCurrentPage={page === currentPage}>
           {page}

--- a/frontend/src/components/PostCountInfo/index.stories.tsx
+++ b/frontend/src/components/PostCountInfo/index.stories.tsx
@@ -1,0 +1,15 @@
+import PostCountInfo from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Components/PostCountInfo',
+  component: PostCountInfo,
+} as ComponentMeta<typeof PostCountInfo>;
+
+const Template: ComponentStory<typeof PostCountInfo> = args => <PostCountInfo {...args} />;
+
+export const PostCountInfoTemplate = Template.bind({});
+PostCountInfoTemplate.args = {
+  likeCount: 15,
+  commentCount: 3,
+};

--- a/frontend/src/components/PostCountInfo/index.styles.ts
+++ b/frontend/src/components/PostCountInfo/index.styles.ts
@@ -1,0 +1,34 @@
+import Comment from '@/assets/images/comment.svg';
+import Heart from '@/assets/images/heart.svg';
+
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  max-width: fit-content;
+  align-self: flex-end;
+  display: flex;
+  justify-content: space-between;
+  font-family: 'Noto Sans KR', sans-serif;
+`;
+
+export const LikeIcon = styled(Heart)`
+  fill: ${props => props.theme.colors.pink_300};
+  stroke: ${props => props.theme.colors.pink_300};
+  width: 16px;
+  height: 14px;
+  margin: 0 4px 0 10px;
+`;
+
+export const LikeCount = styled.span`
+  color: ${props => props.theme.colors.pink_300};
+`;
+
+export const CommentIcon = styled(Comment)`
+  width: 16px;
+  height: 15px;
+  margin: 0 4px 0 10px;
+`;
+
+export const CommentCount = styled.span`
+  color: ${props => props.theme.colors.gray_200};
+`;

--- a/frontend/src/components/PostCountInfo/index.tsx
+++ b/frontend/src/components/PostCountInfo/index.tsx
@@ -1,0 +1,21 @@
+import * as Styled from './index.styles';
+
+import countFormatter from '@/utils/countFormatter';
+
+interface PostCountInfoProps {
+  likeCount: number;
+  commentCount: number;
+}
+
+const PostCountInfo = ({ likeCount, commentCount }: PostCountInfoProps) => {
+  return (
+    <Styled.Container>
+      <Styled.LikeIcon />
+      <Styled.LikeCount>{countFormatter(likeCount)}</Styled.LikeCount>
+      <Styled.CommentIcon />
+      <Styled.CommentCount>{countFormatter(commentCount)}</Styled.CommentCount>
+    </Styled.Container>
+  );
+};
+
+export default PostCountInfo;

--- a/frontend/src/components/PostListItem/index.tsx
+++ b/frontend/src/components/PostListItem/index.tsx
@@ -1,5 +1,7 @@
 import { forwardRef } from 'react';
 
+import PostCountInfo from '@/components/PostCountInfo';
+
 import * as Styled from './index.styles';
 
 import countFormatter from '@/utils/countFormatter';
@@ -26,12 +28,7 @@ const PostListItem = forwardRef<HTMLDivElement, PostListItemProps>(
           <Styled.ContentContainer>
             <Styled.Content>블라인드 처리된 글입니다.</Styled.Content>
           </Styled.ContentContainer>
-          <Styled.PostInfoContainer>
-            <Styled.LikeIcon />
-            <Styled.LikeCount>{countFormatter(likeCount)}</Styled.LikeCount>
-            <Styled.CommentIcon />
-            <Styled.CommentCount>{countFormatter(commentCount)}</Styled.CommentCount>
-          </Styled.PostInfoContainer>
+          <PostCountInfo likeCount={likeCount} commentCount={commentCount} />
         </Styled.BlockedContainer>
       );
     }

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -8,6 +8,7 @@ const PATH = {
   BOARD: '/board',
   HASHTAG: '/hashtag',
   NOTIFICATION: '/notification',
+  PROFILE: '/profile',
 };
 
 export default PATH;

--- a/frontend/src/constants/queries.ts
+++ b/frontend/src/constants/queries.ts
@@ -11,6 +11,7 @@ const QUERY_KEYS = {
   LOGOUT: 'logout',
   NOTIFICATION_EXISTS: 'notification-exists',
   NOTIFICATIONS: 'notifications',
+  MY_POSTS: 'my-posts',
 };
 
 export const MUTATION_KEY = {

--- a/frontend/src/constants/snackbar.ts
+++ b/frontend/src/constants/snackbar.ts
@@ -10,6 +10,7 @@ const SNACKBAR_MESSAGE = {
   SUCCESS_REPORT_COMMENT: '신고에 성공하였습니다.',
   SUCCESS_REPORT_POST: '신고에 성공하였습니다.',
   SUCCESS_LOGOUT: '로그아웃에 성공하였습니다.',
+  SUCCESS_UPDATE_NICKNAME: '닉네임이 성공적으로 수정되었습니다.',
   FAIL_LOGIN: '아이디와 비밀번호를 확인해주세요',
   FAIL_COMMENT: '댓글을 입력해주세요',
   EMPTY_TAG: '내용을 채워주세요.',

--- a/frontend/src/context/Pagination.tsx
+++ b/frontend/src/context/Pagination.tsx
@@ -1,0 +1,16 @@
+import React, { Dispatch, SetStateAction, useState } from 'react';
+
+interface PaginationContextValue {
+  page: number;
+  setPage: Dispatch<SetStateAction<number>>;
+}
+
+const PaginationContext = React.createContext<PaginationContextValue>({} as PaginationContextValue);
+
+export const PaginationContextProvider = ({ children }: { children: React.ReactNode }) => {
+  const [page, setPage] = useState(1);
+
+  return <PaginationContext.Provider value={{ page, setPage }}>{children}</PaginationContext.Provider>;
+};
+
+export default PaginationContext;

--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -341,6 +341,21 @@ export const postList: Post[] = [
     nickname: '못된 젠킨스',
     blocked: false,
   },
+  {
+    id: 21,
+    title: '속닥속닥이 이번 감동크루 맡는다는데',
+    createdAt: '2022-08-16T11:55:31.016376300',
+    content: '쩐다.',
+    likeCount: 1,
+    commentCount: 0,
+    like: true,
+    modified: false,
+    hashtags: [],
+    authorized: true,
+    boardId: 3,
+    nickname: '테스트 계정',
+    blocked: false,
+  },
 ];
 
 export const memberList: Member[] = [

--- a/frontend/src/hooks/queries/member/useUpdateNickname.ts
+++ b/frontend/src/hooks/queries/member/useUpdateNickname.ts
@@ -1,0 +1,23 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+
+import axios, { AxiosError, AxiosResponse } from 'axios';
+
+interface UseUpdateNicknameProps {
+  nickname: string;
+}
+
+const useUpdateNickname = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError<ErrorResponse>, UseUpdateNicknameProps>,
+) => {
+  return useMutation(
+    ({ nickname }): Promise<AxiosResponse> =>
+      axios.patch('/members/nickname', {
+        nickname,
+      }),
+    {
+      ...options,
+    },
+  );
+};
+
+export default useUpdateNickname;

--- a/frontend/src/hooks/queries/profile/useMyPosts.ts
+++ b/frontend/src/hooks/queries/profile/useMyPosts.ts
@@ -1,7 +1,8 @@
 import { QueryKey, useQuery, UseQueryOptions } from 'react-query';
 
-import axios, { AxiosError, AxiosResponse } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 
+import authFetcher from '@/apis';
 import QUERY_KEYS from '@/constants/queries';
 
 type Size = number;
@@ -21,7 +22,7 @@ const useMyPosts = ({
 }) =>
   useQuery(
     [QUERY_KEYS.MY_POSTS, ...storeCode],
-    ({ queryKey: [, size, page] }) => axios.get(`/posts/me?size=${size}&page=${page - 1}`),
+    ({ queryKey: [, size, page] }) => authFetcher.get(`/posts/me?size=${size}&page=${page - 1}`),
     {
       select: data => data.data,
       ...options,

--- a/frontend/src/hooks/queries/profile/useMyPosts.ts
+++ b/frontend/src/hooks/queries/profile/useMyPosts.ts
@@ -1,0 +1,26 @@
+import { QueryKey, useQuery, UseQueryOptions } from 'react-query';
+
+import axios, { AxiosError, AxiosResponse } from 'axios';
+
+import QUERY_KEYS from '@/constants/queries';
+
+type Size = number;
+type Page = number;
+
+const useMyPosts = ({
+  storeCode,
+  options,
+}: {
+  storeCode: [Size, Page];
+  options?: UseQueryOptions<AxiosResponse, AxiosError<ErrorResponse>, Post, [QueryKey, Size, Page]>;
+}) =>
+  useQuery(
+    [QUERY_KEYS.MY_POSTS, ...storeCode],
+    ({ queryKey: [, size, page] }) => axios.get(`/posts/me?size=${size}&page=${page}`),
+    {
+      select: data => data.data,
+      ...options,
+    },
+  );
+
+export default useMyPosts;

--- a/frontend/src/hooks/queries/profile/useMyPosts.ts
+++ b/frontend/src/hooks/queries/profile/useMyPosts.ts
@@ -7,16 +7,21 @@ import QUERY_KEYS from '@/constants/queries';
 type Size = number;
 type Page = number;
 
+interface ResponseData {
+  posts: Post[];
+  totalPageCount: number;
+}
+
 const useMyPosts = ({
   storeCode,
   options,
 }: {
   storeCode: [Size, Page];
-  options?: UseQueryOptions<AxiosResponse, AxiosError<ErrorResponse>, Post, [QueryKey, Size, Page]>;
+  options?: UseQueryOptions<AxiosResponse, AxiosError<ErrorResponse>, ResponseData, [QueryKey, Size, Page]>;
 }) =>
   useQuery(
     [QUERY_KEYS.MY_POSTS, ...storeCode],
-    ({ queryKey: [, size, page] }) => axios.get(`/posts/me?size=${size}&page=${page}`),
+    ({ queryKey: [, size, page] }) => axios.get(`/posts/me?size=${size}&page=${page - 1}`),
     {
       select: data => data.data,
       ...options,

--- a/frontend/src/hooks/queries/profile/useUpdateNickname.ts
+++ b/frontend/src/hooks/queries/profile/useUpdateNickname.ts
@@ -1,6 +1,8 @@
 import { useMutation, UseMutationOptions } from 'react-query';
 
-import axios, { AxiosError, AxiosResponse } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import authFetcher from '@/apis';
 
 interface UseUpdateNicknameProps {
   nickname: string;
@@ -11,7 +13,7 @@ const useUpdateNickname = (
 ) => {
   return useMutation(
     ({ nickname }): Promise<AxiosResponse> =>
-      axios.patch('/members/nickname', {
+      authFetcher.patch('/members/nickname', {
         nickname,
       }),
     {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter } from 'react-router-dom';
 import axios from 'axios';
 
 import { AuthContextProvider } from './context/Auth';
+import { PaginationContextProvider } from './context/Pagination';
 import { SnackBarContextProvider } from './context/Snackbar';
 
 import authFetcher from './apis';
@@ -53,7 +54,9 @@ ReactDOM.createRoot(rootNode).render(
         <BrowserRouter>
           <QueryClientProvider client={queryClient}>
             <AuthContextProvider>
-              <App />
+              <PaginationContextProvider>
+                <App />
+              </PaginationContextProvider>
             </AuthContextProvider>
           </QueryClientProvider>
         </BrowserRouter>

--- a/frontend/src/mocks/handlers/members/index.ts
+++ b/frontend/src/mocks/handlers/members/index.ts
@@ -129,6 +129,10 @@ const memberHandler = [
 
     return res(ctx.status(201));
   }),
+
+  rest.patch('/members/nickname', (req, res, ctx) => {
+    return res(ctx.status(204));
+  }),
 ];
 
 export default memberHandler;

--- a/frontend/src/mocks/handlers/posts/index.ts
+++ b/frontend/src/mocks/handlers/posts/index.ts
@@ -81,6 +81,24 @@ const postHandlers = [
 
   rest.get('/posts/:id', (req, res, ctx) => {
     const { id } = req.params;
+
+    if (isNaN(Number(id))) {
+      const size = Number(req.url.searchParams.get('size'));
+      const page = Number(req.url.searchParams.get('page'));
+
+      const myPosts = postList.filter(post => post.authorized);
+      const currentPage = myPosts.slice(page * size, page * size + size);
+      const totalPageCount = Math.ceil(myPosts.length / size);
+
+      return res(
+        ctx.status(200),
+        ctx.json({
+          posts: currentPage,
+          totalPageCount,
+        }),
+      );
+    }
+
     const targetPost = postList.find(post => post.id === Number(id));
 
     if (!targetPost) {

--- a/frontend/src/pages/MainPage/components/BoardItem/index.tsx
+++ b/frontend/src/pages/MainPage/components/BoardItem/index.tsx
@@ -1,7 +1,8 @@
+import PostCountInfo from '@/components/PostCountInfo';
+
 import * as Styled from './index.styles';
 
 import PATH from '@/constants/path';
-import countFormatter from '@/utils/countFormatter';
 
 interface BoardItemProps {
   id: number;
@@ -17,16 +18,7 @@ const BoardItem = ({ id, title, posts }: BoardItemProps) => {
         {posts.map(post => (
           <Styled.Item key={post.id} to={`${PATH.POST}/${post.id}`} data-testid={post.id}>
             <Styled.ItemTitle>{post.title}</Styled.ItemTitle>
-            <Styled.PostInfoContainer>
-              <Styled.IconContainer>
-                <Styled.LikeIcon />
-                <Styled.LikeCount>{countFormatter(post.likeCount)}</Styled.LikeCount>
-              </Styled.IconContainer>
-              <Styled.IconContainer>
-                <Styled.CommentIcon />
-                <Styled.CommentCount>{countFormatter(post.commentCount)}</Styled.CommentCount>
-              </Styled.IconContainer>
-            </Styled.PostInfoContainer>
+            <PostCountInfo likeCount={post.likeCount} commentCount={post.commentCount} />
           </Styled.Item>
         ))}
       </Styled.ItemContainer>

--- a/frontend/src/pages/ProfilePage/components/PostItem/index.stories.tsx
+++ b/frontend/src/pages/ProfilePage/components/PostItem/index.stories.tsx
@@ -1,0 +1,25 @@
+import { withRouter } from 'storybook-addon-react-router-v6';
+
+import PostItem from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Pages/ProfilePage/PostItem',
+  component: PostItem,
+  decorators: [withRouter],
+} as ComponentMeta<typeof PostItem>;
+
+const Template: ComponentStory<typeof PostItem> = args => (
+  <div style={{ width: '335px' }}>
+    <PostItem {...args} />
+  </div>
+);
+
+export const PostItemTemplate: ComponentStory<typeof PostItem> = Template.bind({});
+PostItemTemplate.args = {
+  title: '똥글',
+  content: '똥글 동글 둥글 ~ 둥글레차',
+  createdAt: new Date('2022-08-10').toISOString(),
+  likeCount: 3,
+  commentCount: 5,
+};

--- a/frontend/src/pages/ProfilePage/components/PostItem/index.styles.ts
+++ b/frontend/src/pages/ProfilePage/components/PostItem/index.styles.ts
@@ -8,6 +8,7 @@ export const Container = styled.div`
   justify-content: space-between;
   border-bottom: 1px solid ${props => props.theme.colors.gray_400};
   padding: 10px 0;
+  cursor: pointer;
 `;
 
 export const Title = styled.p`

--- a/frontend/src/pages/ProfilePage/components/PostItem/index.styles.ts
+++ b/frontend/src/pages/ProfilePage/components/PostItem/index.styles.ts
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  width: 100%;
+  height: 100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-bottom: 1px solid ${props => props.theme.colors.gray_400};
+  padding: 10px 0;
+`;
+
+export const Title = styled.p`
+  font-weight: 700;
+  font-size: 15px;
+`;
+
+export const Content = styled.p`
+  font-size: 14px;
+  color: ${props => props.theme.colors.gray_200};
+`;
+
+export const Information = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const CreatedAt = styled.p`
+  font-size: 10px;
+  color: ${props => props.theme.colors.gray_200};
+`;

--- a/frontend/src/pages/ProfilePage/components/PostItem/index.tsx
+++ b/frontend/src/pages/ProfilePage/components/PostItem/index.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 import PostCountInfo from '@/components/PostCountInfo';
 
 import * as Styled from './index.styles';
@@ -5,6 +7,7 @@ import * as Styled from './index.styles';
 import timeConverter from '@/utils/timeConverter';
 
 interface PostItemProps {
+  id: number;
   title: string;
   content: string;
   createdAt: string;
@@ -12,9 +15,11 @@ interface PostItemProps {
   commentCount: number;
 }
 
-const PostItem = ({ title, content, createdAt, likeCount, commentCount }: PostItemProps) => {
+const PostItem = ({ id, title, content, createdAt, likeCount, commentCount }: PostItemProps) => {
+  const navagate = useNavigate();
+
   return (
-    <Styled.Container>
+    <Styled.Container onClick={() => navagate(`/post/${id}`)}>
       <Styled.Title>{title}</Styled.Title>
       <Styled.Content>{content}</Styled.Content>
       <Styled.Information>

--- a/frontend/src/pages/ProfilePage/components/PostItem/index.tsx
+++ b/frontend/src/pages/ProfilePage/components/PostItem/index.tsx
@@ -1,0 +1,28 @@
+import PostCountInfo from '@/components/PostCountInfo';
+
+import * as Styled from './index.styles';
+
+import timeConverter from '@/utils/timeConverter';
+
+interface PostItemProps {
+  title: string;
+  content: string;
+  createdAt: string;
+  likeCount: number;
+  commentCount: number;
+}
+
+const PostItem = ({ title, content, createdAt, likeCount, commentCount }: PostItemProps) => {
+  return (
+    <Styled.Container>
+      <Styled.Title>{title}</Styled.Title>
+      <Styled.Content>{content}</Styled.Content>
+      <Styled.Information>
+        <Styled.CreatedAt>{timeConverter(createdAt)}</Styled.CreatedAt>
+        <PostCountInfo likeCount={likeCount} commentCount={commentCount} />
+      </Styled.Information>
+    </Styled.Container>
+  );
+};
+
+export default PostItem;

--- a/frontend/src/pages/ProfilePage/index.stories.tsx
+++ b/frontend/src/pages/ProfilePage/index.stories.tsx
@@ -4,7 +4,7 @@ import ProfilePage from '.';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 export default {
-  title: 'Pages/ProfilePage',
+  title: 'Pages/ProfilePage/Page',
   component: ProfilePage,
   decorators: [withRouter],
 } as ComponentMeta<typeof ProfilePage>;

--- a/frontend/src/pages/ProfilePage/index.stories.tsx
+++ b/frontend/src/pages/ProfilePage/index.stories.tsx
@@ -1,0 +1,15 @@
+import { withRouter } from 'storybook-addon-react-router-v6';
+
+import ProfilePage from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Pages/ProfilePage',
+  component: ProfilePage,
+  decorators: [withRouter],
+} as ComponentMeta<typeof ProfilePage>;
+
+const Template = () => <ProfilePage />;
+
+export const ProfilePageTemplate: ComponentStory<typeof ProfilePage> = Template.bind({});
+ProfilePageTemplate.args = {};

--- a/frontend/src/pages/ProfilePage/index.styles.ts
+++ b/frontend/src/pages/ProfilePage/index.styles.ts
@@ -1,0 +1,3 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div``;

--- a/frontend/src/pages/ProfilePage/index.styles.ts
+++ b/frontend/src/pages/ProfilePage/index.styles.ts
@@ -27,6 +27,17 @@ export const Panda = styled(PandaIcon)`
   margin-left: -12px;
 `;
 
+export const FocusBorder = styled.span`
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 1px;
+  background-color: ${props => props.theme.colors.gray_400};
+  transition: 0.4s;
+`;
+
 export const NicknameField = styled.form`
   width: 100%;
   display: flex;
@@ -35,8 +46,16 @@ export const NicknameField = styled.form`
   justify-content: center;
 `;
 
-export const Nickname = styled.input`
-  max-width: 240px;
+export const NicknameInputField = styled.div`
+  width: 100%;
+  height: 30px;
+  position: relative;
+  display: flex;
+  justify-content: center;
+`;
+
+export const Nickname = styled.input<{ length: number }>`
+  width: 200px;
   font-family: 'BMHANNAPro';
   grid-column: 2;
   text-align: center;
@@ -44,7 +63,7 @@ export const Nickname = styled.input`
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 20px;
+  font-size: ${props => (props.length > 10 ? 30 - props.length + 'px' : '20px')};
   padding-bottom: 5px;
 
   :disabled {
@@ -52,13 +71,13 @@ export const Nickname = styled.input`
     background-color: transparent;
   }
 
-  :enabled {
-    padding-bottom: 4px;
-    border-bottom: 1px solid ${props => props.theme.colors.gray_400};
-  }
-
   ::placeholder {
     font-size: 15px;
+  }
+
+  :enabled ~ ${FocusBorder} {
+    width: 200px;
+    transition: 0.4s;
   }
 `;
 

--- a/frontend/src/pages/ProfilePage/index.styles.ts
+++ b/frontend/src/pages/ProfilePage/index.styles.ts
@@ -96,3 +96,12 @@ export const Pagination = styled(PaginationComponent)`
   align-self: center;
   margin: 15px 0;
 `;
+
+export const EmptyPostList = styled.div`
+  font-family: 'BMHANNAPro';
+  height: 363px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: ${props => props.theme.colors.gray_200};
+`;

--- a/frontend/src/pages/ProfilePage/index.styles.ts
+++ b/frontend/src/pages/ProfilePage/index.styles.ts
@@ -36,7 +36,7 @@ export const NicknameField = styled.form`
 `;
 
 export const Nickname = styled.input`
-  min-width: 50px;
+  max-width: 240px;
   font-family: 'BMHANNAPro';
   grid-column: 2;
   text-align: center;

--- a/frontend/src/pages/ProfilePage/index.styles.ts
+++ b/frontend/src/pages/ProfilePage/index.styles.ts
@@ -27,21 +27,39 @@ export const Panda = styled(PandaIcon)`
   margin-left: -12px;
 `;
 
-export const NicknameField = styled.div`
+export const NicknameField = styled.form`
   width: 100%;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  display: flex;
   padding: 30px 0;
+  position: relative;
+  justify-content: center;
 `;
 
-export const Nickname = styled.p`
+export const Nickname = styled.input`
+  min-width: 50px;
   font-family: 'BMHANNAPro';
   grid-column: 2;
+  text-align: center;
 
   display: flex;
   justify-content: center;
   align-items: center;
   font-size: 20px;
+  padding-bottom: 5px;
+
+  :disabled {
+    color: black;
+    background-color: transparent;
+  }
+
+  :enabled {
+    padding-bottom: 4px;
+    border-bottom: 1px solid ${props => props.theme.colors.gray_400};
+  }
+
+  ::placeholder {
+    font-size: 15px;
+  }
 `;
 
 export const UpdateButton = styled.button`
@@ -50,6 +68,10 @@ export const UpdateButton = styled.button`
   align-items: center;
   background-color: transparent;
   color: ${props => props.theme.colors.pink_300};
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translate3d(0, -50%, 0);
 `;
 
 export const PostField = styled.div`

--- a/frontend/src/pages/ProfilePage/index.styles.ts
+++ b/frontend/src/pages/ProfilePage/index.styles.ts
@@ -1,3 +1,76 @@
+import PaginationComponent from '@/components/Pagination';
+
+import PandaIcon from '@/assets/images/panda_logo.svg';
+
 import styled from '@emotion/styled';
 
-export const Container = styled.div``;
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Avatar = styled.div`
+  box-sizing: border-box;
+  width: 150px;
+  height: 150px;
+  border: 1px solid ${props => props.theme.colors.gray_400};
+  border-radius: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-self: center;
+`;
+
+export const Panda = styled(PandaIcon)`
+  width: 140px;
+  margin-left: -12px;
+`;
+
+export const NicknameField = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  padding: 30px 0;
+`;
+
+export const Nickname = styled.p`
+  font-family: 'BMHANNAPro';
+  grid-column: 2;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 20px;
+`;
+
+export const UpdateButton = styled.button`
+  display: flex;
+  justify-self: flex-end;
+  align-items: center;
+  background-color: transparent;
+  color: ${props => props.theme.colors.pink_300};
+`;
+
+export const PostField = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const PostListHeader = styled.p`
+  border-top: 1px solid ${props => props.theme.colors.gray_400};
+  font-family: 'BMHANNAPro';
+  font-size: 20px;
+  padding: 15px 0;
+`;
+
+export const PostList = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 363px;
+`;
+
+export const Pagination = styled(PaginationComponent)`
+  align-self: center;
+  margin: 15px 0;
+`;

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -1,0 +1,13 @@
+import Layout from '@/components/@styled/Layout';
+
+import * as Styled from './index.styles';
+
+const ProfilePage = () => {
+  return (
+    <Layout>
+      <Styled.Container></Styled.Container>
+    </Layout>
+  );
+};
+
+export default ProfilePage;

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -1,19 +1,47 @@
-import { useState } from 'react';
+import { useContext, useReducer, useRef, useState } from 'react';
 
 import PostItem from './components/PostItem';
 import Layout from '@/components/@styled/Layout';
 
+import AuthContext from '@/context/Auth';
+
+import useUpdateNickname from '@/hooks/queries/member/useUpdateNickname';
 import useMyPosts from '@/hooks/queries/profile/useMyPosts';
+import useSnackbar from '@/hooks/useSnackbar';
 
 import * as Styled from './index.styles';
 
+import SNACKBAR_MESSAGE from '@/constants/snackbar';
+
 const ProfilePage = () => {
+  const { showSnackbar } = useSnackbar();
+  const { username, setUserName } = useContext(AuthContext);
+  const [nickname, setNickname] = useState(username);
+  const [disabled, handleDisabled] = useReducer(state => !state, true);
+
   const size = 3;
   const [currentPage, setCurrentPage] = useState(1);
-
   const { data } = useMyPosts({
     storeCode: [size, currentPage],
   });
+
+  const nicknameRef = useRef<HTMLInputElement>(null);
+  const { mutate } = useUpdateNickname({
+    onSuccess: () => {
+      setUserName(nickname);
+      showSnackbar(SNACKBAR_MESSAGE.SUCCESS_UPDATE_NICKNAME);
+    },
+  });
+
+  const handleClick = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!disabled) {
+      mutate({ nickname });
+    }
+
+    handleDisabled();
+  };
 
   return (
     <Layout>
@@ -22,8 +50,17 @@ const ProfilePage = () => {
           <Styled.Panda />
         </Styled.Avatar>
         <Styled.NicknameField>
-          <Styled.Nickname>속닥속닥</Styled.Nickname>
-          <Styled.UpdateButton>수정</Styled.UpdateButton>
+          <Styled.Nickname
+            value={nickname}
+            onChange={e => setNickname(e.target.value)}
+            maxLength={16}
+            disabled={disabled}
+            ref={nicknameRef}
+            size={nickname.length}
+            placeholder="닉네임을 입력해주세요."
+            required
+          />
+          <Styled.UpdateButton onClick={handleClick}>{disabled ? '수정' : '완료'}</Styled.UpdateButton>
         </Styled.NicknameField>
         <Styled.PostField>
           <Styled.PostListHeader>내가 쓴 글</Styled.PostListHeader>

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -1,11 +1,48 @@
+import { useState } from 'react';
+
+import PostItem from './components/PostItem';
 import Layout from '@/components/@styled/Layout';
+
+import useMyPosts from '@/hooks/queries/profile/useMyPosts';
 
 import * as Styled from './index.styles';
 
 const ProfilePage = () => {
+  const size = 3;
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const { data } = useMyPosts({
+    storeCode: [size, currentPage],
+  });
+
   return (
     <Layout>
-      <Styled.Container></Styled.Container>
+      <Styled.Container>
+        <Styled.Avatar>
+          <Styled.Panda />
+        </Styled.Avatar>
+        <Styled.NicknameField>
+          <Styled.Nickname>속닥속닥</Styled.Nickname>
+          <Styled.UpdateButton>수정</Styled.UpdateButton>
+        </Styled.NicknameField>
+        <Styled.PostField>
+          <Styled.PostListHeader>내가 쓴 글</Styled.PostListHeader>
+          {data && data.posts && (
+            <>
+              <Styled.PostList>
+                {data.posts.map(post => (
+                  <PostItem key={post.id} {...post} />
+                ))}
+              </Styled.PostList>
+              <Styled.Pagination
+                lastPage={data.totalPageCount}
+                currentPage={currentPage}
+                setCurrentPage={setCurrentPage}
+              />
+            </>
+          )}
+        </Styled.PostField>
+      </Styled.Container>
     </Layout>
   );
 };

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -33,7 +33,7 @@ const ProfilePage = () => {
     },
   });
 
-  const handleClick = (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
     if (!disabled) {
@@ -49,10 +49,14 @@ const ProfilePage = () => {
         <Styled.Avatar>
           <Styled.Panda />
         </Styled.Avatar>
-        <Styled.NicknameField>
+        <Styled.NicknameField onSubmit={handleSubmit}>
           <Styled.Nickname
             value={nickname}
             onChange={e => setNickname(e.target.value)}
+            onInvalid={(e: React.FormEvent<HTMLInputElement>) => {
+              e.preventDefault();
+              showSnackbar(e.currentTarget.placeholder);
+            }}
             maxLength={16}
             disabled={disabled}
             ref={nicknameRef}
@@ -60,7 +64,7 @@ const ProfilePage = () => {
             placeholder="닉네임을 입력해주세요."
             required
           />
-          <Styled.UpdateButton onClick={handleClick}>{disabled ? '수정' : '완료'}</Styled.UpdateButton>
+          <Styled.UpdateButton>{disabled ? '수정' : '완료'}</Styled.UpdateButton>
         </Styled.NicknameField>
         <Styled.PostField>
           <Styled.PostListHeader>내가 쓴 글</Styled.PostListHeader>

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -6,8 +6,8 @@ import Layout from '@/components/@styled/Layout';
 import AuthContext from '@/context/Auth';
 import PaginationContext from '@/context/Pagination';
 
-import useUpdateNickname from '@/hooks/queries/member/useUpdateNickname';
 import useMyPosts from '@/hooks/queries/profile/useMyPosts';
+import useUpdateNickname from '@/hooks/queries/profile/useUpdateNickname';
 import useSnackbar from '@/hooks/useSnackbar';
 
 import * as Styled from './index.styles';

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -64,7 +64,7 @@ const ProfilePage = () => {
         </Styled.NicknameField>
         <Styled.PostField>
           <Styled.PostListHeader>내가 쓴 글</Styled.PostListHeader>
-          {data && data.posts && (
+          {data && data.posts && data.posts.length !== 0 ? (
             <>
               <Styled.PostList>
                 {data.posts.map(post => (
@@ -77,6 +77,8 @@ const ProfilePage = () => {
                 setCurrentPage={setCurrentPage}
               />
             </>
+          ) : (
+            <Styled.EmptyPostList>아직 작성된 글이 없어요 !</Styled.EmptyPostList>
           )}
         </Styled.PostField>
       </Styled.Container>

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useReducer, useRef, useState } from 'react';
+import { useContext, useEffect, useReducer, useRef, useState } from 'react';
 
 import PostItem from './components/PostItem';
 import Layout from '@/components/@styled/Layout';
@@ -18,16 +18,15 @@ const OFFSET = 1.5;
 
 const ProfilePage = () => {
   const { showSnackbar } = useSnackbar();
+  const [currentPage, setCurrentPage] = useState(1);
   const { username, setUserName } = useContext(AuthContext);
   const [nickname, setNickname] = useState(username);
   const [disabled, handleDisabled] = useReducer(state => !state, true);
+  const nicknameRef = useRef<HTMLInputElement>(null);
 
-  const [currentPage, setCurrentPage] = useState(1);
   const { data } = useMyPosts({
     storeCode: [SIZE, currentPage],
   });
-
-  const nicknameRef = useRef<HTMLInputElement>(null);
   const { mutate } = useUpdateNickname({
     onSuccess: () => {
       setUserName(nickname);
@@ -44,6 +43,12 @@ const ProfilePage = () => {
 
     handleDisabled();
   };
+
+  useEffect(() => {
+    if (!disabled) {
+      nicknameRef.current?.focus();
+    }
+  }, [disabled]);
 
   return (
     <Layout>

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -4,6 +4,7 @@ import PostItem from './components/PostItem';
 import Layout from '@/components/@styled/Layout';
 
 import AuthContext from '@/context/Auth';
+import PaginationContext from '@/context/Pagination';
 
 import useUpdateNickname from '@/hooks/queries/member/useUpdateNickname';
 import useMyPosts from '@/hooks/queries/profile/useMyPosts';
@@ -17,14 +18,17 @@ const SIZE = 3;
 
 const ProfilePage = () => {
   const { showSnackbar } = useSnackbar();
-  const [currentPage, setCurrentPage] = useState(1);
+  const { page, setPage } = useContext(PaginationContext);
   const { username, setUserName } = useContext(AuthContext);
   const [nickname, setNickname] = useState(username);
   const [disabled, handleDisabled] = useReducer(state => !state, true);
   const nicknameRef = useRef<HTMLInputElement>(null);
 
   const { data } = useMyPosts({
-    storeCode: [SIZE, currentPage],
+    storeCode: [SIZE, page],
+    options: {
+      keepPreviousData: true,
+    },
   });
   const { mutate } = useUpdateNickname({
     onSuccess: () => {
@@ -84,11 +88,7 @@ const ProfilePage = () => {
                   <PostItem key={post.id} {...post} />
                 ))}
               </Styled.PostList>
-              <Styled.Pagination
-                lastPage={data.totalPageCount}
-                currentPage={currentPage}
-                setCurrentPage={setCurrentPage}
-              />
+              <Styled.Pagination lastPage={data.totalPageCount} currentPage={page} setCurrentPage={setPage} />
             </>
           ) : (
             <Styled.EmptyPostList>아직 작성된 글이 없어요 !</Styled.EmptyPostList>

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -13,16 +13,18 @@ import * as Styled from './index.styles';
 
 import SNACKBAR_MESSAGE from '@/constants/snackbar';
 
+const SIZE = 3;
+const OFFSET = 1.5;
+
 const ProfilePage = () => {
   const { showSnackbar } = useSnackbar();
   const { username, setUserName } = useContext(AuthContext);
   const [nickname, setNickname] = useState(username);
   const [disabled, handleDisabled] = useReducer(state => !state, true);
 
-  const size = 3;
   const [currentPage, setCurrentPage] = useState(1);
   const { data } = useMyPosts({
-    storeCode: [size, currentPage],
+    storeCode: [SIZE, currentPage],
   });
 
   const nicknameRef = useRef<HTMLInputElement>(null);
@@ -60,7 +62,7 @@ const ProfilePage = () => {
             maxLength={16}
             disabled={disabled}
             ref={nicknameRef}
-            size={nickname.length}
+            size={nickname.length * OFFSET}
             placeholder="닉네임을 입력해주세요."
             required
           />

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -14,7 +14,6 @@ import * as Styled from './index.styles';
 import SNACKBAR_MESSAGE from '@/constants/snackbar';
 
 const SIZE = 3;
-const OFFSET = 1.5;
 
 const ProfilePage = () => {
   const { showSnackbar } = useSnackbar();
@@ -57,20 +56,23 @@ const ProfilePage = () => {
           <Styled.Panda />
         </Styled.Avatar>
         <Styled.NicknameField onSubmit={handleSubmit}>
-          <Styled.Nickname
-            value={nickname}
-            onChange={e => setNickname(e.target.value)}
-            onInvalid={(e: React.FormEvent<HTMLInputElement>) => {
-              e.preventDefault();
-              showSnackbar(e.currentTarget.placeholder);
-            }}
-            maxLength={16}
-            disabled={disabled}
-            ref={nicknameRef}
-            size={nickname.length * OFFSET}
-            placeholder="닉네임을 입력해주세요."
-            required
-          />
+          <Styled.NicknameInputField>
+            <Styled.Nickname
+              value={nickname}
+              onChange={e => setNickname(e.target.value)}
+              onInvalid={(e: React.FormEvent<HTMLInputElement>) => {
+                e.preventDefault();
+                showSnackbar(e.currentTarget.placeholder);
+              }}
+              length={nickname.length}
+              maxLength={16}
+              disabled={disabled}
+              ref={nicknameRef}
+              placeholder="닉네임을 입력해주세요."
+              required
+            />
+            <Styled.FocusBorder />
+          </Styled.NicknameInputField>
           <Styled.UpdateButton>{disabled ? '수정' : '완료'}</Styled.UpdateButton>
         </Styled.NicknameField>
         <Styled.PostField>


### PR DESCRIPTION
### 구현기능

<img width="250" alt="스크린샷 2022-08-11 오전 10 31 21" src="https://user-images.githubusercontent.com/52737532/184050074-2147fc6e-28d8-4328-9976-785cbeef422f.png">

사용자 프로필 페이지를 구현한다. 

### 세부 구현기능

- [x] 사용자는 헤더에서 `프로필` 버튼을 누르면 프로필 페이지로 이동한다. 
- [x] 사용자는 닉네임을 수정할 수 있다. 
  - [x] 닉네임 수정 API를 mocking한다. 
- [x] 사용자는 본인이 쓴 글을 확인할 수 있다.
  - [x] 내가 쓴 글 불러오기 API를 mocking한다.  

### 관련 이슈

<img width="100" alt="스크린샷 2022-08-11 오전 11 46 25" src="https://user-images.githubusercontent.com/52737532/184056578-8aa1573b-e202-40ef-a985-8f710253ad4f.png">

- post안 count 관련 정보들이 중복돼서 사용되는 곳이 많아, 컴포넌트를 분리해서 재활용했습니당. (PostCountInfo 컴포넌트로 분리했습니다.)
- msw mocking handler를 작성할 때 `post/me` 관련 핸들러가 `post/:id`로 간주가 되더라구요. 이 부분에 대해 백앤드 크루에게 물었더니 백앤드에서는 타입으로 분기가 된다고 하여 타입으로 분기하긴 했는데 더 좋은 방법을 고민중입니다 🤔
- 리팩토링할 부분이 많은 것 같은데 이 부분을 중점적으로 리뷰해주시면 감사하겠습니당~!

close #426
