### PR TITLE
feat: 상세페이지에서 해시태그 클릭시 해당 검색페이지로 이동

### DIFF
--- a/frontend/src/components/SearchModal/index.tsx
+++ b/frontend/src/components/SearchModal/index.tsx
@@ -7,6 +7,8 @@ import useQueryDebounce from '@/hooks/queries/hashtag/useQueryDebounce';
 
 import * as Styled from './index.styles';
 
+import PATH from '@/constants/path';
+
 import useModalHistory from './useModalHistory';
 
 interface SearchModalProps {
@@ -26,7 +28,7 @@ const SearchModal = ({ handleSearchModal: closeModal }: SearchModalProps) => {
 
   const handleHashTagClick = (name: string) => {
     closeModal();
-    navigate(`/hashtag/${name}`);
+    navigate(`${PATH.HASHTAG}/${name}`);
   };
 
   return (

--- a/frontend/src/pages/PostPage/components/PostContent/index.tsx
+++ b/frontend/src/pages/PostPage/components/PostContent/index.tsx
@@ -4,11 +4,13 @@ import HashTag from '@/components/HashTag';
 
 import * as Styled from './index.styles';
 
+import PATH from '@/constants/path';
+
 const PostContent = ({ content, hashtags }: Pick<Post, 'hashtags' | 'content'>) => {
   const navigate = useNavigate();
 
   const handleHashtagClick = (name: string) => {
-    navigate(`/hashtag/${name}`);
+    navigate(`${PATH.HASHTAG}/${name}`);
   };
 
   return (

--- a/frontend/src/pages/PostPage/components/PostContent/index.tsx
+++ b/frontend/src/pages/PostPage/components/PostContent/index.tsx
@@ -1,14 +1,22 @@
+import { useNavigate } from 'react-router-dom';
+
 import HashTag from '@/components/HashTag';
 
 import * as Styled from './index.styles';
 
 const PostContent = ({ content, hashtags }: Pick<Post, 'hashtags' | 'content'>) => {
+  const navigate = useNavigate();
+
+  const handleHashtagClick = (name: string) => {
+    navigate(`/hashtag/${name}`);
+  };
+
   return (
     <Styled.ContentContainer>
       <Styled.Content>{content}</Styled.Content>
       <Styled.TagContainer>
         {hashtags?.map(({ name }) => (
-          <HashTag key={name} name={name} />
+          <HashTag key={name} name={name} handleTagClick={() => handleHashtagClick(name)} />
         ))}
       </Styled.TagContainer>
     </Styled.ContentContainer>


### PR DESCRIPTION
### 구현기능

- 글 상세페이지에서 해시태그를 클릭하면 해당 검색페이지로 이동한다.


### 관련 이슈

close #511 