### PR TITLE
chore: 깃헙액션 타임존 설정 스크립트 제거

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          
-      - name: Setup timezone
-        uses: zcong1993/setup-timezone@master
-        with:
-          timezone: Asia/Seoul
 
       - name: Gradle 명령 실행을 위한 권한을 부여합니다.
         run: chmod +x gradlew


### PR DESCRIPTION
### 구현기능
자바레벨에서 타임존 설정이 먹히는지 확인하기 위해 깃헙액션 타임존 설정 스크립트 제거

