### PR TITLE
fix: 닉네임 변경시 토큰을 재설정 하도록 변경

### DIFF
--- a/frontend/src/hooks/queries/profile/useUpdateNickname.ts
+++ b/frontend/src/hooks/queries/profile/useUpdateNickname.ts
@@ -1,10 +1,15 @@
+import { useContext } from 'react';
 import { useMutation, UseMutationOptions } from 'react-query';
 
 import { AxiosError, AxiosResponse } from 'axios';
 
+import AuthContext from '@/context/Auth';
+
 import useSnackbar from '@/hooks/useSnackbar';
 
 import authFetcher from '@/apis';
+import { STORAGE_KEY } from '@/constants/localStorage';
+import SNACKBAR_MESSAGE from '@/constants/snackbar';
 
 interface UseUpdateNicknameProps {
   nickname: string;
@@ -13,6 +18,7 @@ interface UseUpdateNicknameProps {
 const useUpdateNickname = (
   options?: UseMutationOptions<AxiosResponse, AxiosError<ErrorResponse>, UseUpdateNicknameProps>,
 ) => {
+  const { setUserName } = useContext(AuthContext);
   const { showSnackbar } = useSnackbar();
 
   return useMutation(
@@ -27,6 +33,20 @@ const useUpdateNickname = (
           options.onError(error, variables, context);
         }
         showSnackbar(error.response?.data.message!);
+      },
+      onSuccess: (data, variables, context) => {
+        if (options && options.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+
+        const accessToken = data?.headers.authorization;
+
+        if (accessToken) {
+          authFetcher.defaults.headers.common['Authorization'] = accessToken;
+          localStorage.setItem(STORAGE_KEY.ACCESS_TOKEN, accessToken);
+          setUserName(variables.nickname);
+          showSnackbar(SNACKBAR_MESSAGE.SUCCESS_UPDATE_NICKNAME);
+        }
       },
     },
   );

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -12,14 +12,12 @@ import useSnackbar from '@/hooks/useSnackbar';
 
 import * as Styled from './index.styles';
 
-import SNACKBAR_MESSAGE from '@/constants/snackbar';
-
 const SIZE = 3;
 
 const ProfilePage = () => {
   const { showSnackbar } = useSnackbar();
   const { page, setPage } = useContext(PaginationContext);
-  const { username, setUserName } = useContext(AuthContext);
+  const { username } = useContext(AuthContext);
   const [nickname, setNickname] = useState(username);
   const [disabled, handleDisabled] = useReducer(state => !state, true);
   const nicknameRef = useRef<HTMLInputElement>(null);
@@ -32,8 +30,6 @@ const ProfilePage = () => {
   });
   const { mutate, isError } = useUpdateNickname({
     onSuccess: () => {
-      setUserName(nickname);
-      showSnackbar(SNACKBAR_MESSAGE.SUCCESS_UPDATE_NICKNAME);
       handleDisabled();
     },
     onError: () => {


### PR DESCRIPTION
### 구현기능

닉네임 변경시 토큰이 재발급되므로 토큰을 재설정한다. 

### 세부 구현기능

- [x] 닉네임 변경시 토큰을 재설정한다. 

### 관련 이슈

- `닉네임을 수정하고 로그아웃 후 확인해보면 닉네임이 알 수 없는 문자로 되어 있다.` 이건 파싱에러라 다른 PR에서 해결합니다. 
- 헌치가 아직 토큰 재발급 코드를 작성중이라 merge가 되어도 `dev`에서 확인할 수 없습니다. 

close #518 
