### PR TITLE
feat: PWA 사용성 보강

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "속닥속닥",
-  "name": "우리들만의 비밀 이야기, 속닥속닥",
+  "name": "속닥속닥",
   "icons": [
     {
       "src": "./icons/apple-touch-icon-57x57.png",
@@ -51,6 +51,6 @@
   ],
   "start_url": "/",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#000000"
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff"
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,12 +2,14 @@ import { useContext, lazy, Suspense } from 'react';
 import { useQueryClient } from 'react-query';
 import { Route, Routes } from 'react-router-dom';
 
+import Prompt from './components/Prompt';
 import Header from '@/components/Header';
 import Snackbar from '@/components/Snackbar';
 import Spinner from '@/components/Spinner';
 
 import AuthContext from './context/Auth';
 
+import useInstallApp from './hooks/useInstallApp';
 import useSnackbar from './hooks/useSnackbar';
 
 import PATH from './constants/path';
@@ -32,6 +34,7 @@ const UpdatePostPage = lazy(() => import(/* webpackChunkName: "UpdatePostPage" *
 
 const App = () => {
   const { isVisible, message, showSnackbar } = useSnackbar();
+  const { installable, setInstallable, installApp } = useInstallApp();
   const { setIsLogin, setUsername } = useContext(AuthContext);
   const queryClient = useQueryClient();
 
@@ -72,6 +75,17 @@ const App = () => {
         </Routes>
       </Suspense>
       {isVisible && <Snackbar message={message} />}
+      {installable && (
+        <Prompt
+          message="속닥속닥 앱을 설치하시겠습니까?"
+          confirmText="설치"
+          cancelText="취소"
+          confirm={installApp}
+          cancel={() => setInstallable(false)}
+          visible={installable}
+          setVisible={setInstallable}
+        />
+      )}
     </>
   );
 };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,6 +77,7 @@ const App = () => {
       {isVisible && <Snackbar message={message} />}
       {installable && (
         <Prompt
+          name="install"
           message="속닥속닥 앱을 설치하시겠습니까?"
           confirmText="설치"
           cancelText="취소"

--- a/frontend/src/components/Prompt/index.stories.tsx
+++ b/frontend/src/components/Prompt/index.stories.tsx
@@ -1,0 +1,16 @@
+import Prompt from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Components/Prompt',
+  component: Prompt,
+} as ComponentMeta<typeof Prompt>;
+
+const Template: ComponentStory<typeof Prompt> = args => <Prompt {...args} />;
+
+export const PromptTemplate = Template.bind({});
+PromptTemplate.args = {
+  message: '속닥속닥 앱을 설치하시겠습니까?',
+  confirmText: '설치',
+  cancelText: '취소',
+};

--- a/frontend/src/components/Prompt/index.styles.ts
+++ b/frontend/src/components/Prompt/index.styles.ts
@@ -37,18 +37,19 @@ export const Message = styled.div`
   font-size: 17px;
 `;
 
-export const ButtonContainer = styled.div`
+export const ButtonContainer = styled.div``;
+
+export const Controller = styled.div`
   display: flex;
   justify-content: space-between;
 `;
 
 const button = () => css`
-  width: 120px;
+  width: 130px;
   height: 40px;
   border-radius: 4px;
   font-size: 14px;
   background-color: transparent;
-  cursor: pointer;
 `;
 
 export const Confirm = styled.button`
@@ -59,4 +60,14 @@ export const Confirm = styled.button`
 
 export const Cancel = styled.button`
   ${button}
+  color: ${props => props.theme.colors.sub};
+`;
+
+export const Hide = styled.button`
+  background-color: transparent;
+  color: ${props => props.theme.colors.gray_200};
+  width: 100%;
+  text-align: left;
+  margin-top: 2px;
+  font-size: 11px;
 `;

--- a/frontend/src/components/Prompt/index.styles.ts
+++ b/frontend/src/components/Prompt/index.styles.ts
@@ -1,0 +1,62 @@
+import { css, keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+const up = keyframes`
+  0% {
+    opacity: 0;
+    transform: translateY(200px);
+    animation-timing-function: cubic-bezier(1, 0, 0.8, 1)
+  } 
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+export const Container = styled.div`
+  display: flex;
+  position: fixed;
+  bottom: 0px;
+  left: calc(50% - 175px);
+  z-index: 10;
+  width: 350px;
+  height: 200px;
+  background-color: white;
+  padding: 30px;
+  border-radius: 10px 10px 0 0;
+  flex-direction: column;
+  justify-content: space-between;
+  box-sizing: border-box;
+  box-shadow: 0px -7px 13px -6px rgb(0 0 0 / 20%);
+  animation: ${up} 0.8s;
+  user-select: none;
+`;
+
+export const Message = styled.div`
+  font-weight: bold;
+  font-size: 17px;
+`;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const button = () => css`
+  width: 120px;
+  height: 40px;
+  border-radius: 4px;
+  font-size: 14px;
+  background-color: transparent;
+  cursor: pointer;
+`;
+
+export const Confirm = styled.button`
+  ${button}
+  background-color: ${props => props.theme.colors.sub};
+  color: white;
+`;
+
+export const Cancel = styled.button`
+  ${button}
+`;

--- a/frontend/src/components/Prompt/index.tsx
+++ b/frontend/src/components/Prompt/index.tsx
@@ -4,22 +4,44 @@ import { MouseEventHandler, useEffect, useRef } from 'react';
 
 import * as Styled from './index.styles';
 
+import { STORAGE_KEY } from '@/constants/localStorage';
+
 interface PromptProps extends StateAndAction<boolean, 'visible'> {
   message: string;
   confirmText: string;
   cancelText: string;
+  hideText?: string;
   confirm: MouseEventHandler<HTMLButtonElement>;
   cancel: MouseEventHandler<HTMLButtonElement>;
 }
 
-const Prompt = ({ message, confirmText, cancelText, confirm, cancel, setVisible }: PromptProps) => {
+const Prompt = ({
+  message,
+  confirmText,
+  cancelText,
+  hideText = '😴 다시 보지 않기',
+  confirm,
+  cancel,
+  setVisible,
+}: PromptProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
+
   const handleOutsideClick = (e: MouseEvent) => {
     if (!containerRef.current || !(e.target instanceof Node)) return;
     if (!containerRef.current.contains(e.target)) setVisible(false);
   };
 
+  const hide = () => {
+    localStorage.setItem(STORAGE_KEY.INSTALL_PROMPT_HIDE, 'hide');
+    setVisible(false);
+  };
+
   useEffect(() => {
+    if (localStorage.getItem(STORAGE_KEY.INSTALL_PROMPT_HIDE)) {
+      setVisible(false);
+      return;
+    }
+
     window.addEventListener('click', handleOutsideClick);
     return () => window.removeEventListener('click', handleOutsideClick);
   }, []);
@@ -28,8 +50,11 @@ const Prompt = ({ message, confirmText, cancelText, confirm, cancel, setVisible 
     <Styled.Container ref={containerRef}>
       <Styled.Message>{message}</Styled.Message>
       <Styled.ButtonContainer>
-        <Styled.Confirm onClick={confirm}>{confirmText}</Styled.Confirm>
-        <Styled.Cancel onClick={cancel}>{cancelText}</Styled.Cancel>
+        <Styled.Controller>
+          <Styled.Cancel onClick={cancel}>{cancelText}</Styled.Cancel>
+          <Styled.Confirm onClick={confirm}>{confirmText}</Styled.Confirm>
+        </Styled.Controller>
+        <Styled.Hide onClick={hide}>{hideText}</Styled.Hide>
       </Styled.ButtonContainer>
     </Styled.Container>
   );

--- a/frontend/src/components/Prompt/index.tsx
+++ b/frontend/src/components/Prompt/index.tsx
@@ -4,9 +4,8 @@ import { MouseEventHandler, useEffect, useRef } from 'react';
 
 import * as Styled from './index.styles';
 
-import { STORAGE_KEY } from '@/constants/localStorage';
-
 interface PromptProps extends StateAndAction<boolean, 'visible'> {
+  name?: string;
   message: string;
   confirmText: string;
   cancelText: string;
@@ -16,6 +15,7 @@ interface PromptProps extends StateAndAction<boolean, 'visible'> {
 }
 
 const Prompt = ({
+  name = '',
   message,
   confirmText,
   cancelText,
@@ -32,12 +32,12 @@ const Prompt = ({
   };
 
   const hide = () => {
-    localStorage.setItem(STORAGE_KEY.INSTALL_PROMPT_HIDE, 'hide');
+    localStorage.setItem(`${name}_propmt`, 'hide');
     setVisible(false);
   };
 
   useEffect(() => {
-    if (localStorage.getItem(STORAGE_KEY.INSTALL_PROMPT_HIDE)) {
+    if (localStorage.getItem(`${name}_prompt`)) {
       setVisible(false);
       return;
     }

--- a/frontend/src/components/Prompt/index.tsx
+++ b/frontend/src/components/Prompt/index.tsx
@@ -1,0 +1,38 @@
+import { StateAndAction } from 'sokdak-util-types';
+
+import { MouseEventHandler, useEffect, useRef } from 'react';
+
+import * as Styled from './index.styles';
+
+interface PromptProps extends StateAndAction<boolean, 'visible'> {
+  message: string;
+  confirmText: string;
+  cancelText: string;
+  confirm: MouseEventHandler<HTMLButtonElement>;
+  cancel: MouseEventHandler<HTMLButtonElement>;
+}
+
+const Prompt = ({ message, confirmText, cancelText, confirm, cancel, setVisible }: PromptProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const handleOutsideClick = (e: MouseEvent) => {
+    if (!containerRef.current || !(e.target instanceof Node)) return;
+    if (!containerRef.current.contains(e.target)) setVisible(false);
+  };
+
+  useEffect(() => {
+    window.addEventListener('click', handleOutsideClick);
+    return () => window.removeEventListener('click', handleOutsideClick);
+  }, []);
+
+  return (
+    <Styled.Container ref={containerRef}>
+      <Styled.Message>{message}</Styled.Message>
+      <Styled.ButtonContainer>
+        <Styled.Confirm onClick={confirm}>{confirmText}</Styled.Confirm>
+        <Styled.Cancel onClick={cancel}>{cancelText}</Styled.Cancel>
+      </Styled.ButtonContainer>
+    </Styled.Container>
+  );
+};
+
+export default Prompt;

--- a/frontend/src/components/Prompt/index.tsx
+++ b/frontend/src/components/Prompt/index.tsx
@@ -32,7 +32,7 @@ const Prompt = ({
   };
 
   const hide = () => {
-    localStorage.setItem(`${name}_propmt`, 'hide');
+    localStorage.setItem(`${name}_prompt`, 'hide');
     setVisible(false);
   };
 

--- a/frontend/src/constants/localStorage.ts
+++ b/frontend/src/constants/localStorage.ts
@@ -1,4 +1,5 @@
 export const STORAGE_KEY = {
   ACCESS_TOKEN: 'accessToken',
   REFRESH_TOKEN: 'refreshToken',
+  INSTALL_PROMPT_HIDE: 'installPromptHide',
 };

--- a/frontend/src/constants/localStorage.ts
+++ b/frontend/src/constants/localStorage.ts
@@ -1,5 +1,4 @@
 export const STORAGE_KEY = {
   ACCESS_TOKEN: 'accessToken',
   REFRESH_TOKEN: 'refreshToken',
-  INSTALL_PROMPT_HIDE: 'installPromptHide',
 };

--- a/frontend/src/constants/snackbar.ts
+++ b/frontend/src/constants/snackbar.ts
@@ -20,6 +20,7 @@ const SNACKBAR_MESSAGE = {
   NOT_LOGIN: '로그인이 필요한 서비스입니다.',
   ALREADY_LOGIN: '이미 로그인하였습니다.',
   LARGE_IMAGE: '이미지 크기가 너무 큽니다.',
+  FAIL_INSTALL: '이미 설치했거나, 다운로드가 불가능한 환경입니다.',
 };
 
 export default SNACKBAR_MESSAGE;

--- a/frontend/src/hooks/useInstallApp.ts
+++ b/frontend/src/hooks/useInstallApp.ts
@@ -1,14 +1,28 @@
-// @ts-nocheck
 import { useState, useEffect, useRef } from 'react';
 
 import useSnackbar from '@/hooks/useSnackbar';
 
 import SNACKBAR_MESSAGE from '@/constants/snackbar';
 
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: Array<string>;
+  readonly userChoice: Promise<{
+    outcome: 'accepted' | 'dismissed';
+    platform: string;
+  }>;
+  prompt(): Promise<void>;
+}
+
+declare global {
+  interface WindowEventMap {
+    beforeinstallprompt: BeforeInstallPromptEvent;
+  }
+}
+
 const useInstallApp = () => {
   const { showSnackbar } = useSnackbar();
   const [installable, setInstallable] = useState(false);
-  const deferredPrompt = useRef(null);
+  const deferredPrompt = useRef<BeforeInstallPromptEvent | null>(null);
 
   useEffect(() => {
     window.addEventListener('beforeinstallprompt', e => {

--- a/frontend/src/hooks/useInstallApp.ts
+++ b/frontend/src/hooks/useInstallApp.ts
@@ -26,6 +26,7 @@ const useInstallApp = () => {
     }
 
     deferredPrompt.current.prompt();
+    setInstallable(false);
   };
 
   return { installable, setInstallable, installApp };

--- a/frontend/src/hooks/useInstallApp.ts
+++ b/frontend/src/hooks/useInstallApp.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+import { useState, useEffect, useRef } from 'react';
+
+import useSnackbar from '@/hooks/useSnackbar';
+
+import SNACKBAR_MESSAGE from '@/constants/snackbar';
+
+const useInstallApp = () => {
+  const { showSnackbar } = useSnackbar();
+  const [installable, setInstallable] = useState(false);
+  const deferredPrompt = useRef(null);
+
+  useEffect(() => {
+    window.addEventListener('beforeinstallprompt', e => {
+      e.preventDefault();
+      deferredPrompt.current = e;
+      setInstallable(!!deferredPrompt.current);
+    });
+  }, []);
+
+  const installApp = () => {
+    if (!deferredPrompt.current) {
+      showSnackbar(SNACKBAR_MESSAGE.FAIL_INSTALL);
+      setInstallable(false);
+      return;
+    }
+
+    deferredPrompt.current.prompt();
+  };
+
+  return { installable, setInstallable, installApp };
+};
+
+export default useInstallApp;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -27,7 +27,7 @@ if (process.env.MODE === 'LOCAL:MSW') {
   worker.start();
 }
 
-if ('serviceWorker' in navigator) {
+if (process.env.MODE !== 'LOCAL:MSW' && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker
       .register('/service-worker.js')

--- a/frontend/webpack/webpack.config.js
+++ b/frontend/webpack/webpack.config.js
@@ -2,8 +2,6 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { ESBuildMinifyPlugin } = require('esbuild-loader');
 const { DefinePlugin } = require('webpack');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
-const WorkboxPlugin = require('workbox-webpack-plugin');
 
 module.exports = {
   mode: 'development',
@@ -63,13 +61,6 @@ module.exports = {
     }),
     new DefinePlugin({
       'process.env.IMAGE_API_URL': JSON.stringify('https://img.sokdaksokdak.com/images/'),
-    }),
-    new CopyWebpackPlugin({
-      patterns: [{ from: './public/icons', to: './icons' }, './public/manifest.json'],
-    }),
-    new WorkboxPlugin.GenerateSW({
-      clientsClaim: true,
-      skipWaiting: true,
     }),
   ],
   devtool: 'source-map',

--- a/frontend/webpack/webpack.dev.js
+++ b/frontend/webpack/webpack.dev.js
@@ -2,6 +2,8 @@ const { merge } = require('webpack-merge');
 const common = require('./webpack.config.js');
 const { DefinePlugin } = require('webpack');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const WorkboxPlugin = require('workbox-webpack-plugin');
 
 module.exports = merge(common, {
   mode: 'production',
@@ -14,6 +16,13 @@ module.exports = merge(common, {
       openAnalyzer: false,
       analyzerMode: 'static',
       reportFilename: 'bundle-analyzer.html',
+    }),
+    new CopyWebpackPlugin({
+      patterns: [{ from: './public/icons', to: './icons' }, './public/manifest.json'],
+    }),
+    new WorkboxPlugin.GenerateSW({
+      clientsClaim: true,
+      skipWaiting: true,
     }),
   ],
 });

--- a/frontend/webpack/webpack.prod.js
+++ b/frontend/webpack/webpack.prod.js
@@ -1,6 +1,8 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.config.js');
 const { DefinePlugin } = require('webpack');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const WorkboxPlugin = require('workbox-webpack-plugin');
 
 module.exports = merge(common, {
   mode: 'production',
@@ -8,6 +10,13 @@ module.exports = merge(common, {
     new DefinePlugin({
       'process.env.API_URL': JSON.stringify('https://was.sokdaksokdak.com'),
       'process.env.MODE': JSON.stringify('production'),
+    }),
+    new CopyWebpackPlugin({
+      patterns: [{ from: './public/icons', to: './icons' }, './public/manifest.json'],
+    }),
+    new WorkboxPlugin.GenerateSW({
+      clientsClaim: true,
+      skipWaiting: true,
     }),
   ],
 });


### PR DESCRIPTION
### 구현기능

사용자들이 손쉽게 PWA를 이용할 수 있도록 사용성을 보강한다.

<img width="300" alt="스크린샷 2022-09-30 오후 4 22 38" src="https://user-images.githubusercontent.com/52737532/193214219-1bc86497-1ee1-4b1c-8279-beb7195ea87b.png">

### 세부 구현기능

- [x] 앱이 설치되어 있지 않다면 prompt를 띄워서 앱 설치를 유도한다. 
  - [x] `다시 보지 않기` 버튼을 만들어 앱 기능을 사용하고 싶지 않은 사용자도 불편함을 느끼지 않도록 한다. (localStorage 사용) 
  - [x] 클릭 이벤트를 등록해 prompt outside를 클릭하면 prompt가 닫히도록 한다. 
- [x] 상단바, 배경화면 색을 속닥속닥 컬러와 어울리게 변경한다. (menifest.json)

### 관련 이슈

- 현재 반응형 기능 개발 이후, 디자인에 대해 좀 더 고민하고 수정하겠습니다! 
- `beforeinstallprompt` 이벤트가 현재 비표준으로, type이 존재하지 않아 `// @ts-nocheck`를 해주었습니다. (hooks/useInstallApp.ts)
- 개발 환경에서 service worker를 register할 경우 cache 관련 오류가 발생하여 구글링한 결과, 개발 환경에서는 등록을 하지 않는다고 합니당. 이런 이유로 개발환경에서는 PWA를 제외시켰습니다. 현재 개발 환경에서 테스트 해볼 경우 prompt가 나타나고, 사라지는 것만 확인 가능하며 설치는 불가능합니다. - [fix: 개발 환경에서 PWA 제외](https://github.com/woowacourse-teams/2022-sokdak/commit/360e08ac92c72b5f450744cea4ae9bb5b41a0e68), [fix: 개발 환경 서비스 워커 등록 제거](https://github.com/woowacourse-teams/2022-sokdak/commit/dca4691fb4f385b45530f634ee1470a637f75d2b)

close #593 
