### PR TITLE
fix: 좋아요가 초기화되는 문제 해결

### DIFF
--- a/frontend/src/hooks/queries/likes/useLike.ts
+++ b/frontend/src/hooks/queries/likes/useLike.ts
@@ -20,7 +20,7 @@ const useLike = (
     {
       ...options,
       onSuccess: (data, variables, context) => {
-        queryClient.refetchQueries(QUERY_KEYS.POSTS);
+        queryClient.invalidateQueries(QUERY_KEYS.POST);
 
         if (options && options.onSuccess) {
           options.onSuccess(data, variables, context);

--- a/frontend/src/pages/PostPage/components/PostHeader/index.tsx
+++ b/frontend/src/pages/PostPage/components/PostHeader/index.tsx
@@ -26,13 +26,14 @@ interface PostHeaderProps {
     hashtags: Omit<Hashtag, 'count'>[];
     authorized: boolean;
     nickname: string;
+    like: boolean;
+    likeCount: number;
   };
-  like: { isLiked: boolean; likeCount: number };
   onClickDeleteButton: () => void;
   onClickLikeButton: () => void;
 }
 
-const PostHeader = ({ post, like, onClickDeleteButton, onClickLikeButton }: PostHeaderProps) => {
+const PostHeader = ({ post, onClickDeleteButton, onClickLikeButton }: PostHeaderProps) => {
   const navigate = useNavigate();
   const { showSnackbar } = useContext(SnackbarContext);
   const [isReportModalOpen, handleReportModal] = useReducer(state => !state, false);
@@ -84,7 +85,7 @@ const PostHeader = ({ post, like, onClickDeleteButton, onClickLikeButton }: Post
         <Styled.Date>{timeConverter(post.createdAt)}</Styled.Date>
       </Styled.PostInfo>
       <Styled.LikeButtonContainer>
-        <LikeButton {...like} onClick={onClickLikeButton} />
+        <LikeButton isLiked={post.like} likeCount={post.likeCount} onClick={onClickLikeButton} />
       </Styled.LikeButtonContainer>
       <ReportModal isModalOpen={isReportModalOpen} onClose={handleReportModal} submitReport={handleSubmitReport} />
     </Styled.HeadContainer>

--- a/frontend/src/pages/PostPage/index.tsx
+++ b/frontend/src/pages/PostPage/index.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useState } from 'react';
+import { useReducer } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import CommentList from './components/CommentList';
@@ -19,30 +19,16 @@ import PATH from '@/constants/path';
 const PostPage = () => {
   const navigate = useNavigate();
   const { id } = useParams();
-
-  const [like, setLike] = useState({
-    isLiked: true,
-    likeCount: 0,
-  });
-
   const [isConfirmModalOpen, handleConfirmModal] = useReducer(state => !state, false);
+
   const { data, isLoading, isError } = usePost({
     storeCode: id!,
     options: {
-      onSuccess: data => {
-        setLike({ isLiked: data.like, likeCount: data.likeCount });
-      },
       staleTime: 1000 * 20,
     },
   });
   const hasImage = !!(data && data.imageName !== '');
-
-  const { mutate: putLike } = useLike({
-    onSuccess: data => {
-      setLike({ isLiked: data.data.like, likeCount: data.data.likeCount });
-    },
-  });
-
+  const { mutate: putLike } = useLike({});
   const { mutate: deletePost } = useDeletePost({
     onSuccess: () => {
       handleConfirmModal();
@@ -95,12 +81,7 @@ const PostPage = () => {
   return (
     <Layout>
       <Styled.Container>
-        <PostHeader
-          post={data!}
-          like={like}
-          onClickDeleteButton={handleConfirmModal}
-          onClickLikeButton={handleLikeButton}
-        />
+        <PostHeader post={data!} onClickDeleteButton={handleConfirmModal} onClickLikeButton={handleLikeButton} />
         {hasImage && <Styled.Image src={process.env.IMAGE_API_URL + data.imageName} alt={data.imageName} />}
         <PostContent content={data?.content!} hashtags={data?.hashtags!} hasImage={hasImage} />
         <CommentList id={id!} />


### PR DESCRIPTION
### 구현기능

좋아요 수가 0개로 표시되는 버그를 해결한다. 

> 버그 시나리오
> 
> 1. 특정 게시물 페이지에 들어간다.
> 2. 페이지를 나갔다가 다시 페이지에 들어간다. 
> 3. 좋아요 수가 0개로 초기화된다.

### 세부 구현기능

- [x] state로 관리하던 like를 삭제한다. 

### 관련 이슈

close #604 
