### PR TITLE
fix: 기명 게시글에서 작성자가 익명 댓글을 여러번 달아도 동일한 닉네임 할당되지 않던 버그 수정

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/repository/CommentRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/repository/CommentRepository.java
@@ -18,5 +18,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByPostIdAndParentId(Long postId, Long parentId);
 
+    boolean existsByPostIdAndMemberId(Long postId, Long memberId);
+
     void deleteAllByPostId(Long id);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/service/CommentService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/service/CommentService.java
@@ -92,7 +92,7 @@ public class CommentService {
             return memberNickname;
         }
         if (post.isAuthorized(authInfo.getId())) { // 댓글 작성하는 사람과 게시글 작성자 일치
-            return getPostWriterNickname(post);
+            return getPostWriterNickname(post, authInfo.getId());
         }
 
         // 익명이면, comment table에서 memberId에 해당하는 nickname들을 다 가져와서, member
@@ -106,9 +106,13 @@ public class CommentService {
                 .orElseGet(() -> RandomNicknameGenerator.generate(new HashSet<>(usedNicknames)));
     }
 
-    private String getPostWriterNickname(Post post) {
+    private String getPostWriterNickname(Post post, Long memberId) {
         if (post.isAnonymous()) { // 작성자가 기명으로 글 작성
             return post.getNickname();
+        }
+        if (commentRepository.existsByPostIdAndMemberId(post.getId(), memberId)) {
+            return commentRepository.findNickNamesByPostIdAndMemberId(post.getId(), memberId)
+                    .get(0);
         }
         List<String> commentNicknames = commentRepository.findNicknamesByPostId(post.getId());
         return RandomNicknameGenerator.generate(new HashSet<>(commentNicknames));

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/service/CommentServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/service/CommentServiceTest.java
@@ -21,7 +21,6 @@ import com.wooteco.sokdak.comment.repository.CommentRepository;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.repository.MemberRepository;
 import com.wooteco.sokdak.member.util.RandomNicknameGenerator;
-import com.wooteco.sokdak.notification.repository.NotificationRepository;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.repository.PostRepository;
 import com.wooteco.sokdak.util.IntegrationTest;
@@ -46,9 +45,6 @@ class CommentServiceTest extends IntegrationTest {
 
     @Autowired
     private CommentRepository commentRepository;
-
-    @Autowired
-    private NotificationRepository notificationRepository;
 
     private Post anonymousPost;
     private Post identifiedPost;
@@ -180,6 +176,19 @@ class CommentServiceTest extends IntegrationTest {
                 () -> assertThat(foundComment.getMember()).isEqualTo(member),
                 () -> assertThat(foundComment.getNickname()).isNotEqualTo(member.getNickname())
         );
+    }
+
+    @DisplayName("기명 게시글에서 게시글 작성자가 익명으로 댓글 등록을 여러번하면 동일한 닉네임이 할당된다.")
+    @Test
+    void addComment_Anonymous_PostWriterIdentified() {
+        NewCommentRequest newCommentRequest = new NewCommentRequest("댓글", true);
+        Long firstCommentId = commentService.addComment(identifiedPost.getId(), newCommentRequest, AUTH_INFO);
+        Long secondCommentId = commentService.addComment(identifiedPost.getId(), newCommentRequest, AUTH_INFO);
+
+        Comment firstFoundComment = commentRepository.findById(firstCommentId).orElseThrow();
+        Comment secondFoundComment = commentRepository.findById(secondCommentId).orElseThrow();
+
+        assertThat(firstFoundComment.getNickname()).isEqualTo(secondFoundComment.getNickname());
     }
 
     @DisplayName("익명 게시글에서 게시글 작성자 아닌 사용자가 익명으로 댓글 등록")


### PR DESCRIPTION
### 구현기능
기명 게시글에서 작성자가 익명 댓글을 여러번 달아도 동일한 닉네임 할당되지 않던 버그 수정

fix #524 
