### PR TITLE
fix: 닉네임 수정 예외 처리

### DIFF
--- a/frontend/src/hooks/queries/profile/useUpdateNickname.ts
+++ b/frontend/src/hooks/queries/profile/useUpdateNickname.ts
@@ -2,6 +2,8 @@ import { useMutation, UseMutationOptions } from 'react-query';
 
 import { AxiosError, AxiosResponse } from 'axios';
 
+import useSnackbar from '@/hooks/useSnackbar';
+
 import authFetcher from '@/apis';
 
 interface UseUpdateNicknameProps {
@@ -11,6 +13,8 @@ interface UseUpdateNicknameProps {
 const useUpdateNickname = (
   options?: UseMutationOptions<AxiosResponse, AxiosError<ErrorResponse>, UseUpdateNicknameProps>,
 ) => {
+  const { showSnackbar } = useSnackbar();
+
   return useMutation(
     ({ nickname }): Promise<AxiosResponse> =>
       authFetcher.patch('/members/nickname', {
@@ -18,6 +22,12 @@ const useUpdateNickname = (
       }),
     {
       ...options,
+      onError: (error, variables, context) => {
+        if (options && options.onError) {
+          options.onError(error, variables, context);
+        }
+        showSnackbar(error.response?.data.message!);
+      },
     },
   );
 };

--- a/frontend/src/mocks/handlers/members/index.ts
+++ b/frontend/src/mocks/handlers/members/index.ts
@@ -130,7 +130,27 @@ const memberHandler = [
     return res(ctx.status(201));
   }),
 
-  rest.patch('/members/nickname', (req, res, ctx) => {
+  rest.patch<{ nickname: string }>('/members/nickname', (req, res, ctx) => {
+    const { nickname } = req.body;
+
+    if (!/^[가-힣a-zA-Z]+$/.test(nickname)) {
+      if (/[\{\}\[\]\/?.,;:|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/.test(nickname)) {
+        return res(ctx.status(400), ctx.json({ message: '닉네임에는 특수문자가 포함될 수 없습니다.' }));
+      }
+
+      if (/\s/.test(nickname)) {
+        return res(ctx.status(400), ctx.json({ message: '닉네임에는 공백이 포함될 수 없습니다.' }));
+      }
+
+      return res(ctx.status(400), ctx.json({ message: '닉네임은 완전한 음절로만 작성해주세요.' }));
+    }
+
+    const existedNickname = validMemberEmail.find(member => member.nickname === nickname);
+
+    if (existedNickname) {
+      return res(ctx.status(400), ctx.json({ message: '이미 존재하는 닉네임입니다.' }));
+    }
+
     return res(ctx.status(204));
   }),
 ];

--- a/frontend/src/pages/ProfilePage/index.styles.ts
+++ b/frontend/src/pages/ProfilePage/index.styles.ts
@@ -2,6 +2,7 @@ import PaginationComponent from '@/components/Pagination';
 
 import PandaIcon from '@/assets/images/panda_logo.svg';
 
+import { invalidInputAnimation } from '@/style/GlobalStyle';
 import styled from '@emotion/styled';
 
 export const Container = styled.div`
@@ -54,7 +55,7 @@ export const NicknameInputField = styled.div`
   justify-content: center;
 `;
 
-export const Nickname = styled.input<{ length: number }>`
+export const Nickname = styled.input<{ length: number; isAnimationActive?: boolean }>`
   width: 200px;
   font-family: 'BMHANNAPro';
   grid-column: 2;
@@ -79,6 +80,8 @@ export const Nickname = styled.input<{ length: number }>`
     width: 200px;
     transition: 0.4s;
   }
+
+  ${invalidInputAnimation}
 `;
 
 export const UpdateButton = styled.button`

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -30,10 +30,14 @@ const ProfilePage = () => {
       keepPreviousData: true,
     },
   });
-  const { mutate } = useUpdateNickname({
+  const { mutate, isError } = useUpdateNickname({
     onSuccess: () => {
       setUserName(nickname);
       showSnackbar(SNACKBAR_MESSAGE.SUCCESS_UPDATE_NICKNAME);
+      handleDisabled();
+    },
+    onError: () => {
+      nicknameRef.current?.focus();
     },
   });
 
@@ -42,6 +46,7 @@ const ProfilePage = () => {
 
     if (!disabled) {
       mutate({ nickname });
+      return;
     }
 
     handleDisabled();
@@ -73,6 +78,7 @@ const ProfilePage = () => {
               disabled={disabled}
               ref={nicknameRef}
               placeholder="닉네임을 입력해주세요."
+              isAnimationActive={isError}
               required
             />
             <Styled.FocusBorder />


### PR DESCRIPTION
### 구현기능

- 닉네임 수정에 실패한 경우에 대한 예외처리 추가 

### 세부 구현기능

- [x] 닉네임 수정에 실패한 경우 스낵바에 안내 메시지를 보여준다. 
- [x] 닉네임 수정에 실패한 경우 input 창을 disabled하지 않고 focus한다. 
- [x] 닉네임 수정 handler에 실패 관련 응답을 추가한다. 

### 관련 이슈

- `isAnimationActive`를 state로 선언하지 않고 query가 뱉는 `isError`를 사용하면 쉽게 후덜덜 애니메이션을 적용할 수 있습니다.

```jsx
const { isError } = useQuery ...

<Input 
     isAnimationActive={isError}
/>
```

close #502 
