### PR TITLE
feat: react-query 캐싱 기능을 이용하여 API 호출 최적화 

### DIFF
--- a/frontend/src/hooks/queries/post/useCreatePost.ts
+++ b/frontend/src/hooks/queries/post/useCreatePost.ts
@@ -39,9 +39,9 @@ const useCreatePost = (
     {
       ...options,
       onSuccess: (data, variables, context) => {
-        queryClient.resetQueries(QUERY_KEYS.POSTS);
-        queryClient.resetQueries(QUERY_KEYS.POSTS_BY_BOARDS);
-        queryClient.resetQueries(QUERY_KEYS.MY_POSTS);
+        queryClient.invalidateQueries(QUERY_KEYS.POSTS);
+        queryClient.invalidateQueries(QUERY_KEYS.POSTS_BY_BOARDS);
+        queryClient.invalidateQueries(QUERY_KEYS.MY_POSTS);
 
         showSnackbar(SNACKBAR_MESSAGE.SUCCESS_WRITE_POST);
         if (options && options.onSuccess) {

--- a/frontend/src/hooks/queries/post/useCreatePost.ts
+++ b/frontend/src/hooks/queries/post/useCreatePost.ts
@@ -41,6 +41,7 @@ const useCreatePost = (
       onSuccess: (data, variables, context) => {
         queryClient.resetQueries(QUERY_KEYS.POSTS);
         queryClient.resetQueries(QUERY_KEYS.POSTS_BY_BOARDS);
+        queryClient.resetQueries(QUERY_KEYS.MY_POSTS);
 
         showSnackbar(SNACKBAR_MESSAGE.SUCCESS_WRITE_POST);
         if (options && options.onSuccess) {

--- a/frontend/src/hooks/queries/post/useCreatePost.ts
+++ b/frontend/src/hooks/queries/post/useCreatePost.ts
@@ -40,6 +40,8 @@ const useCreatePost = (
       ...options,
       onSuccess: (data, variables, context) => {
         queryClient.resetQueries(QUERY_KEYS.POSTS);
+        queryClient.resetQueries(QUERY_KEYS.POSTS_BY_BOARDS);
+
         showSnackbar(SNACKBAR_MESSAGE.SUCCESS_WRITE_POST);
         if (options && options.onSuccess) {
           options.onSuccess(data, variables, context);

--- a/frontend/src/hooks/queries/post/useDeletePost.ts
+++ b/frontend/src/hooks/queries/post/useDeletePost.ts
@@ -19,9 +19,9 @@ const useDeletePost = (options?: UseMutationOptions<AxiosResponse, AxiosError, s
     {
       ...options,
       onSuccess: (data, variables, context) => {
-        queryClient.resetQueries(QUERY_KEYS.POSTS);
-        queryClient.resetQueries(QUERY_KEYS.POSTS_BY_BOARDS);
-        queryClient.resetQueries(QUERY_KEYS.MY_POSTS);
+        queryClient.invalidateQueries(QUERY_KEYS.POSTS);
+        queryClient.invalidateQueries(QUERY_KEYS.POSTS_BY_BOARDS);
+        queryClient.invalidateQueries(QUERY_KEYS.MY_POSTS);
 
         showSnackbar(SNACKBAR_MESSAGE.SUCCESS_DELETE_POST);
 

--- a/frontend/src/hooks/queries/post/useDeletePost.ts
+++ b/frontend/src/hooks/queries/post/useDeletePost.ts
@@ -20,6 +20,9 @@ const useDeletePost = (options?: UseMutationOptions<AxiosResponse, AxiosError, s
       ...options,
       onSuccess: (data, variables, context) => {
         queryClient.resetQueries(QUERY_KEYS.POSTS);
+        queryClient.resetQueries(QUERY_KEYS.POSTS_BY_BOARDS);
+        queryClient.resetQueries(QUERY_KEYS.MY_POSTS);
+
         showSnackbar(SNACKBAR_MESSAGE.SUCCESS_DELETE_POST);
 
         if (options && options.onSuccess) {

--- a/frontend/src/hooks/queries/post/useUpdatePost.ts
+++ b/frontend/src/hooks/queries/post/useUpdatePost.ts
@@ -29,6 +29,10 @@ const useUpdatePost = ({
       ...options,
       onSuccess: (data, variables, context) => {
         queryClient.resetQueries(QUERY_KEYS.POSTS);
+        queryClient.resetQueries(QUERY_KEYS.POSTS_BY_BOARDS);
+        queryClient.resetQueries(QUERY_KEYS.MY_POSTS);
+        queryClient.resetQueries([QUERY_KEYS.POST, String(id)]);
+
         showSnackbar(SNACKBAR_MESSAGE.SUCCESS_UPDATE_POST);
 
         if (options && options.onSuccess) {

--- a/frontend/src/hooks/queries/post/useUpdatePost.ts
+++ b/frontend/src/hooks/queries/post/useUpdatePost.ts
@@ -28,10 +28,10 @@ const useUpdatePost = ({
     {
       ...options,
       onSuccess: (data, variables, context) => {
-        queryClient.resetQueries(QUERY_KEYS.POSTS);
-        queryClient.resetQueries(QUERY_KEYS.POSTS_BY_BOARDS);
-        queryClient.resetQueries(QUERY_KEYS.MY_POSTS);
-        queryClient.resetQueries([QUERY_KEYS.POST, String(id)]);
+        queryClient.invalidateQueries(QUERY_KEYS.POSTS);
+        queryClient.invalidateQueries(QUERY_KEYS.POSTS_BY_BOARDS);
+        queryClient.invalidateQueries(QUERY_KEYS.MY_POSTS);
+        queryClient.invalidateQueries([QUERY_KEYS.POST, String(id)]);
 
         showSnackbar(SNACKBAR_MESSAGE.SUCCESS_UPDATE_POST);
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClientProvider, QueryClient } from 'react-query';
+import { ReactQueryDevtools } from 'react-query/devtools';
 import { BrowserRouter } from 'react-router-dom';
 
 import axios from 'axios';
@@ -59,6 +60,7 @@ ReactDOM.createRoot(rootNode).render(
               </PaginationContextProvider>
             </SnackBarContextProvider>
           </ThemeProvider>
+          <ReactQueryDevtools />
         </QueryClientProvider>
       </BrowserRouter>
       <GlobalStyle />

--- a/frontend/src/pages/BoardPage/index.tsx
+++ b/frontend/src/pages/BoardPage/index.tsx
@@ -19,7 +19,11 @@ const HOT_BOARD_ID = '1';
 const BoardPage = () => {
   const navigate = useNavigate();
   const { id: boardId } = useParams();
-  const { isLoading: boardIsLoading, data: boards } = useBoards({});
+  const { isLoading: boardIsLoading, data: boards } = useBoards({
+    options: {
+      staleTime: Infinity,
+    },
+  });
   const { isLoading, data, fetchNextPage, refetch } = usePosts({ storeCode: [boardId!, 3] });
 
   useEffect(() => {

--- a/frontend/src/pages/MainPage/index.tsx
+++ b/frontend/src/pages/MainPage/index.tsx
@@ -9,7 +9,11 @@ import * as Styled from './index.styles';
 import { BOARDS } from '@/constants/board';
 
 const MainPage = () => {
-  const { isLoading, data } = usePostByBoards({});
+  const { isLoading, data } = usePostByBoards({
+    options: {
+      staleTime: 1000 * 20,
+    },
+  });
 
   if (isLoading) {
     return (

--- a/frontend/src/pages/PostPage/index.tsx
+++ b/frontend/src/pages/PostPage/index.tsx
@@ -32,6 +32,7 @@ const PostPage = () => {
       onSuccess: data => {
         setLike({ isLiked: data.like, likeCount: data.likeCount });
       },
+      staleTime: 1000 * 20,
     },
   });
 

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useReducer, useRef, useState } from 'react';
+import { useQueryClient } from 'react-query';
 
 import PostItem from './components/PostItem';
 import Layout from '@/components/@styled/Layout';
@@ -12,6 +13,8 @@ import useSnackbar from '@/hooks/useSnackbar';
 
 import * as Styled from './index.styles';
 
+import QUERY_KEYS from '@/constants/queries';
+
 const SIZE = 3;
 
 const ProfilePage = () => {
@@ -21,13 +24,20 @@ const ProfilePage = () => {
   const [nickname, setNickname] = useState(username);
   const [disabled, handleDisabled] = useReducer(state => !state, true);
   const nicknameRef = useRef<HTMLInputElement>(null);
+  const queryClient = useQueryClient();
 
   const { data } = useMyPosts({
     storeCode: [SIZE, page],
     options: {
       keepPreviousData: true,
+      staleTime: Infinity,
     },
   });
+
+  useEffect(() => {
+    queryClient.resetQueries(QUERY_KEYS.MY_POSTS);
+  }, []);
+
   const { mutate, isError } = useUpdateNickname({
     onSuccess: () => {
       handleDisabled();

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -1,5 +1,4 @@
 import { useContext, useEffect, useReducer, useRef, useState } from 'react';
-import { useQueryClient } from 'react-query';
 
 import PostItem from './components/PostItem';
 import Layout from '@/components/@styled/Layout';
@@ -13,8 +12,6 @@ import useSnackbar from '@/hooks/useSnackbar';
 
 import * as Styled from './index.styles';
 
-import QUERY_KEYS from '@/constants/queries';
-
 const SIZE = 3;
 
 const ProfilePage = () => {
@@ -24,7 +21,6 @@ const ProfilePage = () => {
   const [nickname, setNickname] = useState(username);
   const [disabled, handleDisabled] = useReducer(state => !state, true);
   const nicknameRef = useRef<HTMLInputElement>(null);
-  const queryClient = useQueryClient();
 
   const { data } = useMyPosts({
     storeCode: [SIZE, page],
@@ -33,10 +29,6 @@ const ProfilePage = () => {
       staleTime: Infinity,
     },
   });
-
-  useEffect(() => {
-    queryClient.resetQueries(QUERY_KEYS.MY_POSTS);
-  }, []);
 
   const { mutate, isError } = useUpdateNickname({
     onSuccess: () => {


### PR DESCRIPTION
### 구현기능

react-query 캐싱 기능을 이용하여 API 호출을 최적화한다. 

### 세부 구현기능

#### 프로필 페이지

<details>
<summary>페이지네이션 데이터를 가져올 때 이전 페이지를 캐싱한다.</summary>

[feat: 페이지 이동시 이전 페이지 데이터 유지](https://github.com/woowacourse-teams/2022-sokdak/commit/0f81b74729da6a8c920f0abfe30db663e697895d)

기존에는 이미 봤던 페이지로 이동하더라도 새로 페이지를 가져왔습니다. 
이는 캐싱 설정을 하지 않았기 때문입니다. 
이번 구현에서는 staleTime을 설정해주어 캐싱을 진행했습니다. 

> staleTime vs cacheTime
> 
> **staleTime** : 데이터의 신선한 상태가 언제까지 지속될지 (default 0 = 즉시 stale하다고 판단하여 데이터와 무관하게 fetching)  
> **cacheTime** : 메모리에 저장된 캐시 데이터가 언제까지 유지될지 알려주는 옵션  (default 5분, inactive 상태일 때 메모리에 캐시를 언제까지 유지할 지) 

- staleTime 설정 기준?
  - 현재 staleTime을 Infinity로 설정해주었습니다. 이유는 사용자가 프로필 페이지에 있는 이상 새로운 글을 작성할 일이 없다고 판단했습니다. 
  - staleTime은 Infinity로 설정 되어있지만 글이 등록/삭제/수정되었을 때 resetQueries를 통해 캐시가 무효화되도록 설정해주었습니다. 

</details>

#### 메인 페이지

<details>
<summary>(게시판 + 각 게시판 최신글 3개) 데이터를 캐싱한다.</summary>

[feat: 메인 페이지 API 응답 staleTime 지정](https://github.com/woowacourse-teams/2022-sokdak/commit/abec52c1a03e239e85dc9d9a6b2672d754b03203)

- staleTime 설정 기준?
  - 사람은 보통 1분에 300단어를 읽는다고 합니다. - [참고](https://xjin.kr/629)
  - 저희 서비스 사용자들은 평균 100단어 이하로 글을 작성하기 때문에 staleTime이 20초면 적당할 것이라고 판단했습니다. 
- 캐싱이 필요할까?
  - 메인 페이지로의 이동이 반복됐을 때 불필요한 API 요청을 줄이기 위해서 필요하다고 생각했습니다. 하지만 react-query만을 통해 캐싱을 진행하는 것은 임시방편에 그친다고 생각해, 백앤드와의 협업을 통해 ETag등 HTTP 요청 차원에서 캐싱을 진행할 필요성을 느꼈습니다. 

</details>

#### 각 게시판 페이지

<details>
<summary>게시판 스위칭을 위해 게시판 id와 이름을 불러오는 API (/boards)</summary>

[feat: 게시판 드롭다운 컨텐츠를 가져오는 API 캐싱](https://github.com/woowacourse-teams/2022-sokdak/commit/46e5c399da320c1a731b24b659b892ff48ccedee)

<img width="224" alt="스크린샷 2022-09-19 오후 5 40 12" src="https://user-images.githubusercontent.com/52737532/190980201-fc265e0f-879b-4375-8e2b-bbabcc0a2683.png">

- staleTime 설정 기준?
  - 위 사진 부분인데요. 저희가 게시판을 따로 추가하지 않는 이상 데이터가 변경될 일이 없다고 판단하였습니다. 그렇기 때문에 staleTime을 Infinity로 설정해주었습니다. 여기서 cacheTime은 추가로 설정해주지 않아서 default에 따라 5분인데요. cacheTime은 inactive할 때 캐시를 삭제하므로 5분정도면 API 요청이 낭비되고 있다!는 것은 없을 것 같아 건드리지 않았습니다. 


</details>

<details>
<summary>글을 불러오는 API (캐싱하지 않음)</summary>

- 글을 불러오는 API를 캐싱해야하나 고민했을 때 이런 부분들을 알게 되었습니다.
  - 우선 `useInfiniteQuery`를 사용하면 `사용자가 특정 글을 들어간다. -> 다시 글 목록으로 뒤로간다.`를 진행했을 때 mount시 stale한 데이터 이므로 다시 글 목록을 fetch해옵니다. 이때 지금까지 읽은 모든 페이지의 글을 모두 불러옵니다. (만약 사용자가 5페이지까지 읽었다면 1, 2, 3, 4, 5 페이지 모두 불러옵니다.) 이유는 새로운 글이 추가되었을 때 그 글을 포함해서 fetch 하려면 페이지가 오버돼서 1~5페이지까지 변경이 됐을 수 있기 때문입니다. 사용자가 실시간으로 올라오는 글을 보기 위해서는 이 부분을 캐싱하지 않는게 좋겠다고 생각해서 캐싱을 진행하지 않았습니다. 

</details>

<details>
<summary>특정 글을 불러오는 API</summary>

- 캐싱할 필요가 있을까?
  - 앞에서 말했듯이 저희 서비스에 올라오는 글을 읽을 때 평균 20초가 걸린다고 생각했습니다. 사용자가 `글을 읽는다. (20초가 걸린다고 가정하자. -> 다시 글 목록으로 돌아온다. -> 다시 한번 해당 글로 이동한다.`라고 플로우를 생각했을 때 만약 해당 글이 변경되었더라고 해도 staleTime을 20초로 설정해주면 사용자는 바로 변경을 확인할 수 있을 것이다!라고 판단하여 staleTime을 20초로 설정해주었습니다. 저희의 서비스를 지금까지 보았을 때 글이 변경되는 일은 드문 경우라고 생각해서 캐싱이 필요하다고 생각했고 (그보다 해당글에 들락날락하는 경우가 더 많은 것 같았습니다.), staleTime을 20초정도로 설정해두면 충분히 변화도 확인하고 캐싱도 가능하겠다.라고 판단했습니다. 
  - 추가로 댓글과 좋아요는 실시간으로 변화가 많을 것이라고 생각해 staleTime을 지정해주지 않았습니다.  

</details>

### 관련 이슈

close #542 

- 현재는 로그인한 사용자가 글을 작성/수정/삭제하면 메인 페이지, 글 목록, 내 글 목록(프로필 페이지), 현재 글을 query key를 통해 `resetQueries`를 진행합니다. 

```js
// onSuccess
        queryClient.resetQueries(QUERY_KEYS.POSTS);
        queryClient.resetQueries(QUERY_KEYS.POSTS_BY_BOARDS);
        queryClient.resetQueries(QUERY_KEYS.MY_POSTS);
```

이런 느낌인데 이게 맞는 방식인지 확신이 잘 들지 않네요 🤔.. 혹시 더 좋은 방식이 생각나신다면 조언 부탁드립니다!!

- 현재는 위에 작성한 내용만 staleTime을 지정해주었습니다. 혹시 추가로 해야될 부분이 있으시다면 말씀해주세욧.
- react-query를 통한 캐싱은 한계가 있다고 생각이 들어 추후 백앤드와의 협업을 통해 ETag 등을 추가로 설정해 줄 예정입니다.
