### PR TITLE
feat: 블라인드 된 게시글의 작성자 닉네임 응답값 수정

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
@@ -31,7 +31,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class Comment {
 
     private static final int BLOCKED_CONDITION = 5;
-    private static final String BLIND_MESSAGE = "블라인드 처리되었습니다.";
+    private static final String BLIND_COMMENT_MESSAGE = "블라인드 처리된 댓글입니다.";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -144,14 +144,14 @@ public class Comment {
 
     public String getNickname() {
         if (isBlocked()) {
-            return BLIND_MESSAGE;
+            return BLIND_COMMENT_MESSAGE;
         }
         return nickname;
     }
 
     public String getMessage() {
         if (isBlocked()) {
-            return BLIND_MESSAGE;
+            return BLIND_COMMENT_MESSAGE;
         }
         return message.getValue();
     }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -34,7 +34,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class Post {
 
     private static final int BLOCKED_CONDITION = 5;
-    private static final String BLIND_MESSAGE = "블라인드 처리된 글입니다";
+    private static final String BLIND_MESSAGE = "블라인드 처리된 게시글입니다.";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -124,7 +124,7 @@ public class Post {
         postReports.stream()
                 .filter(other::isSameReporter)
                 .findAny()
-                 .ifPresent(it -> {
+                .ifPresent(it -> {
                     throw new AlreadyReportPostException();
                 });
         postReports.add(other);
@@ -187,6 +187,9 @@ public class Post {
     }
 
     public String getNickname() {
+        if (isBlocked()) {
+            return BLIND_MESSAGE;
+        }
         return writerNickname;
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -34,7 +34,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class Post {
 
     private static final int BLOCKED_CONDITION = 5;
-    private static final String BLIND_MESSAGE = "블라인드 처리된 게시글입니다.";
+    private static final String BLIND_POST_MESSAGE = "블라인드 처리된 게시글입니다.";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -140,14 +140,14 @@ public class Post {
 
     public String getTitle() {
         if (isBlocked()) {
-            return BLIND_MESSAGE;
+            return BLIND_POST_MESSAGE;
         }
         return title.getValue();
     }
 
     public String getContent() {
         if (isBlocked()) {
-            return BLIND_MESSAGE;
+            return BLIND_POST_MESSAGE;
         }
         return content.getValue();
     }
@@ -188,7 +188,7 @@ public class Post {
 
     public String getNickname() {
         if (isBlocked()) {
-            return BLIND_MESSAGE;
+            return BLIND_POST_MESSAGE;
         }
         return writerNickname;
     }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/acceptance/CommentAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/acceptance/CommentAcceptanceTest.java
@@ -121,7 +121,7 @@ class CommentAcceptanceTest extends AcceptanceTest {
         Long commentId = addNewCommentInPost(postId);
         addNewCommentInPost(postId);
         List<String> tokens = getTokens();
-        String blindMessage = "블라인드 처리되었습니다.";
+        String blindMessage = "블라인드 처리된 댓글입니다.";
 
         for (int i = 0; i < 5; ++i) {
             ReportRequest reportRequest = new ReportRequest("댓글신고");

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/domain/CommentTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/domain/CommentTest.java
@@ -110,8 +110,8 @@ class CommentTest {
                     .build();
         }
 
-        boolean nicknameActual = comment.getNickname().equals("블라인드 처리되었습니다.");
-        boolean messageActual = comment.getMessage().equals("블라인드 처리되었습니다.");
+        boolean nicknameActual = comment.getNickname().equals("블라인드 처리된 댓글입니다.");
+        boolean messageActual = comment.getMessage().equals("블라인드 처리된 댓글입니다.");
 
         assertAll(
                 () -> assertThat(nicknameActual).isEqualTo(expected),

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
@@ -121,8 +121,8 @@ class PostAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(postsElementResponses.get(0).isBlocked()).isFalse(),
                 () -> assertThat(postsElementResponses.get(1).isBlocked()).isTrue(),
-                () -> assertThat(postsElementResponses.get(1).getTitle()).isEqualTo("블라인드 처리된 글입니다"),
-                () -> assertThat(postsElementResponses.get(1).getContent()).isEqualTo("블라인드 처리된 글입니다")
+                () -> assertThat(postsElementResponses.get(1).getTitle()).isEqualTo("블라인드 처리된 게시글입니다."),
+                () -> assertThat(postsElementResponses.get(1).getContent()).isEqualTo("블라인드 처리된 게시글입니다.")
         );
     }
 
@@ -136,16 +136,16 @@ class PostAcceptanceTest extends AcceptanceTest {
             httpPostWithAuthorization(reportRequest, "/posts/" + blockedPostId + "/report", tokens.get(i));
         }
 
-        ExtractableResponse<Response> response = httpGet(
-                "/posts/" + blockedPostId);
-        PostDetailResponse postDetailResponse = response
-                .jsonPath()
+        ExtractableResponse<Response> response = httpGet("/posts/" + blockedPostId);
+
+        PostDetailResponse postDetailResponse = response.jsonPath()
                 .getObject(".", PostDetailResponse.class);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(postDetailResponse.isBlocked()).isTrue(),
-                () -> assertThat(postDetailResponse.getTitle()).isEqualTo("블라인드 처리된 글입니다"),
-                () -> assertThat(postDetailResponse.getContent()).isEqualTo("블라인드 처리된 글입니다")
+                () -> assertThat(postDetailResponse.getNickname()).isEqualTo("블라인드 처리된 게시글입니다."),
+                () -> assertThat(postDetailResponse.getTitle()).isEqualTo("블라인드 처리된 게시글입니다."),
+                () -> assertThat(postDetailResponse.getContent()).isEqualTo("블라인드 처리된 게시글입니다.")
         );
     }
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
@@ -97,7 +97,7 @@ class PostTest {
         );
     }
 
-    @DisplayName("신고가 5개 이상이면 isBlocked()가 false를 반환하고 게시글 정보들이 반환된다.")
+    @DisplayName("신고가 5개 미만이면 isBlocked()가 false를 반환하고 게시글 정보들이 반환된다.")
     @Test
     void isBlocked_false() {
         List<Member> members = getMembersForReport();

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/report/service/CommentReportServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/report/service/CommentReportServiceTest.java
@@ -103,7 +103,7 @@ class CommentReportServiceTest extends ServiceTest {
                 .isInstanceOf(InvalidReportMessageException.class);
     }
 
-    @DisplayName("댓글 신고가 5회 신고시 ")
+    @DisplayName("댓글 신고가 5회 신고시 댓글의 내용이 반환되지 않는다.")
     @Test
     void reportComment_Block() {
         AuthInfo authInfo;
@@ -111,14 +111,15 @@ class CommentReportServiceTest extends ServiceTest {
             authInfo = new AuthInfo(i, "USER", VALID_NICKNAME);
             commentReportService.reportComment(comment.getId(), REPORT_REQUEST, authInfo);
         }
+        String blindCommentMessage = "블라인드 처리된 댓글입니다.";
 
         Comment found = commentRepository.findById(this.comment.getId())
                 .orElseThrow(CommentNotFoundException::new);
 
         assertAll(
                 () -> assertThat(found.isBlocked()).isTrue(),
-                () -> assertThat(found.getNickname()).isNotEqualTo(VALID_NICKNAME),
-                () -> assertThat(found.getMessage()).isNotEqualTo(VALID_COMMENT_MESSAGE)
+                () -> assertThat(found.getNickname()).isEqualTo(blindCommentMessage),
+                () -> assertThat(found.getMessage()).isEqualTo(blindCommentMessage)
         );
     }
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/PostFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/PostFixture.java
@@ -17,6 +17,7 @@ public class PostFixture {
 
     public static final String VALID_POST_TITLE = "제목";
     public static final String VALID_POST_CONTENT = "본문";
+    public static final String VALID_POST_WRITER_NICKNAME = "작성자 닉네임";
 
     public static final String UPDATED_POST_TITLE = "변경된 제목";
     public static final String UPDATED_POST_CONTENT = "변경된 본문";


### PR DESCRIPTION
### 구현기능
블라인드 된 게시글 작성자 닉네임의 응답값이 원래 작성자 닉네임이었는데, 이를 블라인드 처리되었다는 메시지로 수정
또한, 게시글과 댓글의 블라인드 메시지를 변경했습니다.
