### PR TITLE
fix: 내가 쓴 글에서 긴 글 개행/숨김 처리 추가

### DIFF
--- a/frontend/src/pages/ProfilePage/components/PostItem/index.styles.ts
+++ b/frontend/src/pages/ProfilePage/components/PostItem/index.styles.ts
@@ -14,6 +14,10 @@ export const Container = styled.div`
 export const Title = styled.p`
   font-weight: 700;
   font-size: 15px;
+  width: 85%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 export const Content = styled.p`

--- a/frontend/src/pages/ProfilePage/components/PostItem/index.styles.ts
+++ b/frontend/src/pages/ProfilePage/components/PostItem/index.styles.ts
@@ -19,6 +19,15 @@ export const Title = styled.p`
 export const Content = styled.p`
   font-size: 14px;
   color: ${props => props.theme.colors.gray_200};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  word-wrap: break-word;
+  line-height: 19px;
+  max-height: 57px;
+  white-space: pre-wrap;
 `;
 
 export const Information = styled.div`


### PR DESCRIPTION
### 구현기능

<img width="463" alt="스크린샷 2022-08-18 오전 11 39 59" src="https://user-images.githubusercontent.com/52737532/185280926-f9330482-8f07-44e4-ab0c-826223355aa9.png">

프로필 안 내가 쓴 글에서 긴 글에 개행/숨김 처리를 추가한다.

### 세부 구현기능

- [x] 제목에 `ellipsis`추가
- [x] 내용에 최대 line 수 추가 

### 관련 이슈

close #510 
