### PR TITLE
fix: 닉네임 수정 시 새로 토큰을 발급해 반환하도록 변경

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/controller/MemberController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/controller/MemberController.java
@@ -78,10 +78,14 @@ public class MemberController {
     public ResponseEntity<Void> editNickname(@RequestBody NicknameUpdateRequest nicknameUpdateRequest,
                                              @Login AuthInfo authInfo) {
         memberService.editNickname(nicknameUpdateRequest, authInfo);
-        AuthInfo newAuthInfo = new AuthInfo(authInfo.getId(), authInfo.getRole(), nicknameUpdateRequest.getNickname());
-        String accessToken = tokenManager.createAccessToken(newAuthInfo);
+        String accessToken = getTokenOfNewNickname(nicknameUpdateRequest, authInfo);
         return ResponseEntity.noContent()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                 .build();
+    }
+
+    private String getTokenOfNewNickname(NicknameUpdateRequest nicknameUpdateRequest, AuthInfo authInfo) {
+        AuthInfo newAuthInfo = new AuthInfo(authInfo.getId(), authInfo.getRole(), nicknameUpdateRequest.getNickname());
+        return tokenManager.createAccessToken(newAuthInfo);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/member/acceptance/MemberAcceptanceTest.java
@@ -7,6 +7,7 @@ import static com.wooteco.sokdak.util.fixture.HttpMethodFixture.httpPost;
 import static com.wooteco.sokdak.util.fixture.MemberFixture.getChrisToken;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.wooteco.sokdak.member.dto.NicknameResponse;
 import com.wooteco.sokdak.member.dto.NicknameUpdateRequest;
@@ -79,6 +80,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
 
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
+                () -> assertThat(response.header(AUTHORIZATION)).contains("Bearer"),
                 () -> assertThat(nicknameResponse.getNickname()).isEqualTo(nickname)
         );
     }


### PR DESCRIPTION
### 구현기능
닉네임 수정 시 새로 토큰을 발급해 반환하도록 변경

### 세부 구현기능
- [x] 닉네임 수정 시 새로 토큰을 발급해 반환
- [x] 필요없는 sql문 삭제

### 관련 이슈
resolve: #526 