### PR TITLE
refactor: Notification 리팩토링

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/domain/Notification.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/domain/Notification.java
@@ -72,8 +72,4 @@ public class Notification {
             throw new AuthorizationException();
         }
     }
-
-    public void inquire() {
-        inquired = true;
-    }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
@@ -12,8 +12,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     boolean existsByMemberIdAndInquiredIsFalse(Long memberId);
 
-    void deleteAllByCommentId(Long commentId);
-
     @Modifying
     @Query(value = "DELETE from Notification n WHERE n.id in :ids")
     void deleteAllById(List<Long> ids);

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+    @Query(value = "SELECT exists (SELECT * from Notification where member_id = :memberId and inquired = false)",
+            nativeQuery = true)
     boolean existsByMemberIdAndInquiredIsFalse(Long memberId);
 
     @Modifying

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
@@ -1,9 +1,12 @@
 package com.wooteco.sokdak.notification.repository;
 
 import com.wooteco.sokdak.notification.domain.Notification;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -14,4 +17,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     void deleteAllByCommentId(Long commentId);
 
     Slice<Notification> findNotificationsByMemberId(Long memberId, Pageable pageable);
+
+    @Modifying
+    @Query(value = "UPDATE Notification n SET n.inquired = true WHERE n.id in :ids")
+    void inquireNotificationByIds(List<Long> ids);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
@@ -16,6 +16,13 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     void deleteAllByCommentId(Long commentId);
 
+    @Modifying
+    @Query(value = "DELETE from Notification n WHERE n.id in :ids")
+    void deleteAllById(List<Long> ids);
+
+    @Query(value = "SELECT n.id from Notification n where n.comment.id = :commentId")
+    List<Long> findIdsByCommentId(Long commentId);
+
     Slice<Notification> findNotificationsByMemberId(Long memberId, Pageable pageable);
 
     @Modifying

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
@@ -12,8 +12,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     boolean existsByMemberIdAndInquiredIsFalse(Long memberId);
 
-    void deleteAllByPostId(Long postId);
-
     void deleteAllByCommentId(Long commentId);
 
     @Modifying
@@ -22,6 +20,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     @Query(value = "SELECT n.id from Notification n where n.comment.id = :commentId")
     List<Long> findIdsByCommentId(Long commentId);
+
+    @Query(value = "SELECT n.id from Notification n where n.post.id = :postId")
+    List<Long> findIdsByPostId(Long postId);
 
     Slice<Notification> findNotificationsByMemberId(Long memberId, Pageable pageable);
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
@@ -22,6 +22,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query(value = "SELECT n.id from Notification n where n.post.id = :postId")
     List<Long> findIdsByPostId(Long postId);
 
+    @Query(value = "SELECT n from Notification n where n.member.id = :memberId")
     Slice<Notification> findNotificationsByMemberId(Long memberId, Pageable pageable);
 
     @Modifying

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
@@ -10,24 +10,24 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    @Query(value = "SELECT exists (SELECT * from Notification where member_id = :memberId and inquired = false)",
+    @Query(value = "SELECT EXISTS (SELECT * FROM Notification WHERE member_id = :memberId AND inquired = false)",
             nativeQuery = true)
     boolean existsByMemberIdAndInquiredIsFalse(Long memberId);
 
     @Modifying
-    @Query(value = "DELETE from Notification n WHERE n.id in :ids")
+    @Query(value = "DELETE FROM Notification n WHERE n.id IN :ids")
     void deleteAllById(List<Long> ids);
 
-    @Query(value = "SELECT n.id from Notification n where n.comment.id = :commentId")
+    @Query(value = "SELECT n.id FROM Notification n WHERE n.comment.id = :commentId")
     List<Long> findIdsByCommentId(Long commentId);
 
-    @Query(value = "SELECT n.id from Notification n where n.post.id = :postId")
+    @Query(value = "SELECT n.id FROM Notification n WHERE n.post.id = :postId")
     List<Long> findIdsByPostId(Long postId);
 
-    @Query(value = "SELECT n from Notification n where n.member.id = :memberId")
+    @Query(value = "SELECT n FROM Notification n WHERE n.member.id = :memberId")
     Slice<Notification> findNotificationsByMemberId(Long memberId, Pageable pageable);
 
     @Modifying
-    @Query(value = "UPDATE Notification n SET n.inquired = true WHERE n.id in :ids")
+    @Query(value = "UPDATE Notification n SET n.inquired = true WHERE n.id IN :ids")
     void inquireNotificationByIds(List<Long> ids);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
@@ -34,24 +34,29 @@ public class NotificationService {
         this.notificationRepository = notificationRepository;
     }
 
+    @Transactional
     public void notifyCommentIfNotMine(Member member, Post post, Comment comment) {
         if (!comment.isAuthorized(member.getId())) {
             notify(member, post, comment, NEW_COMMENT);
         }
     }
 
+    @Transactional
     public void notifyCommentReport(Post post, Comment comment) {
         notify(comment.getMember(), post, comment, COMMENT_REPORT);
     }
 
+    @Transactional
     public void notifyHotBoard(Post post) {
         notify(post.getMember(), post, null, HOT_BOARD);
     }
 
+    @Transactional
     public void notifyPostReport(Post post) {
         notify(post.getMember(), post, null, POST_REPORT);
     }
 
+    @Transactional
     public void notifyReplyIfNotMine(Member member, Post post, Comment comment, Comment reply) {
         if (!reply.isAuthorized(member.getId())) {
             notify(member, post, comment, NEW_REPLY);
@@ -68,13 +73,11 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
-    @Transactional(readOnly = true)
     public NewNotificationCheckResponse checkNewNotification(AuthInfo authInfo) {
         return new NewNotificationCheckResponse(
                 notificationRepository.existsByMemberIdAndInquiredIsFalse(authInfo.getId()));
     }
 
-    @Transactional(readOnly = true)
     public NotificationsResponse findNotifications(AuthInfo authInfo, Pageable pageable) {
         Slice<Notification> foundNotifications = notificationRepository
                 .findNotificationsByMemberId(authInfo.getId(), pageable);
@@ -100,6 +103,7 @@ public class NotificationService {
         return new NotificationsResponse(notificationResponses, isLastPage);
     }
 
+    @Transactional
     public void deleteNotification(AuthInfo authInfo, Long notificationId) {
         Notification notification = notificationRepository.findById(notificationId)
                 .orElseThrow(NotificationNotFoundException::new);
@@ -107,6 +111,7 @@ public class NotificationService {
         notificationRepository.deleteById(notificationId);
     }
 
+    @Transactional
     public void deleteCommentNotification(Long commentId) {
         List<Long> ids = notificationRepository.findIdsByCommentId(commentId);
         if (!ids.isEmpty()) {
@@ -114,6 +119,7 @@ public class NotificationService {
         }
     }
 
+    @Transactional
     public void deletePostNotification(Long postId) {
         List<Long> ids = notificationRepository.findIdsByPostId(postId);
         if (!ids.isEmpty()) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
@@ -68,20 +68,6 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
-    public void deleteCommentNotification(Long commentId) {
-        List<Long> ids = notificationRepository.findIdsByCommentId(commentId);
-        if (!ids.isEmpty()) {
-            notificationRepository.deleteAllById(ids);
-        }
-    }
-
-    public void deletePostNotification(Long postId) {
-        List<Long> ids = notificationRepository.findIdsByPostId(postId);
-        if (!ids.isEmpty()) {
-            notificationRepository.deleteAllById(ids);
-        }
-    }
-
     @Transactional(readOnly = true)
     public NewNotificationCheckResponse checkNewNotification(AuthInfo authInfo) {
         return new NewNotificationCheckResponse(
@@ -118,5 +104,19 @@ public class NotificationService {
                 .orElseThrow(NotificationNotFoundException::new);
         notification.validateOwner(authInfo.getId());
         notificationRepository.deleteById(notificationId);
+    }
+
+    public void deleteCommentNotification(Long commentId) {
+        List<Long> ids = notificationRepository.findIdsByCommentId(commentId);
+        if (!ids.isEmpty()) {
+            notificationRepository.deleteAllById(ids);
+        }
+    }
+
+    public void deletePostNotification(Long postId) {
+        List<Long> ids = notificationRepository.findIdsByPostId(postId);
+        if (!ids.isEmpty()) {
+            notificationRepository.deleteAllById(ids);
+        }
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
@@ -74,6 +74,7 @@ public class NotificationService {
                 notificationRepository.existsByMemberIdAndInquiredIsFalse(authInfo.getId()));
     }
 
+    @Transactional(readOnly = true)
     public NotificationsResponse findNotifications(AuthInfo authInfo, Pageable pageable) {
         Slice<Notification> foundNotifications = notificationRepository
                 .findNotificationsByMemberId(authInfo.getId(), pageable);

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
@@ -81,7 +81,7 @@ public class NotificationService {
         if (foundNotifications.hasContent()) {
             inquireNotification(notifications);
         }
-        return generateNotificationsResponse(notifications, foundNotifications.isLast());
+        return findNotifications(notifications, foundNotifications.isLast());
     }
 
     private void inquireNotification(List<Notification> notifications) {
@@ -91,7 +91,7 @@ public class NotificationService {
         notificationRepository.inquireNotificationByIds(inquiredNotificationIds);
     }
 
-    private NotificationsResponse generateNotificationsResponse(List<Notification> notifications, boolean isLastPage) {
+    private NotificationsResponse findNotifications(List<Notification> notifications, boolean isLastPage) {
         List<NotificationResponse> notificationResponses = notifications
                 .stream()
                 .map(NotificationResponse::of)

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
@@ -69,7 +69,8 @@ public class NotificationService {
     }
 
     public void deleteCommentNotification(Long commentId) {
-        notificationRepository.deleteAllByCommentId(commentId);
+        List<Long> ids = notificationRepository.findIdsByCommentId(commentId);
+        notificationRepository.deleteAllById(ids);
     }
 
     @Transactional(readOnly = true)

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
@@ -73,6 +73,11 @@ public class NotificationService {
         notificationRepository.deleteAllById(ids);
     }
 
+    public void deletePostNotification(Long postId) {
+        List<Long> ids = notificationRepository.findIdsByPostId(postId);
+        notificationRepository.deleteAllById(ids);
+    }
+
     @Transactional(readOnly = true)
     public NewNotificationCheckResponse checkNewNotification(AuthInfo authInfo) {
         return new NewNotificationCheckResponse(

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
@@ -70,12 +70,16 @@ public class NotificationService {
 
     public void deleteCommentNotification(Long commentId) {
         List<Long> ids = notificationRepository.findIdsByCommentId(commentId);
-        notificationRepository.deleteAllById(ids);
+        if (!ids.isEmpty()) {
+            notificationRepository.deleteAllById(ids);
+        }
     }
 
     public void deletePostNotification(Long postId) {
         List<Long> ids = notificationRepository.findIdsByPostId(postId);
-        notificationRepository.deleteAllById(ids);
+        if (!ids.isEmpty()) {
+            notificationRepository.deleteAllById(ids);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -12,7 +12,7 @@ import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.exception.MemberNotFoundException;
 import com.wooteco.sokdak.member.repository.MemberRepository;
 import com.wooteco.sokdak.member.util.RandomNicknameGenerator;
-import com.wooteco.sokdak.notification.repository.NotificationRepository;
+import com.wooteco.sokdak.notification.service.NotificationService;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.dto.MyPostsResponse;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
@@ -40,12 +40,12 @@ public class PostService {
     private final MemberRepository memberRepository;
     private final CommentRepository commentRepository;
     private final LikeRepository likeRepository;
-    private final NotificationRepository notificationRepository;
+    private final NotificationService notificationService;
 
     public PostService(HashtagService hashtagService, BoardService boardService,
                        PostRepository postRepository, PostBoardRepository postBoardRepository,
                        MemberRepository memberRepository, CommentRepository commentRepository,
-                       LikeRepository likeRepository, NotificationRepository notificationRepository) {
+                       LikeRepository likeRepository, NotificationService notificationService) {
         this.hashtagService = hashtagService;
         this.boardService = boardService;
         this.postRepository = postRepository;
@@ -53,7 +53,7 @@ public class PostService {
         this.memberRepository = memberRepository;
         this.commentRepository = commentRepository;
         this.likeRepository = likeRepository;
-        this.notificationRepository = notificationRepository;
+        this.notificationService = notificationService;
     }
 
     @Transactional
@@ -130,7 +130,7 @@ public class PostService {
         commentRepository.deleteAllByPostId(post.getId());
         likeRepository.deleteAllByPostId(post.getId());
         hashtagService.deleteAllByPostId(hashtags, id);
-        notificationRepository.deleteAllByPostId(id);
+        notificationService.deletePostNotification(id);
 
         postRepository.delete(post);
     }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/repository/NotificationRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/repository/NotificationRepositoryTest.java
@@ -85,16 +85,6 @@ class NotificationRepositoryTest extends RepositoryTest {
         assertThat(actual).isTrue();
     }
 
-    @DisplayName("댓글 알림을 삭제한다.")
-    @Test
-    void deleteAllByCommentId() {
-        notificationRepository.deleteAllByCommentId(comment.getId());
-
-        boolean actual = notificationRepository.existsByMemberIdAndInquiredIsFalse(member1.getId());
-
-        assertThat(actual).isFalse();
-    }
-
     @DisplayName("회원에 따른 알림을 반환한다.")
     @Test
     void findNotificationsByMemberId() {

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/repository/NotificationRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/repository/NotificationRepositoryTest.java
@@ -15,11 +15,15 @@ import com.wooteco.sokdak.notification.domain.Notification;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.repository.PostRepository;
 import com.wooteco.sokdak.util.RepositoryTest;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 
@@ -34,12 +38,17 @@ class NotificationRepositoryTest extends RepositoryTest {
     @Autowired
     private NotificationRepository notificationRepository;
 
+    @PersistenceContext
+    private EntityManager em;
+
     private Post post;
     private Comment comment;
+    private Member member2;
+    private Notification notification;
 
     @BeforeEach
     void setUp() {
-        Member member2 = Member.builder()
+        member2 = Member.builder()
                 .username("josh")
                 .password("Abcd123!@")
                 .nickname("joshNickname")
@@ -59,7 +68,7 @@ class NotificationRepositoryTest extends RepositoryTest {
                 .nickname("닉네임")
                 .build();
         commentRepository.save(comment);
-        Notification notification = Notification.builder()
+        notification = Notification.builder()
                 .member(member1)
                 .post(post)
                 .comment(comment)
@@ -127,5 +136,41 @@ class NotificationRepositoryTest extends RepositoryTest {
                 () -> assertThat(notifications.getContent().get(1).getNotificationType()).isEqualTo(NEW_COMMENT),
                 () -> assertThat(notifications.getContent().get(1).getContent()).isEqualTo(post.getTitle())
         );
+    }
+
+    @DisplayName("알림들의 id를 받아 조회 여부를 true로 변경한다.")
+    @Test
+    void inquireNotificationByIds() {
+        Comment comment2 = Comment.builder()
+                .post(post)
+                .member(member2)
+                .message("댓글2")
+                .nickname("깔깔")
+                .build();
+        commentRepository.save(comment2);
+        Notification notification2 = Notification.builder()
+                .member(member1)
+                .post(post)
+                .comment(comment2)
+                .notificationType(NEW_COMMENT)
+                .build();
+        notificationRepository.save(notification2);
+        Notification notification3 = Notification.builder()
+                .member(member1)
+                .post(post)
+                .notificationType(POST_REPORT)
+                .build();
+        notificationRepository.save(notification3);
+        em.clear();
+
+        notificationRepository.inquireNotificationByIds(
+                List.of(notification.getId(), notification2.getId(), notification3.getId()));
+
+        List<Notification> notifications = notificationRepository
+                .findNotificationsByMemberId(member1.getId(), Pageable.ofSize(3))
+                .getContent();
+        boolean actual = notifications.stream()
+                .allMatch(Notification::isInquired);
+        assertThat(actual).isTrue();
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
@@ -273,16 +273,9 @@ class NotificationServiceTest extends ServiceTest {
                 .comment(comment)
                 .member(member)
                 .build();
-        Notification notification3 = Notification.builder()
-                .notificationType(COMMENT_REPORT)
-                .post(post)
-                .comment(comment)
-                .member(member)
-                .build();
 
         notificationRepository.save(notification1);
         notificationRepository.save(notification2);
-        notificationRepository.save(notification3);
 
         em.clear();
 
@@ -301,12 +294,7 @@ class NotificationServiceTest extends ServiceTest {
                 .nickname("닉네임")
                 .message("내용")
                 .build();
-        Comment comment4 = Comment.builder()
-                .post(post)
-                .member(member2)
-                .nickname("닉네임")
-                .message("내용")
-                .build();
+        commentRepository.save(comment3);
         Notification notification1 = Notification.builder()
                 .notificationType(NEW_COMMENT)
                 .post(post)
@@ -319,16 +307,9 @@ class NotificationServiceTest extends ServiceTest {
                 .comment(comment3)
                 .member(member)
                 .build();
-        Notification notification3 = Notification.builder()
-                .notificationType(NEW_COMMENT)
-                .post(post)
-                .comment(comment4)
-                .member(member)
-                .build();
 
         notificationRepository.save(notification1);
         notificationRepository.save(notification2);
-        notificationRepository.save(notification3);
 
         em.clear();
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
@@ -26,6 +26,8 @@ import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.repository.PostRepository;
 import com.wooteco.sokdak.util.ServiceTest;
 import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,6 +41,9 @@ import org.springframework.data.domain.Sort;
 class NotificationServiceTest extends ServiceTest {
 
     private static final Pageable PAGEABLE = PageRequest.of(0, 100);
+
+    @PersistenceContext
+    private EntityManager em;
 
     @Autowired
     private NotificationService notificationService;
@@ -256,13 +261,19 @@ class NotificationServiceTest extends ServiceTest {
     @Test
     void deleteCommentNotification() {
         Notification notification1 = Notification.builder()
-                .notificationType(NEW_COMMENT)
+                .notificationType(COMMENT_REPORT)
                 .post(post)
                 .comment(comment)
                 .member(member)
                 .build();
         Notification notification2 = Notification.builder()
-                .notificationType(NEW_COMMENT)
+                .notificationType(COMMENT_REPORT)
+                .post(post)
+                .comment(comment)
+                .member(member)
+                .build();
+        Notification notification3 = Notification.builder()
+                .notificationType(COMMENT_REPORT)
                 .post(post)
                 .comment(comment)
                 .member(member)
@@ -270,6 +281,9 @@ class NotificationServiceTest extends ServiceTest {
 
         notificationRepository.save(notification1);
         notificationRepository.save(notification2);
+        notificationRepository.save(notification3);
+
+        em.clear();
 
         notificationService.deleteCommentNotification(comment.getId());
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
@@ -316,13 +316,13 @@ class NotificationServiceTest extends ServiceTest {
         Notification notification2 = Notification.builder()
                 .notificationType(NEW_COMMENT)
                 .post(post)
-                .comment(comment)
+                .comment(comment3)
                 .member(member)
                 .build();
         Notification notification3 = Notification.builder()
                 .notificationType(NEW_COMMENT)
                 .post(post)
-                .comment(comment)
+                .comment(comment4)
                 .member(member)
                 .build();
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
@@ -252,7 +252,32 @@ class NotificationServiceTest extends ServiceTest {
         );
     }
 
-    @DisplayName("댓글을 삭제한다.")
+    @DisplayName("댓글에 해당하는 알림들을 삭제한다.")
+    @Test
+    void deleteCommentNotification() {
+        Notification notification1 = Notification.builder()
+                .notificationType(NEW_COMMENT)
+                .post(post)
+                .comment(comment)
+                .member(member)
+                .build();
+        Notification notification2 = Notification.builder()
+                .notificationType(NEW_COMMENT)
+                .post(post)
+                .comment(comment)
+                .member(member)
+                .build();
+
+        notificationRepository.save(notification1);
+        notificationRepository.save(notification2);
+
+        notificationService.deleteCommentNotification(comment.getId());
+
+        NotificationsResponse notifications = notificationService.findNotifications(AUTH_INFO, PageRequest.of(0, 10));
+        assertThat(notifications.getNotifications()).isEmpty();
+    }
+
+    @DisplayName("알림을 삭제한다.")
     @Test
     void deleteNotification() {
         Notification notification = Notification.builder()

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
@@ -288,7 +288,7 @@ class NotificationServiceTest extends ServiceTest {
 
         notificationService.deleteCommentNotification(comment.getId());
 
-        NotificationsResponse notifications = notificationService.findNotifications(AUTH_INFO, PageRequest.of(0, 10));
+        NotificationsResponse notifications = notificationService.findNotifications(AUTH_INFO, PAGEABLE);
         assertThat(notifications.getNotifications()).isEmpty();
     }
 
@@ -334,7 +334,7 @@ class NotificationServiceTest extends ServiceTest {
 
         notificationService.deletePostNotification(post.getId());
 
-        NotificationsResponse notifications = notificationService.findNotifications(AUTH_INFO, PageRequest.of(0, 10));
+        NotificationsResponse notifications = notificationService.findNotifications(AUTH_INFO, PAGEABLE);
         assertThat(notifications.getNotifications()).isEmpty();
     }
 
@@ -351,7 +351,7 @@ class NotificationServiceTest extends ServiceTest {
         notificationService.deleteNotification(AUTH_INFO, notification.getId());
 
         List<Notification> notifications = notificationRepository
-                .findNotificationsByMemberId(member.getId(), PageRequest.of(0, 10))
+                .findNotificationsByMemberId(member.getId(), PAGEABLE)
                 .getContent();
         assertThat(notifications).isEmpty();
     }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
@@ -89,6 +89,7 @@ class NotificationServiceTest extends ServiceTest {
                 .message("내용")
                 .build();
         commentRepository.save(comment);
+        commentRepository.save(comment2);
     }
 
     @DisplayName("새 댓글 알림을 등록한다.")
@@ -286,6 +287,52 @@ class NotificationServiceTest extends ServiceTest {
         em.clear();
 
         notificationService.deleteCommentNotification(comment.getId());
+
+        NotificationsResponse notifications = notificationService.findNotifications(AUTH_INFO, PageRequest.of(0, 10));
+        assertThat(notifications.getNotifications()).isEmpty();
+    }
+
+    @DisplayName("게시글에 해당하는 알림들을 삭제한다.")
+    @Test
+    void deletePostNotification() {
+        Comment comment3 = Comment.builder()
+                .post(post)
+                .member(member2)
+                .nickname("닉네임")
+                .message("내용")
+                .build();
+        Comment comment4 = Comment.builder()
+                .post(post)
+                .member(member2)
+                .nickname("닉네임")
+                .message("내용")
+                .build();
+        Notification notification1 = Notification.builder()
+                .notificationType(NEW_COMMENT)
+                .post(post)
+                .comment(comment)
+                .member(member)
+                .build();
+        Notification notification2 = Notification.builder()
+                .notificationType(NEW_COMMENT)
+                .post(post)
+                .comment(comment)
+                .member(member)
+                .build();
+        Notification notification3 = Notification.builder()
+                .notificationType(NEW_COMMENT)
+                .post(post)
+                .comment(comment)
+                .member(member)
+                .build();
+
+        notificationRepository.save(notification1);
+        notificationRepository.save(notification2);
+        notificationRepository.save(notification3);
+
+        em.clear();
+
+        notificationService.deletePostNotification(post.getId());
 
         NotificationsResponse notifications = notificationService.findNotifications(AUTH_INFO, PageRequest.of(0, 10));
         assertThat(notifications.getNotifications()).isEmpty();


### PR DESCRIPTION
### 구현기능
- notification 조회시 반복문을 돌면서 query문을 실행하는 로직, where~in으로 개선
- comment와 post에 해당하는 Notification 삭제 로직에서 query문이 Notification의 개수만큼 실행되는 문제 where~in으로 개선

#576 