### PR TITLE
refactor: typescript 유틸 타입 npm 출시 및 분리

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -64,6 +64,7 @@
         "react-refresh": "^0.14.0",
         "react-router-dom": "^6.3.0",
         "react-test-renderer": "^18.2.0",
+        "sokdak-util-types": "^1.0.1",
         "storybook-addon-react-router-v6": "^0.1.10",
         "ts-jest": "^28.0.7",
         "tsconfig-paths-webpack-plugin": "^3.5.2",
@@ -28640,6 +28641,12 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sokdak-util-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sokdak-util-types/-/sokdak-util-types-1.0.1.tgz",
+      "integrity": "sha512-Rw68ktMom98QT7YFhIM61sVweN+hO9JZtN02/2tc7V3ZAndOCFkFmymRXuR+fEH9kYMTgXNwykgpjZovqGhKKQ==",
+      "dev": true
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -54103,6 +54110,12 @@
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
       }
+    },
+    "sokdak-util-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sokdak-util-types/-/sokdak-util-types-1.0.1.tgz",
+      "integrity": "sha512-Rw68ktMom98QT7YFhIM61sVweN+hO9JZtN02/2tc7V3ZAndOCFkFmymRXuR+fEH9kYMTgXNwykgpjZovqGhKKQ==",
+      "dev": true
     },
     "source-list-map": {
       "version": "2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,6 +92,7 @@
     "react-refresh": "^0.14.0",
     "react-router-dom": "^6.3.0",
     "react-test-renderer": "^18.2.0",
+    "sokdak-util-types": "^1.0.1",
     "storybook-addon-react-router-v6": "^0.1.10",
     "ts-jest": "^28.0.7",
     "tsconfig-paths-webpack-plugin": "^3.5.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,7 +32,7 @@ const UpdatePostPage = lazy(() => import(/* webpackChunkName: "UpdatePostPage" *
 
 const App = () => {
   const { isVisible, message, showSnackbar } = useSnackbar();
-  const { setIsLogin, setUserName } = useContext(AuthContext);
+  const { setIsLogin, setUsername } = useContext(AuthContext);
   const queryClient = useQueryClient();
 
   Object.values(MUTATION_KEY).forEach(KEY => {
@@ -41,7 +41,7 @@ const App = () => {
         if (err.response?.status === 401) {
           showSnackbar(SNACKBAR_MESSAGE.NOT_LOGIN);
           setIsLogin(false);
-          setUserName('');
+          setUsername('');
           return;
         }
         showSnackbar(err.response?.data.message!);

--- a/frontend/src/components/@shared/Dropdown/index.tsx
+++ b/frontend/src/components/@shared/Dropdown/index.tsx
@@ -1,26 +1,17 @@
-import {
-  createContext,
-  ReactNode,
-  SetStateAction,
-  useContext,
-  useState,
-  Dispatch,
-  useRef,
-  useEffect,
-  useCallback,
-} from 'react';
+import { PropsWithChildrenC } from 'sokdak-util-types';
+
+import { createContext, SetStateAction, useContext, useState, Dispatch, useRef, useEffect, useCallback } from 'react';
 
 import * as Styled from './index.styles';
 
 interface DropdownProps {
   className?: string;
-  children: ReactNode;
 }
 const DropdownContext = createContext<{ open: boolean; setOpen: Dispatch<SetStateAction<boolean>> } | undefined>(
   undefined,
 );
 
-const Dropdown = ({ children }: DropdownProps) => {
+const Dropdown = ({ children }: PropsWithChildrenC<DropdownProps>) => {
   const [open, setOpen] = useState(false);
 
   const ref = useRef<HTMLDivElement>(null);
@@ -45,7 +36,7 @@ const Dropdown = ({ children }: DropdownProps) => {
   );
 };
 
-const Trigger = ({ children }: DropdownProps) => {
+const Trigger = ({ children }: PropsWithChildrenC<DropdownProps>) => {
   const dropdown = useContext(DropdownContext);
   if (!dropdown) {
     throw new Error('');
@@ -58,7 +49,7 @@ const Trigger = ({ children }: DropdownProps) => {
   return <Styled.DropdownTrigger onClick={handleTrigger}>{children}</Styled.DropdownTrigger>;
 };
 
-const OptionList = ({ className, children }: DropdownProps) => {
+const OptionList = ({ className, children }: PropsWithChildrenC<DropdownProps>) => {
   const dropdown = useContext(DropdownContext);
   if (!dropdown) {
     throw new Error('');

--- a/frontend/src/components/@shared/Dropdown/index.tsx
+++ b/frontend/src/components/@shared/Dropdown/index.tsx
@@ -1,15 +1,13 @@
-import { PropsWithChildrenC } from 'sokdak-util-types';
+import { PropsWithChildrenC, StateAndAction } from 'sokdak-util-types';
 
-import { createContext, SetStateAction, useContext, useState, Dispatch, useRef, useEffect, useCallback } from 'react';
+import { createContext, useContext, useState, useRef, useEffect, useCallback } from 'react';
 
 import * as Styled from './index.styles';
 
 interface DropdownProps {
   className?: string;
 }
-const DropdownContext = createContext<{ open: boolean; setOpen: Dispatch<SetStateAction<boolean>> } | undefined>(
-  undefined,
-);
+const DropdownContext = createContext<StateAndAction<boolean, 'open'> | undefined>(undefined);
 
 const Dropdown = ({ children }: PropsWithChildrenC<DropdownProps>) => {
   const [open, setOpen] = useState(false);

--- a/frontend/src/components/@shared/InputBox/components/Input/index.tsx
+++ b/frontend/src/components/@shared/InputBox/components/Input/index.tsx
@@ -1,13 +1,11 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import { InputHTMLAttributes } from 'react';
 
 import * as Styled from './index.styles';
 
 import { useInputContext } from '../../useInputContext';
 
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   hasError?: boolean;
-  isAnimationActive?: boolean;
-  setIsAnimationActive?: Dispatch<SetStateAction<boolean>>;
   handleInvalid: () => void;
 }
 

--- a/frontend/src/components/@shared/InputBox/components/SubmitButton/index.tsx
+++ b/frontend/src/components/@shared/InputBox/components/SubmitButton/index.tsx
@@ -1,10 +1,14 @@
+import { PropsWithChildrenC } from 'sokdak-util-types';
+
+import React from 'react';
+
 import * as Styled from './index.styles';
 
-interface SubmitButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children: React.ReactNode;
-}
-
-const SubmitButton = ({ children, onClick, disabled }: SubmitButtonProps) => {
+const SubmitButton = ({
+  children,
+  onClick,
+  disabled,
+}: PropsWithChildrenC<React.ButtonHTMLAttributes<HTMLButtonElement>>) => {
   return (
     <Styled.Button onClick={onClick} disabled={disabled}>
       {children}

--- a/frontend/src/components/@shared/InputBox/index.tsx
+++ b/frontend/src/components/@shared/InputBox/index.tsx
@@ -1,6 +1,4 @@
-import { PropsWithChildrenC } from 'sokdak-util-types';
-
-import { Dispatch, SetStateAction } from 'react';
+import { PropsWithChildrenC, StateAndAction } from 'sokdak-util-types';
 
 import ErrorMessage from './components/ErrorMessage';
 import Input from './components/Input';
@@ -8,14 +6,10 @@ import SubmitButton from './components/SubmitButton';
 
 import { InputContextProvider } from './useInputContext';
 
-interface InputBoxProps<T = string> {
-  value: string;
-  setValue: Dispatch<SetStateAction<string>>;
-  error: T;
-  setError: Dispatch<SetStateAction<T>>;
-  isAnimationActive: boolean;
-  setIsAnimationActive: Dispatch<SetStateAction<boolean>>;
-}
+interface InputBoxProps<T = string>
+  extends StateAndAction<string, 'value'>,
+    StateAndAction<boolean, 'isAnimationActive'>,
+    StateAndAction<T, 'error'> {}
 
 const InputBox = ({
   children,

--- a/frontend/src/components/@shared/InputBox/index.tsx
+++ b/frontend/src/components/@shared/InputBox/index.tsx
@@ -1,3 +1,5 @@
+import { PropsWithChildrenC } from 'sokdak-util-types';
+
 import { Dispatch, SetStateAction } from 'react';
 
 import ErrorMessage from './components/ErrorMessage';
@@ -7,7 +9,6 @@ import SubmitButton from './components/SubmitButton';
 import { InputContextProvider } from './useInputContext';
 
 interface InputBoxProps<T = string> {
-  children: React.ReactNode;
   value: string;
   setValue: Dispatch<SetStateAction<string>>;
   error: T;
@@ -24,7 +25,7 @@ const InputBox = ({
   setError,
   isAnimationActive,
   setIsAnimationActive,
-}: InputBoxProps) => {
+}: PropsWithChildrenC<InputBoxProps>) => {
   return (
     <InputContextProvider value={{ value, setValue, error, setError, isAnimationActive, setIsAnimationActive }}>
       {children}

--- a/frontend/src/components/@shared/InputBox/useInputContext.tsx
+++ b/frontend/src/components/@shared/InputBox/useInputContext.tsx
@@ -1,15 +1,16 @@
+import { PropsWithChildrenC } from 'sokdak-util-types';
+
 import React from 'react';
 
 import { useInput } from './useInput';
 
 interface InputContextProviderProps {
-  children: React.ReactNode;
   value?: ReturnType<typeof useInput>;
 }
 
 const InputContext = React.createContext<ReturnType<typeof useInput> | undefined>(undefined);
 
-const InputContextProvider = ({ children, value }: InputContextProviderProps) => {
+const InputContextProvider = ({ children, value }: PropsWithChildrenC<InputContextProviderProps>) => {
   return <InputContext.Provider value={value}>{children}</InputContext.Provider>;
 };
 

--- a/frontend/src/components/@shared/Modal/index.tsx
+++ b/frontend/src/components/@shared/Modal/index.tsx
@@ -1,15 +1,15 @@
-import { ReactNode } from 'react';
+import { PropsWithChildrenC } from 'sokdak-util-types';
+
 import ReactDOM from 'react-dom';
 
 import * as Styled from './index.styles';
 
 interface ModalProps {
   isModalOpen: boolean;
-  children: ReactNode;
   handleCancel: () => void;
 }
 
-const Modal = ({ isModalOpen, children, handleCancel }: ModalProps) => {
+const Modal = ({ isModalOpen, children, handleCancel }: PropsWithChildrenC<ModalProps>) => {
   return (
     <>
       {isModalOpen && (

--- a/frontend/src/components/CheckBox/index.tsx
+++ b/frontend/src/components/CheckBox/index.tsx
@@ -1,9 +1,9 @@
+import { StateAndAction } from 'sokdak-util-types';
+
 import * as Styled from './index.styles';
 
-interface CheckBoxProps {
+interface CheckBoxProps extends StateAndAction<boolean, 'isChecked'> {
   className?: string;
-  isChecked: boolean;
-  setIsChecked: React.Dispatch<React.SetStateAction<boolean>>;
   labelText: string;
   visible?: boolean;
 }

--- a/frontend/src/components/Pagination/index.tsx
+++ b/frontend/src/components/Pagination/index.tsx
@@ -1,3 +1,5 @@
+import { StateAndAction } from 'sokdak-util-types';
+
 import { useEffect, useState } from 'react';
 
 import * as Styled from './index.styles';
@@ -6,12 +8,10 @@ const MAX_PAGE_LOAD = 8;
 const STANDARD = MAX_PAGE_LOAD / 2;
 const DISPLAY_STANDARD = STANDARD + 1;
 
-interface PaginationProps {
+interface PaginationProps extends StateAndAction<number, 'currentPage'> {
   className?: string;
   firstPage?: number;
   lastPage: number;
-  currentPage: number;
-  setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
 }
 
 const Pagination = ({ className, firstPage = 1, lastPage, currentPage, setCurrentPage }: PaginationProps) => {

--- a/frontend/src/components/PostForm/components/HashTagInput/index.tsx
+++ b/frontend/src/components/PostForm/components/HashTagInput/index.tsx
@@ -1,15 +1,12 @@
+import { StateAndAction } from 'sokdak-util-types';
+
 import HashTag from '@/components/HashTag';
 
 import * as Styled from './index.styles';
 
 import useHashTagInput from './useHashTagInput';
 
-interface HashTagInputProps {
-  hashtags: string[];
-  setHashtags: React.Dispatch<React.SetStateAction<string[]>>;
-}
-
-const HashTagInput = ({ hashtags, setHashtags }: HashTagInputProps) => {
+const HashTagInput = ({ hashtags, setHashtags }: StateAndAction<string[], 'hashtags'>) => {
   const { tagInputValue, handleTagInputChange, handleTagInputKeyDown, isTagInputFocus, handleTagInputFocus } =
     useHashTagInput({ hashtags, setHashtags });
 

--- a/frontend/src/context/Auth.tsx
+++ b/frontend/src/context/Auth.tsx
@@ -1,14 +1,11 @@
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import { StateAndAction } from 'sokdak-util-types';
+
+import React, { useState } from 'react';
 
 import { STORAGE_KEY } from '@/constants/localStorage';
 import { parseJwt } from '@/utils/decodeJwt';
 
-interface AuthContextValue {
-  isLogin: boolean;
-  setIsLogin: Dispatch<SetStateAction<boolean>>;
-  username: string;
-  setUserName: Dispatch<SetStateAction<string>>;
-}
+interface AuthContextValue extends StateAndAction<boolean, 'isLogin'>, StateAndAction<string, 'username'> {}
 const AuthContext = React.createContext<AuthContextValue>({} as AuthContextValue);
 
 export const AuthContextProvider = ({ children }: { children: React.ReactNode }) => {
@@ -20,14 +17,14 @@ export const AuthContextProvider = ({ children }: { children: React.ReactNode })
     return false;
   });
 
-  const [username, setUserName] = useState(() => {
+  const [username, setUsername] = useState(() => {
     if (accessToken) {
       return parseJwt(accessToken)?.nickname!;
     }
     return '';
   });
 
-  return <AuthContext.Provider value={{ isLogin, setIsLogin, username, setUserName }}>{children}</AuthContext.Provider>;
+  return <AuthContext.Provider value={{ isLogin, setIsLogin, username, setUsername }}>{children}</AuthContext.Provider>;
 };
 
 export default AuthContext;

--- a/frontend/src/context/Pagination.tsx
+++ b/frontend/src/context/Pagination.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import React, { Dispatch, PropsWithChildren, SetStateAction, useState } from 'react';
 
 interface PaginationContextValue {
   page: number;
@@ -7,7 +7,7 @@ interface PaginationContextValue {
 
 const PaginationContext = React.createContext<PaginationContextValue>({} as PaginationContextValue);
 
-export const PaginationContextProvider = ({ children }: { children: React.ReactNode }) => {
+export const PaginationContextProvider = ({ children }: PropsWithChildren) => {
   const [page, setPage] = useState(1);
 
   return <PaginationContext.Provider value={{ page, setPage }}>{children}</PaginationContext.Provider>;

--- a/frontend/src/context/Pagination.tsx
+++ b/frontend/src/context/Pagination.tsx
@@ -1,11 +1,8 @@
-import React, { Dispatch, PropsWithChildren, SetStateAction, useState } from 'react';
+import { StateAndAction } from 'sokdak-util-types';
 
-interface PaginationContextValue {
-  page: number;
-  setPage: Dispatch<SetStateAction<number>>;
-}
+import React, { PropsWithChildren, useState } from 'react';
 
-const PaginationContext = React.createContext<PaginationContextValue>({} as PaginationContextValue);
+const PaginationContext = React.createContext<StateAndAction<number, 'page'>>({} as StateAndAction<number, 'page'>);
 
 export const PaginationContextProvider = ({ children }: PropsWithChildren) => {
   const [page, setPage] = useState(1);

--- a/frontend/src/context/Snackbar.tsx
+++ b/frontend/src/context/Snackbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { PropsWithChildren, useState } from 'react';
 
 interface SnackbarContextValue {
   isVisible: boolean;
@@ -8,7 +8,7 @@ interface SnackbarContextValue {
 
 const SnackbarContext = React.createContext<SnackbarContextValue>({} as SnackbarContextValue);
 
-export const SnackBarContextProvider = (props: { children: React.ReactNode }) => {
+export const SnackBarContextProvider = ({ children }: PropsWithChildren) => {
   const [isVisible, setIsVisible] = useState(false);
   const [message, setMessage] = useState('');
   let timer: NodeJS.Timeout;
@@ -28,9 +28,7 @@ export const SnackBarContextProvider = (props: { children: React.ReactNode }) =>
     clearTimeout(timer);
   };
 
-  return (
-    <SnackbarContext.Provider value={{ isVisible, message, showSnackbar }}>{props.children}</SnackbarContext.Provider>
-  );
+  return <SnackbarContext.Provider value={{ isVisible, message, showSnackbar }}>{children}</SnackbarContext.Provider>;
 };
 
 export default SnackbarContext;

--- a/frontend/src/hooks/queries/member/useLogin.ts
+++ b/frontend/src/hooks/queries/member/useLogin.ts
@@ -14,7 +14,7 @@ import { parseJwt } from '@/utils/decodeJwt';
 
 const useLogin = (options?: UseMutationOptions<AxiosResponse<never>, AxiosError<{ message: string }>, Member>) => {
   const { showSnackbar } = useSnackbar();
-  const { setIsLogin, setUserName } = useContext(AuthContext);
+  const { setIsLogin, setUsername } = useContext(AuthContext);
   return useMutation(
     ({ username, password }): Promise<AxiosResponse<never>> =>
       axios.post<never>(
@@ -36,7 +36,7 @@ const useLogin = (options?: UseMutationOptions<AxiosResponse<never>, AxiosError<
         if (accessToken) {
           authFetcher.defaults.headers.common['Authorization'] = accessToken;
           localStorage.setItem(STORAGE_KEY.ACCESS_TOKEN, accessToken);
-          setUserName(parseJwt(accessToken)?.nickname!);
+          setUsername(parseJwt(accessToken)?.nickname!);
         }
         if (refreshToken) {
           authFetcher.defaults.headers.common['Refresh-Token'] = refreshToken;

--- a/frontend/src/hooks/queries/member/useLogout.ts
+++ b/frontend/src/hooks/queries/member/useLogout.ts
@@ -14,13 +14,13 @@ import SNACKBAR_MESSAGE from '@/constants/snackbar';
 
 const useLogout = (options?: UseQueryOptions<AxiosResponse<never>, AxiosError<{ message: string }>, never, string>) => {
   const { showSnackbar } = useSnackbar();
-  const { setIsLogin, setUserName } = useContext(AuthContext);
+  const { setIsLogin, setUsername } = useContext(AuthContext);
   return useQuery(QUERY_KEYS.LOGOUT, () => authFetcher.get<never>('/logout'), {
     ...options,
     onSuccess(data) {
       showSnackbar(SNACKBAR_MESSAGE.SUCCESS_LOGOUT);
       setIsLogin(false);
-      setUserName('');
+      setUsername('');
       authFetcher.defaults.headers.common = {};
       localStorage.setItem(STORAGE_KEY.ACCESS_TOKEN, '');
       localStorage.setItem(STORAGE_KEY.REFRESH_TOKEN, '');

--- a/frontend/src/hooks/queries/profile/useUpdateNickname.ts
+++ b/frontend/src/hooks/queries/profile/useUpdateNickname.ts
@@ -18,7 +18,7 @@ interface UseUpdateNicknameProps {
 const useUpdateNickname = (
   options?: UseMutationOptions<AxiosResponse, AxiosError<ErrorResponse>, UseUpdateNicknameProps>,
 ) => {
-  const { setUserName } = useContext(AuthContext);
+  const { setUsername } = useContext(AuthContext);
   const { showSnackbar } = useSnackbar();
 
   return useMutation(
@@ -44,7 +44,7 @@ const useUpdateNickname = (
         if (accessToken) {
           authFetcher.defaults.headers.common['Authorization'] = accessToken;
           localStorage.setItem(STORAGE_KEY.ACCESS_TOKEN, accessToken);
-          setUserName(variables.nickname);
+          setUsername(variables.nickname);
           showSnackbar(SNACKBAR_MESSAGE.SUCCESS_UPDATE_NICKNAME);
         }
       },

--- a/frontend/src/style/GlobalStyle.tsx
+++ b/frontend/src/style/GlobalStyle.tsx
@@ -96,8 +96,8 @@ export const huduldul = keyframes`
   }
 `;
 
-export const invalidInputAnimation = (props: { isAnimationActive?: boolean }) => css`
-  animation: ${props.isAnimationActive ? huduldul : null} 0.3s;
+export const invalidInputAnimation = ({ isAnimationActive }: { isAnimationActive?: boolean }) => css`
+  animation: ${isAnimationActive ? huduldul : null} 0.3s;
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
### 구현기능

-  유틸 타입을 분리하고 [속닥 유틸 타입](https://www.npmjs.com/package/sokdak-util-types)을 publish하여 이를 프로젝트에 반영한다.

```typescript
export type PropsWithChildrenC<P = unknown, C = ReactNode> = P & {
  children: C;
};

export type StateAndAction<T, K extends string> = {
  [P in K]: T;
} & {
  [P in `set${Capitalize<K>}`]: Dispatch<SetStateAction<T>>;
};


```
### 관련 이슈

#582 