### PR TITLE
fix: native 쿼리의 테이블명(Notification)을 notification으로 수정

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    @Query(value = "SELECT EXISTS (SELECT * FROM Notification WHERE member_id = :memberId AND inquired = false)",
+    @Query(value = "SELECT EXISTS (SELECT * FROM notification WHERE member_id = :memberId AND inquired = false)",
             nativeQuery = true)
     boolean existsByMemberIdAndInquiredIsFalse(Long memberId);
 


### PR DESCRIPTION
### 구현기능
native 쿼리의 테이블명(Notification)을 notification으로 수정
