### PR TITLE
fix: 새로고침시 폰트가 적용되지 않는 문제 해결

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.0",
+    "interpolate-html-plugin": "^4.0.0",
     "jest": "^28.0.7",
     "jest-environment-jsdom": "^28.1.3",
     "jest-transformer-svg": "^2.0.0",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,9 +5,9 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="preload" href="static/BMYEONSUNG.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="static/BMHANNAPro.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="static/BMHANNAAir.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="%PUBLIC_URL%/static/BMYEONSUNG.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="%PUBLIC_URL%/static/BMHANNAPro.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="%PUBLIC_URL%/static/BMHANNAAir.woff2" as="font" type="font/woff2" crossorigin>
   <title>속닥속닥</title>
 </head>
 

--- a/frontend/src/style/GlobalStyle.tsx
+++ b/frontend/src/style/GlobalStyle.tsx
@@ -1,14 +1,14 @@
 import emotionReset from 'emotion-reset';
 
-import '@/assets/fonts/BMHANNAAir/BMHANNAAir.ttf';
-import '@/assets/fonts/BMHANNAAir/BMHANNAAir.woff';
-import '@/assets/fonts/BMHANNAAir/BMHANNAAir.woff2';
-import '@/assets/fonts/BMHANNAPro/BMHANNAPro.ttf';
-import '@/assets/fonts/BMHANNAPro/BMHANNAPro.woff';
-import '@/assets/fonts/BMHANNAPro/BMHANNAPro.woff2';
-import '@/assets/fonts/BMYEONSUNG/BMYEONSUNG.ttf';
-import '@/assets/fonts/BMYEONSUNG/BMYEONSUNG.woff';
-import '@/assets/fonts/BMYEONSUNG/BMYEONSUNG.woff2';
+import BMHANNA_AIR_TTF from '@/assets/fonts/BMHANNAAir/BMHANNAAir.ttf';
+import BMHANNA_AIR_WOFF from '@/assets/fonts/BMHANNAAir/BMHANNAAir.woff';
+import BMHANNA_AIR_WOFF2 from '@/assets/fonts/BMHANNAAir/BMHANNAAir.woff2';
+import BMHANNA_PRO_TTF from '@/assets/fonts/BMHANNAPro/BMHANNAPro.ttf';
+import BMHANNA_PRO_WOFF from '@/assets/fonts/BMHANNAPro/BMHANNAPro.woff';
+import BMHANNA_PRO_WOFF2 from '@/assets/fonts/BMHANNAPro/BMHANNAPro.woff2';
+import BMYEONSUNG_TTF from '@/assets/fonts/BMYEONSUNG/BMYEONSUNG.ttf';
+import BMYEONSUNG_WOFF from '@/assets/fonts/BMYEONSUNG/BMYEONSUNG.woff';
+import BMYEONSUNG_WOFF2 from '@/assets/fonts/BMYEONSUNG/BMYEONSUNG.woff2';
 
 import { css, Global, keyframes } from '@emotion/react';
 
@@ -17,8 +17,8 @@ const style = css`
 
   @font-face {
     font-family: 'BMYEONSUNG';
-    src: url('static/BMYEONSUNG.woff2') format('woff2'), url('static/BMYEONSUNG.woff2') format('woff'),
-      url('static/BMYEONSUNG.woff2') format('truetype');
+    src: url('${BMYEONSUNG_WOFF2}') format('woff2'), url('${BMYEONSUNG_WOFF}') format('woff'),
+      url('${BMYEONSUNG_TTF}') format('truetype');
     font-weight: normal;
     font-style: normal;
     font-display: optional;
@@ -26,8 +26,8 @@ const style = css`
 
   @font-face {
     font-family: 'BMHANNAPro';
-    src: url('static/BMHANNAPro.woff2') format('woff2'), url('static/BMHANNAPro.woff2') format('woff'),
-      url('static/BMHANNAPro.woff2') format('truetype');
+    src: url('${BMHANNA_PRO_WOFF2}') format('woff2'), url('${BMHANNA_PRO_WOFF}') format('woff'),
+      url('${BMHANNA_PRO_TTF}') format('truetype');
     font-weight: normal;
     font-style: normal;
     font-display: optional;
@@ -35,8 +35,8 @@ const style = css`
 
   @font-face {
     font-family: 'BMHANNAAir';
-    src: url('static/BMHANNAAir.woff2') format('woff2'), url('static/BMHANNAAir.woff2') format('woff'),
-      url('static/BMHANNAAir.woff2') format('truetype');
+    src: url('${BMHANNA_AIR_WOFF2}') format('woff2'), url('${BMHANNA_AIR_WOFF}') format('woff'),
+      url('${BMHANNA_AIR_TTF}') format('truetype');
     font-weight: normal;
     font-style: normal;
     font-display: optional;

--- a/frontend/src/types/file.d.ts
+++ b/frontend/src/types/file.d.ts
@@ -5,4 +5,8 @@ declare module '*.svg' {
 }
 declare module '*.png';
 
+declare module '*.ttf';
+declare module '*.woff';
+declare module '*.woff2';
+
 // TODO: default props

--- a/frontend/webpack/webpack.config.js
+++ b/frontend/webpack/webpack.config.js
@@ -4,6 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const Dotenv = require('dotenv-webpack');
+const InterpolateHtmlPlugin = require('interpolate-html-plugin');
 require('dotenv').config();
 
 module.exports = {
@@ -56,6 +57,7 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, '../public/index.html'),
     }),
+    new InterpolateHtmlPlugin({ PUBLIC_URL: '' }),
   ],
   devtool: 'source-map',
 };


### PR DESCRIPTION
### 버그 설명

새로고침 시 폰트가 적용되지 않는 문제 

### 세부 구현기능

메인 페이지가 아닌 다른 url로 접속하고 새로고침을 하면 해당 url기준으로 폰트 요청이 날라감

이는 preload를 위한 index.html내 link태그의 href에 경로 설정 문제로 인해 발생함

interpolate-html-plugin을 통해 PUBLIC_URL 변수를 index.html로 전달하고 이를 href에 활용함으로써 새로고침 후에도 PUBLIC_URL을 참조하도록 설정

### 관련 이슈

close #548
