### PR TITLE
refactor: Auth에 있던 인증/회원가입 관련 기능 분리

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketElement.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketElement.java
@@ -1,6 +1,6 @@
 package com.wooteco.sokdak.admin.dto;
 
-import com.wooteco.sokdak.auth.domain.Ticket;
+import com.wooteco.sokdak.ticket.domain.Ticket;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketRequest.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/TicketRequest.java
@@ -1,6 +1,6 @@
 package com.wooteco.sokdak.admin.dto;
 
-import com.wooteco.sokdak.auth.domain.Ticket;
+import com.wooteco.sokdak.ticket.domain.Ticket;
 import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
@@ -7,7 +7,7 @@ import com.wooteco.sokdak.admin.dto.TicketElement;
 import com.wooteco.sokdak.admin.dto.TicketRequest;
 import com.wooteco.sokdak.admin.dto.TicketsResponse;
 import com.wooteco.sokdak.admin.exception.NoAdminException;
-import com.wooteco.sokdak.auth.domain.Ticket;
+import com.wooteco.sokdak.ticket.domain.Ticket;
 import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.auth.service.Encryptor;
 import com.wooteco.sokdak.member.domain.Member;

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/controller/AuthController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/controller/AuthController.java
@@ -46,12 +46,6 @@ public class AuthController {
                 .build();
     }
 
-    @PostMapping("members/signup/email/verification")
-    public ResponseEntity<Void> verifyAuthCode(@Valid @RequestBody VerificationRequest verificationRequest) {
-        authService.verifyAuthCode(verificationRequest);
-        return ResponseEntity.noContent().build();
-    }
-
     @GetMapping("/refresh")
     public ResponseEntity<Void> refresh(HttpServletRequest request, @Login AuthInfo authInfo) {
         validateExistHeader(request);

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/service/AuthService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.wooteco.sokdak.auth.service;
 
-import com.wooteco.sokdak.auth.domain.AuthCode;
-import com.wooteco.sokdak.auth.domain.Ticket;
+import com.wooteco.sokdak.ticket.domain.AuthCode;
+import com.wooteco.sokdak.ticket.domain.Ticket;
 import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.auth.dto.LoginRequest;
 import com.wooteco.sokdak.auth.exception.LoginFailedException;
@@ -21,18 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
 
-    private final AuthCodeRepository authCodeRepository;
     private final MemberRepository memberRepository;
-    private final TicketRepository ticketRepository;
-    private final Clock clock;
 
     public AuthService(AuthCodeRepository authCodeRepository,
                        MemberRepository memberRepository,
                        TicketRepository ticketRepository, Clock clock) {
-        this.authCodeRepository = authCodeRepository;
         this.memberRepository = memberRepository;
-        this.ticketRepository = ticketRepository;
-        this.clock = clock;
     }
 
     public AuthInfo login(LoginRequest loginRequest) {
@@ -41,42 +35,5 @@ public class AuthService {
         Member member = memberRepository.findByUsernameValueAndPasswordValue(username, password)
                 .orElseThrow(LoginFailedException::new);
         return new AuthInfo(member.getId(), member.getRoleType().getName(), member.getNickname());
-    }
-
-    @Transactional
-    public void useTicket(String email) {
-        String serialNumber = Encryptor.encrypt(email);
-        Ticket ticket = ticketRepository.findBySerialNumber(serialNumber)
-                .orElseThrow(SerialNumberNotFoundException::new);
-        ticket.use();
-    }
-
-    public void verifyAuthCode(VerificationRequest verificationRequest) {
-        String serialNumber = Encryptor.encrypt(verificationRequest.getEmail());
-        AuthCode authCode = authCodeRepository.findBySerialNumber(serialNumber)
-                .orElseThrow(SerialNumberNotFoundException::new);
-        authCode.verify(verificationRequest.getCode());
-        LocalDateTime now = LocalDateTime.now(clock);
-        authCode.verifyTime(now);
-    }
-
-    public void validateSignUpMember(String serialNumber) {
-        validateQualified(serialNumber);
-        validateNewMember(serialNumber);
-    }
-
-    public void validateQualified(String serialNumber) {
-        boolean exist = ticketRepository.existsBySerialNumber(serialNumber);
-        if (!exist) {
-            throw new NotWootecoMemberException();
-        }
-    }
-
-    private void validateNewMember(String serialNumber) {
-        Ticket ticket = ticketRepository.findBySerialNumber(serialNumber)
-                .orElseThrow(NotWootecoMemberException::new);
-        if (ticket.isUsed()) {
-            throw new TicketUsedException();
-        }
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/repository/AuthCodeRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/repository/AuthCodeRepository.java
@@ -1,6 +1,6 @@
 package com.wooteco.sokdak.member.repository;
 
-import com.wooteco.sokdak.auth.domain.AuthCode;
+import com.wooteco.sokdak.ticket.domain.AuthCode;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/repository/TicketRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/repository/TicketRepository.java
@@ -1,6 +1,6 @@
 package com.wooteco.sokdak.member.repository;
 
-import com.wooteco.sokdak.auth.domain.Ticket;
+import com.wooteco.sokdak.ticket.domain.Ticket;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/service/EmailService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/service/EmailService.java
@@ -1,12 +1,12 @@
 package com.wooteco.sokdak.member.service;
 
-import com.wooteco.sokdak.auth.domain.AuthCode;
+import com.wooteco.sokdak.ticket.domain.AuthCode;
 import com.wooteco.sokdak.auth.service.AuthCodeGenerator;
 import com.wooteco.sokdak.auth.service.AuthService;
 import com.wooteco.sokdak.auth.service.Encryptor;
 import com.wooteco.sokdak.member.dto.EmailRequest;
-import com.wooteco.sokdak.member.dto.VerificationRequest;
 import com.wooteco.sokdak.member.repository.AuthCodeRepository;
+import com.wooteco.sokdak.ticket.service.RegisterService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,21 +17,25 @@ public class EmailService {
     private final AuthCodeGenerator authCodeGenerator;
     private final EmailSender emailSender;
     private final AuthService authService;
+    private final RegisterService registerService;
     private final AuthCodeRepository authCodeRepository;
 
 
     public EmailService(AuthCodeGenerator authCodeGenerator,
-                        AuthService authService, EmailSender emailSender, AuthCodeRepository authCodeRepository) {
+                        AuthService authService, EmailSender emailSender,
+                        RegisterService registerService,
+                        AuthCodeRepository authCodeRepository) {
         this.authCodeGenerator = authCodeGenerator;
         this.authService = authService;
         this.emailSender = emailSender;
+        this.registerService = registerService;
         this.authCodeRepository = authCodeRepository;
     }
 
     @Transactional
     public void sendCodeToValidUser(EmailRequest emailRequest) {
         String serialNumber = Encryptor.encrypt(emailRequest.getEmail());
-        authService.validateSignUpMember(serialNumber);
+        registerService.validateSignUpMember(serialNumber);
 
         String authCode = createAndSaveAuthCode(serialNumber);
         sendEmail(emailRequest, authCode);

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/service/MemberService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/service/MemberService.java
@@ -15,6 +15,7 @@ import com.wooteco.sokdak.member.repository.MemberRepository;
 import com.wooteco.sokdak.member.dto.NicknameResponse;
 import com.wooteco.sokdak.member.dto.NicknameUpdateRequest;
 import com.wooteco.sokdak.member.exception.DuplicateNicknameException;
+import com.wooteco.sokdak.ticket.service.RegisterService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,12 +26,14 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final EmailService emailService;
     private final AuthService authService;
+    private final RegisterService registerService;
 
     public MemberService(MemberRepository memberRepository, EmailService emailService,
-                         AuthService authService) {
+                         AuthService authService, RegisterService registerService) {
         this.memberRepository = memberRepository;
         this.emailService = emailService;
         this.authService = authService;
+        this.registerService = registerService;
     }
 
     public UniqueResponse checkUniqueUsername(String username) {
@@ -54,7 +57,7 @@ public class MemberService {
                 .nickname(signupRequest.getNickname())
                 .build();
         memberRepository.save(member);
-        authService.useTicket(signupRequest.getEmail());
+        registerService.useTicket(signupRequest.getEmail());
     }
 
     private void validate(SignupRequest signupRequest) {
@@ -84,12 +87,12 @@ public class MemberService {
     private void validateAuthCode(SignupRequest signupRequest) {
         VerificationRequest verificationRequest = new VerificationRequest(
                 signupRequest.getEmail(), signupRequest.getCode());
-        authService.verifyAuthCode(verificationRequest);
+        registerService.verifyAuthCode(verificationRequest);
     }
 
     private void validateSerialNumber(SignupRequest signupRequest) {
         String serialNumber = Encryptor.encrypt(signupRequest.getEmail());
-        authService.validateSignUpMember(serialNumber);
+        registerService.validateSignUpMember(serialNumber);
     }
 
     private void confirmPassword(String password, String passwordConfirmation) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/ticket/controller/RegisterController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/ticket/controller/RegisterController.java
@@ -1,0 +1,25 @@
+package com.wooteco.sokdak.ticket.controller;
+
+import com.wooteco.sokdak.member.dto.VerificationRequest;
+import com.wooteco.sokdak.ticket.service.RegisterService;
+import javax.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RegisterController {
+
+    private final RegisterService registerService;
+
+    public RegisterController(RegisterService registerService) {
+        this.registerService = registerService;
+    }
+
+    @PostMapping("members/signup/email/verification")
+    public ResponseEntity<Void> verifyAuthCode(@Valid @RequestBody VerificationRequest verificationRequest) {
+        registerService.verifyAuthCode(verificationRequest);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/ticket/domain/AuthCode.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/ticket/domain/AuthCode.java
@@ -1,4 +1,4 @@
-package com.wooteco.sokdak.auth.domain;
+package com.wooteco.sokdak.ticket.domain;
 
 import com.wooteco.sokdak.member.exception.InvalidAuthCodeException;
 import java.time.LocalDateTime;

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/ticket/domain/Ticket.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/ticket/domain/Ticket.java
@@ -1,4 +1,4 @@
-package com.wooteco.sokdak.auth.domain;
+package com.wooteco.sokdak.ticket.domain;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/ticket/service/RegisterService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/ticket/service/RegisterService.java
@@ -1,0 +1,67 @@
+package com.wooteco.sokdak.ticket.service;
+
+import com.wooteco.sokdak.auth.service.Encryptor;
+import com.wooteco.sokdak.member.dto.VerificationRequest;
+import com.wooteco.sokdak.member.exception.NotWootecoMemberException;
+import com.wooteco.sokdak.member.exception.SerialNumberNotFoundException;
+import com.wooteco.sokdak.member.exception.TicketUsedException;
+import com.wooteco.sokdak.member.repository.AuthCodeRepository;
+import com.wooteco.sokdak.member.repository.TicketRepository;
+import com.wooteco.sokdak.ticket.domain.AuthCode;
+import com.wooteco.sokdak.ticket.domain.Ticket;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RegisterService {
+
+    private final TicketRepository ticketRepository;
+    private final AuthCodeRepository authCodeRepository;
+    private final Clock clock;
+
+    public RegisterService(TicketRepository ticketRepository,
+                           AuthCodeRepository authCodeRepository, Clock clock) {
+        this.ticketRepository = ticketRepository;
+        this.authCodeRepository = authCodeRepository;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public void useTicket(String email) {
+        String serialNumber = Encryptor.encrypt(email);
+        Ticket ticket = ticketRepository.findBySerialNumber(serialNumber)
+                .orElseThrow(SerialNumberNotFoundException::new);
+        ticket.use();
+    }
+
+    public void verifyAuthCode(VerificationRequest verificationRequest) {
+        String serialNumber = Encryptor.encrypt(verificationRequest.getEmail());
+        AuthCode authCode = authCodeRepository.findBySerialNumber(serialNumber)
+                .orElseThrow(SerialNumberNotFoundException::new);
+        authCode.verify(verificationRequest.getCode());
+        LocalDateTime now = LocalDateTime.now(clock);
+        authCode.verifyTime(now);
+    }
+
+    public void validateSignUpMember(String serialNumber) {
+        validateQualified(serialNumber);
+        validateNewMember(serialNumber);
+    }
+
+    public void validateQualified(String serialNumber) {
+        boolean exist = ticketRepository.existsBySerialNumber(serialNumber);
+        if (!exist) {
+            throw new NotWootecoMemberException();
+        }
+    }
+
+    private void validateNewMember(String serialNumber) {
+        Ticket ticket = ticketRepository.findBySerialNumber(serialNumber)
+                .orElseThrow(NotWootecoMemberException::new);
+        if (ticket.isUsed()) {
+            throw new TicketUsedException();
+        }
+    }
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/service/AdminServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/service/AdminServiceTest.java
@@ -11,7 +11,7 @@ import com.wooteco.sokdak.admin.dto.PostReportsResponse;
 import com.wooteco.sokdak.admin.dto.TicketRequest;
 import com.wooteco.sokdak.admin.dto.TicketsResponse;
 import com.wooteco.sokdak.admin.exception.NoAdminException;
-import com.wooteco.sokdak.auth.domain.Ticket;
+import com.wooteco.sokdak.ticket.domain.Ticket;
 import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.board.domain.Board;
 import com.wooteco.sokdak.board.domain.PostBoard;

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/acceptance/AuthAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/acceptance/AuthAcceptanceTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
-import com.wooteco.sokdak.auth.domain.AuthCode;
+import com.wooteco.sokdak.ticket.domain.AuthCode;
 import com.wooteco.sokdak.auth.service.Encryptor;
 import com.wooteco.sokdak.member.dto.VerificationRequest;
 import com.wooteco.sokdak.member.repository.AuthCodeRepository;

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/controller/AuthControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/controller/AuthControllerTest.java
@@ -87,23 +87,4 @@ class AuthControllerTest extends ControllerTest {
                 .apply(document("refresh/success"))
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
-
-    @DisplayName("인증코드가 일치하지 않거나 만료되었으면 400 반환")
-    @Test
-    void verifyAuthCode_Exception_different() {
-        VerificationRequest verificationRequest = new VerificationRequest("test@gmail.com", "a1b2c3");
-        doThrow(new InvalidAuthCodeException())
-                .when(authService)
-                .verifyAuthCode(any());
-
-        restDocs
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(verificationRequest)
-                .when().post("/members/signup/email/verification")
-                .then().log().all()
-                .assertThat()
-                .body("message", equalTo("잘못된 인증번호입니다."))
-                .apply(document("member/verification/fail"))
-                .statusCode(HttpStatus.BAD_REQUEST.value());
-    }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/domain/AuthCodeTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/domain/AuthCodeTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.wooteco.sokdak.member.exception.InvalidAuthCodeException;
 import com.wooteco.sokdak.member.repository.AuthCodeRepository;
+import com.wooteco.sokdak.ticket.domain.AuthCode;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/service/AuthServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/service/AuthServiceTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.doReturn;
 
-import com.wooteco.sokdak.auth.domain.AuthCode;
+import com.wooteco.sokdak.ticket.domain.AuthCode;
 import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.auth.exception.LoginFailedException;
 import com.wooteco.sokdak.member.dto.VerificationRequest;
@@ -25,18 +25,8 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 
 class AuthServiceTest extends ServiceTest {
 
-    private static final String EMAIL = "test@gmail.com";
-    private static final String AUTH_CODE = "ABCDEF";
-    private static final Clock FUTURE_CLOCK = Clock.fixed(Instant.parse("3333-08-22T10:00:00Z"), ZoneOffset.UTC);
-
     @Autowired
     private AuthService authService;
-
-    @Autowired
-    private AuthCodeRepository authCodeRepository;
-
-    @SpyBean
-    private Clock clock;
 
     @DisplayName("로그인 기능")
     @Test
@@ -51,64 +41,5 @@ class AuthServiceTest extends ServiceTest {
     void login_Exception() {
         assertThatThrownBy(() -> authService.login(INVALID_LOGIN_REQUEST))
                 .isInstanceOf(LoginFailedException.class);
-    }
-
-    @DisplayName("인증번호 만료 여부 검증 기능")
-    @Test
-    void verifyAuthCode() {
-        AuthCode authCode = AuthCode.builder()
-                .code(AUTH_CODE)
-                .serialNumber(Encryptor.encrypt(EMAIL))
-                .build();
-        authCodeRepository.save(authCode);
-
-        VerificationRequest verificationRequest = new VerificationRequest(EMAIL, AUTH_CODE);
-        assertDoesNotThrow(() -> authService.verifyAuthCode(verificationRequest));
-    }
-
-    @DisplayName("잘못된 인증번호일 시 예외 발생")
-    @Test
-    void verifyAuthCode_Exception_WrongAuthCode() {
-        AuthCode authCode = AuthCode.builder()
-                .code(AUTH_CODE)
-                .serialNumber(Encryptor.encrypt(EMAIL))
-                .build();
-        authCodeRepository.save(authCode);
-
-        VerificationRequest verificationRequest = new VerificationRequest(EMAIL, "NONONO");
-        assertThatThrownBy(() -> authService.verifyAuthCode(verificationRequest))
-                .isInstanceOf(InvalidAuthCodeException.class);
-    }
-
-    @DisplayName("인증번호와 이메일이 매칭되지 않을 시 예외 발생")
-    @Test
-    void verifyAuthCode_Exception_WrongEmail() {
-        AuthCode authCode = AuthCode.builder()
-                .code(AUTH_CODE)
-                .serialNumber(Encryptor.encrypt(EMAIL))
-                .build();
-        authCodeRepository.save(authCode);
-
-        VerificationRequest verificationRequest = new VerificationRequest("wrong@gmail.com", AUTH_CODE);
-        assertThatThrownBy(() -> authService.verifyAuthCode(verificationRequest))
-                .isInstanceOf(SerialNumberNotFoundException.class);
-    }
-
-    @DisplayName("인증번호 만료 시 예외 발생")
-    @Test
-    void verifyAuthCode_Exception_Expired() {
-        AuthCode authCode = AuthCode.builder()
-                .code(AUTH_CODE)
-                .serialNumber(Encryptor.encrypt(EMAIL))
-                .build();
-        authCodeRepository.save(authCode);
-
-        doReturn(Instant.now(FUTURE_CLOCK))
-                .when(clock)
-                .instant();
-
-        VerificationRequest verificationRequest = new VerificationRequest(EMAIL, AUTH_CODE);
-        assertThatThrownBy(() -> authService.verifyAuthCode(verificationRequest))
-                .isInstanceOf(InvalidAuthCodeException.class);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/member/controller/MemberControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/member/controller/MemberControllerTest.java
@@ -83,21 +83,6 @@ class MemberControllerTest extends ControllerTest {
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
-    @DisplayName("인증코드가 일치하면 204 반환")
-    @Test
-    void verifyAuthCode() {
-        VerificationRequest verificationRequest = new VerificationRequest("test@gmail.com", "a1b2c3");
-
-        restDocs
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(verificationRequest)
-                .when().post("/members/signup/email/verification")
-                .then().log().all()
-                .assertThat()
-                .apply(document("member/verification/success"))
-                .statusCode(HttpStatus.NO_CONTENT.value());
-    }
-
     @DisplayName("아이디가 중복되지 않으면 true 반환")
     @Test
     void validateUniqueUsername_true() {

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/member/service/EmailServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/member/service/EmailServiceTest.java
@@ -4,7 +4,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.wooteco.sokdak.auth.domain.Ticket;
+import com.wooteco.sokdak.ticket.domain.Ticket;
 import com.wooteco.sokdak.auth.service.AuthCodeGenerator;
 import com.wooteco.sokdak.auth.service.Encryptor;
 import com.wooteco.sokdak.member.dto.EmailRequest;

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/member/service/MemberServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/member/service/MemberServiceTest.java
@@ -3,7 +3,7 @@ package com.wooteco.sokdak.member.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.wooteco.sokdak.auth.domain.AuthCode;
+import com.wooteco.sokdak.ticket.domain.AuthCode;
 import com.wooteco.sokdak.auth.service.Encryptor;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.dto.NicknameUpdateRequest;

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/support/token/JwtTokenProviderTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/support/token/JwtTokenProviderTest.java
@@ -1,12 +1,9 @@
 package com.wooteco.sokdak.support.token;
 
 import static com.wooteco.sokdak.member.domain.RoleType.USER;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.wooteco.sokdak.auth.dto.AuthInfo;
-import com.wooteco.sokdak.member.domain.RoleType;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/ticket/controller/RegisterControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/ticket/controller/RegisterControllerTest.java
@@ -1,0 +1,52 @@
+package com.wooteco.sokdak.ticket.controller;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+
+import com.wooteco.sokdak.member.dto.VerificationRequest;
+import com.wooteco.sokdak.member.exception.InvalidAuthCodeException;
+import com.wooteco.sokdak.util.ControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class RegisterControllerTest extends ControllerTest {
+
+    @DisplayName("인증코드가 일치하면 204 반환")
+    @Test
+    void verifyAuthCode() {
+        VerificationRequest verificationRequest = new VerificationRequest("test@gmail.com", "a1b2c3");
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(verificationRequest)
+                .when().post("/members/signup/email/verification")
+                .then().log().all()
+                .assertThat()
+                .apply(document("member/verification/success"))
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @DisplayName("인증코드가 일치하지 않거나 만료되었으면 400 반환")
+    @Test
+    void verifyAuthCode_Exception_different() {
+        VerificationRequest verificationRequest = new VerificationRequest("test@gmail.com", "a1b2c3");
+        doThrow(new InvalidAuthCodeException())
+                .when(registerService)
+                .verifyAuthCode(any());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(verificationRequest)
+                .when().post("/members/signup/email/verification")
+                .then().log().all()
+                .assertThat()
+                .body("message", equalTo("잘못된 인증번호입니다."))
+                .apply(document("member/verification/fail"))
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/ticket/service/RegisterServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/ticket/service/RegisterServiceTest.java
@@ -1,0 +1,95 @@
+package com.wooteco.sokdak.ticket.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doReturn;
+
+import com.wooteco.sokdak.auth.service.Encryptor;
+import com.wooteco.sokdak.member.dto.VerificationRequest;
+import com.wooteco.sokdak.member.exception.InvalidAuthCodeException;
+import com.wooteco.sokdak.member.exception.SerialNumberNotFoundException;
+import com.wooteco.sokdak.member.repository.AuthCodeRepository;
+import com.wooteco.sokdak.ticket.domain.AuthCode;
+import com.wooteco.sokdak.util.ServiceTest;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+class RegisterServiceTest extends ServiceTest {
+
+    private static final String EMAIL = "test@gmail.com";
+    private static final String AUTH_CODE = "ABCDEF";
+    private static final Clock FUTURE_CLOCK = Clock.fixed(Instant.parse("3333-08-22T10:00:00Z"), ZoneOffset.UTC);
+
+    @Autowired
+    private RegisterService registerService;
+
+    @Autowired
+    private AuthCodeRepository authCodeRepository;
+
+    @SpyBean
+    private Clock clock;
+
+    @DisplayName("인증번호 만료 여부 검증 기능")
+    @Test
+    void verifyAuthCode() {
+        AuthCode authCode = AuthCode.builder()
+                .code(AUTH_CODE)
+                .serialNumber(Encryptor.encrypt(EMAIL))
+                .build();
+        authCodeRepository.save(authCode);
+
+        VerificationRequest verificationRequest = new VerificationRequest(EMAIL, AUTH_CODE);
+        assertDoesNotThrow(() -> registerService.verifyAuthCode(verificationRequest));
+    }
+
+    @DisplayName("잘못된 인증번호일 시 예외 발생")
+    @Test
+    void verifyAuthCode_Exception_WrongAuthCode() {
+        AuthCode authCode = AuthCode.builder()
+                .code(AUTH_CODE)
+                .serialNumber(Encryptor.encrypt(EMAIL))
+                .build();
+        authCodeRepository.save(authCode);
+
+        VerificationRequest verificationRequest = new VerificationRequest(EMAIL, "NONONO");
+        assertThatThrownBy(() -> registerService.verifyAuthCode(verificationRequest))
+                .isInstanceOf(InvalidAuthCodeException.class);
+    }
+
+    @DisplayName("인증번호와 이메일이 매칭되지 않을 시 예외 발생")
+    @Test
+    void verifyAuthCode_Exception_WrongEmail() {
+        AuthCode authCode = AuthCode.builder()
+                .code(AUTH_CODE)
+                .serialNumber(Encryptor.encrypt(EMAIL))
+                .build();
+        authCodeRepository.save(authCode);
+
+        VerificationRequest verificationRequest = new VerificationRequest("wrong@gmail.com", AUTH_CODE);
+        assertThatThrownBy(() -> registerService.verifyAuthCode(verificationRequest))
+                .isInstanceOf(SerialNumberNotFoundException.class);
+    }
+
+    @DisplayName("인증번호 만료 시 예외 발생")
+    @Test
+    void verifyAuthCode_Exception_Expired() {
+        AuthCode authCode = AuthCode.builder()
+                .code(AUTH_CODE)
+                .serialNumber(Encryptor.encrypt(EMAIL))
+                .build();
+        authCodeRepository.save(authCode);
+
+        doReturn(Instant.now(FUTURE_CLOCK))
+                .when(clock)
+                .instant();
+
+        VerificationRequest verificationRequest = new VerificationRequest(EMAIL, AUTH_CODE);
+        assertThatThrownBy(() -> registerService.verifyAuthCode(verificationRequest))
+                .isInstanceOf(InvalidAuthCodeException.class);
+    }
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/ControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/ControllerTest.java
@@ -33,6 +33,8 @@ import com.wooteco.sokdak.report.service.PostReportService;
 import com.wooteco.sokdak.support.AuthInterceptor;
 import com.wooteco.sokdak.support.token.AuthenticationPrincipalArgumentResolver;
 import com.wooteco.sokdak.support.token.TokenManager;
+import com.wooteco.sokdak.ticket.controller.RegisterController;
+import com.wooteco.sokdak.ticket.service.RegisterService;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,7 +58,8 @@ import org.springframework.web.context.WebApplicationContext;
         HashtagController.class,
         NotificationController.class,
         HashtagController.class,
-        AdminController.class
+        AdminController.class,
+        RegisterController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 public class ControllerTest {
@@ -98,6 +101,9 @@ public class ControllerTest {
 
     @MockBean
     protected NotificationService notificationService;
+
+    @MockBean
+    protected RegisterService registerService;
 
     @MockBean
     protected TokenManager tokenManager;


### PR DESCRIPTION
### 구현기능
Auth에 있던 인증/회원가입 관련 기능 분리

### 세부 구현기능
회원가입에 사용하는 인증코드 검사/티켓 사용은 ticket 패키지 하위의 RegisterController에서 처리하게 하였습니다. 패키지명을 Register로 할까하다가 우선 팀에서 회원가입할 때 ticket을 공통적으로 인지하고 있어 ticket으로 했습니다. 