### PR TITLE
fix: 게시판 이름이 짤려 개행되는 문제 해결

### DIFF
--- a/frontend/src/pages/BoardPage/components/BoardCategory/index.styles.ts
+++ b/frontend/src/pages/BoardPage/components/BoardCategory/index.styles.ts
@@ -29,15 +29,12 @@ export const Title = styled.p`
 
 export const BoardItem = styled(Link)`
   font-family: 'BMHANNAAir';
-  width: 100%;
+  width: fit-content;
   font-size: 14px;
   color: ${props => props.theme.colors.gray_200};
-  text-align: left;
-  display: flex;
-  justify-content: center;
-  align-items: center;
   height: 100%;
   padding: 1em 0;
+  white-space: nowrap;
 `;
 
 export const BoardList = styled.div`


### PR DESCRIPTION
### 구현기능

![image](https://user-images.githubusercontent.com/52737532/185276825-dce011ad-d59d-41f6-8c04-5343615b0782.png)

게시판 이름이 짤려 개행되는 문제 개선

### 세부 구현기능

- [x] 게시판 이름 태그의 width를 `fit-content`로 하여 해결

### 관련 이슈

close #508 
