### PR TITLE
refactor: 좋아요 기능에서의 불필요한 쿼리 삭제

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
@@ -15,6 +15,7 @@ import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -37,25 +38,25 @@ public class Comment {
     @Column(name = "comment_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Comment parent;
 
     @OneToMany(mappedBy = "parent")
     private List<Comment> children = new ArrayList<>();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 
     @OneToMany(mappedBy = "comment")
     private List<CommentReport> commentReports = new ArrayList<>();
 
-    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<CommentLike> commentLikes = new ArrayList<>();
 
     private String nickname;

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
@@ -2,10 +2,10 @@ package com.wooteco.sokdak.comment.domain;
 
 import com.wooteco.sokdak.auth.exception.AuthorizationException;
 import com.wooteco.sokdak.like.domain.CommentLike;
+import com.wooteco.sokdak.like.exception.CommentLikeNotFoundException;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.report.domain.CommentReport;
-import com.wooteco.sokdak.report.exception.AlreadyReportCommentException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -162,10 +162,6 @@ public class Comment {
         return commentReports;
     }
 
-    public List<CommentLike> getCommentLikes() {
-        return commentLikes;
-    }
-
     public int getCommentLikesCount() {
         return commentLikes.size();
     }
@@ -188,5 +184,22 @@ public class Comment {
 
     public boolean hasNoReply() {
         return children.isEmpty();
+    }
+
+    public boolean hasLikeOfMember(Long memberId) {
+        return commentLikes.stream()
+                .anyMatch(commentLike -> commentLike.isLikeOf(memberId));
+    }
+
+    public void addCommentLike(CommentLike commentLike) {
+        commentLikes.add(commentLike);
+    }
+
+    public void deleteLikeOfMember(Long memberId) {
+        CommentLike commentLike = commentLikes.stream()
+                .filter(it -> it.isLikeOf(memberId))
+                .findAny()
+                .orElseThrow(CommentLikeNotFoundException::new);
+        commentLikes.remove(commentLike);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/repository/CommentRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/repository/CommentRepository.java
@@ -25,6 +25,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     void deleteAllByPost(Post post);
 
-    @Query(value = "SELECT c FROM Comment c LEFT JOIN FETCH c.commentReports cr LEFT JOIN FETCH cr.reporter WHERE c.id = :commentId")
+    @Query(value = "SELECT c FROM Comment c LEFT JOIN FETCH c.commentReports cr LEFT JOIN FETCH cr.reporter "
+            + "LEFT JOIN FETCH c.commentLikes WHERE c.id = :commentId")
     Optional<Comment> findByCommentId(@Param("commentId") Long commentId);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/repository/CommentRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/repository/CommentRepository.java
@@ -25,7 +25,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     void deleteAllByPost(Post post);
 
-    @Query(value = "SELECT c FROM Comment c LEFT JOIN FETCH c.commentReports cr LEFT JOIN FETCH cr.reporter "
-            + "LEFT JOIN FETCH c.commentLikes WHERE c.id = :commentId")
+    @Query(value = "SELECT c FROM Comment c LEFT JOIN FETCH c.commentReports cr LEFT JOIN FETCH cr.reporter WHERE c.id = :commentId")
     Optional<Comment> findByCommentId(@Param("commentId") Long commentId);
+
+    @Query(value = "SELECT c FROM Comment c LEFT JOIN FETCH c.commentLikes cl LEFT JOIN FETCH cl.member WHERE c.id = :id")
+    Optional<Comment> findByIdForCommentLike(Long id);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/service/CommentService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/service/CommentService.java
@@ -135,7 +135,7 @@ public class CommentService {
     }
 
     public CommentsResponse findComments(Long postId, AuthInfo authInfo) {
-        final List<Comment> comments = commentRepository.findCommentsByPostId(postId);
+        List<Comment> comments = commentRepository.findCommentsByPostId(postId);
         List<CommentResponse> commentResponses = comments.stream()
                 .map(it -> convertToCommentResponse(authInfo, it))
                 .collect(Collectors.toList());

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/domain/CommentLike.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/domain/CommentLike.java
@@ -36,10 +36,10 @@ public class CommentLike {
     private CommentLike(Comment comment, Member member) {
         this.comment = comment;
         this.member = member;
+        comment.addCommentLike(this);
     }
 
-    public void addComment(Comment comment) {
-        this.comment = comment;
-        comment.getCommentLikes().add(this);
+    public boolean isLikeOf(Long memberId) {
+        return member.hasId(memberId);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/domain/CommentLike.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/domain/CommentLike.java
@@ -11,8 +11,10 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Entity(name = "comment_likes")
 public class CommentLike {
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/domain/CommentLike.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/domain/CommentLike.java
@@ -11,10 +11,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Entity(name = "comment_likes")
 public class CommentLike {
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/domain/PostLike.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/domain/PostLike.java
@@ -36,10 +36,10 @@ public class PostLike {
     private PostLike(Post post, Member member) {
         this.post = post;
         this.member = member;
+        post.addPostLike(this);
     }
 
-    public void addPost(Post post) {
-        this.post = post;
-        post.getPostLikes().add(this);
+    public boolean isLikeOf(Long memberId) {
+        return member.hasId(memberId);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/exception/CommentLikeNotFoundException.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/exception/CommentLikeNotFoundException.java
@@ -1,0 +1,10 @@
+package com.wooteco.sokdak.like.exception;
+
+public class CommentLikeNotFoundException extends RuntimeException {
+
+    private static final String MESSAGE = "해당 회원이 누른 좋아요가 존재하지 않습니다.";
+
+    public CommentLikeNotFoundException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/exception/CommentLikeNotFoundException.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/exception/CommentLikeNotFoundException.java
@@ -1,6 +1,8 @@
 package com.wooteco.sokdak.like.exception;
 
-public class CommentLikeNotFoundException extends RuntimeException {
+import com.wooteco.sokdak.advice.NotFoundException;
+
+public class CommentLikeNotFoundException extends NotFoundException {
 
     private static final String MESSAGE = "해당 회원이 누른 좋아요가 존재하지 않습니다.";
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/exception/PostLikeNotFoundException.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/exception/PostLikeNotFoundException.java
@@ -1,0 +1,12 @@
+package com.wooteco.sokdak.like.exception;
+
+import com.wooteco.sokdak.advice.NotFoundException;
+
+public class PostLikeNotFoundException extends NotFoundException {
+
+    private static final String MESSAGE = "해당 회원이 누른 좋아요가 존재하지 않습니다.";
+
+    public PostLikeNotFoundException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/repository/PostLikeRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/repository/PostLikeRepository.java
@@ -1,18 +1,10 @@
 package com.wooteco.sokdak.like.repository;
 
 import com.wooteco.sokdak.like.domain.PostLike;
-import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.post.domain.Post;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
-
-    Optional<PostLike> findByMemberAndPost(Member member, Post post);
-
-    int countByPost(Post post);
-
-    boolean existsByMemberIdAndPostId(Long memberId, Long postId);
 
     void deleteAllByPost(Post post);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -5,12 +5,12 @@ import com.wooteco.sokdak.board.domain.PostBoard;
 import com.wooteco.sokdak.comment.domain.Comment;
 import com.wooteco.sokdak.hashtag.domain.PostHashtag;
 import com.wooteco.sokdak.like.domain.PostLike;
+import com.wooteco.sokdak.like.exception.PostLikeNotFoundException;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.report.domain.PostReport;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import com.wooteco.sokdak.board.domain.Board;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -149,6 +149,11 @@ public class Post {
         return content.getValue();
     }
 
+    public boolean hasLikeOfMember(Long memberId) {
+        return postLikes.stream()
+                .anyMatch(postLike -> postLike.isLikeOf(memberId));
+    }
+
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }
@@ -204,5 +209,17 @@ public class Post {
 
     public void deleteAllReports() {
         postReports = new ArrayList<>();
+    }
+
+    public void addPostLike(PostLike postLike) {
+        postLikes.add(postLike);
+    }
+
+    public void deleteLikeOfMember(Long memberId) {
+        PostLike postLike = postLikes.stream()
+                .filter(it -> it.isLikeOf(memberId))
+                .findAny()
+                .orElseThrow(PostLikeNotFoundException::new);
+        postLikes.remove(postLike);
     }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -54,7 +54,7 @@ public class Post {
 
     private String imageName;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<PostLike> postLikes = new ArrayList<>();
 
     @OneToMany(mappedBy = "post")

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/repository/PostRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/repository/PostRepository.java
@@ -2,13 +2,18 @@ package com.wooteco.sokdak.post.repository;
 
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.post.domain.Post;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findPostsByMemberOrderByCreatedAtDesc(Pageable pageable, Member member);
+
+    @Query(value = "SELECT p FROM Post p LEFT JOIN FETCH p.postLikes WHERE p.id = :id")
+    Optional<Post> findById(Long id);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -93,7 +93,7 @@ public class PostService {
     public PostDetailResponse findPost(Long postId, AuthInfo authInfo) {
         Post foundPost = findPostObject(postId);
         Board writableBoard = foundPost.getWritableBoard();
-        boolean liked = postLikeRepository.existsByMemberIdAndPostId(authInfo.getId(), postId);
+        boolean liked = foundPost.hasLikeOfMember(authInfo.getId());
         Hashtags hashtags = hashtagService.findHashtagsByPost(foundPost);
 
         return PostDetailResponse.of(foundPost, writableBoard, liked,

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/domain/CommentTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/domain/CommentTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.wooteco.sokdak.auth.exception.AuthorizationException;
+import com.wooteco.sokdak.like.domain.CommentLike;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.report.domain.CommentReport;
@@ -167,5 +168,19 @@ class CommentTest {
                 Arguments.of(reporter, reporter, true),
                 Arguments.of(reporter, member, false)
         );
+    }
+
+    @DisplayName("특정 멤버가 누른 좋아요가 있는지 반환한다.")
+    @ParameterizedTest
+    @CsvSource({"1, true", "2, false"})
+    void hasLikeOfMember(Long memberId, boolean expected) {
+        CommentLike.builder()
+                .member(member)
+                .comment(comment)
+                .build();
+
+        boolean actual = comment.hasLikeOfMember(memberId);
+
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/like/acceptance/LikeAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/like/acceptance/LikeAcceptanceTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-class PostLikeAcceptanceTest extends AcceptanceTest {
+class LikeAcceptanceTest extends AcceptanceTest {
 
     @DisplayName("로그인한 회원은 좋아요 하지 않은 게시물에 좋아요를 할 수 있다.")
     @Test

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/like/domain/CommentLikeTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/like/domain/CommentLikeTest.java
@@ -1,0 +1,39 @@
+package com.wooteco.sokdak.like.domain;
+
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_NICKNAME;
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_PASSWORD;
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_USERNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wooteco.sokdak.comment.domain.Comment;
+import com.wooteco.sokdak.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class CommentLikeTest {
+
+    @DisplayName("특정 회원이 누른 댓글 좋아요인지 반환한다.")
+    @ParameterizedTest
+    @CsvSource({"1, true", "2, false"})
+    void isLikeOf(Long memberId, boolean expected) {
+        Comment comment = Comment.builder()
+                .nickname(VALID_NICKNAME)
+                .message("댓글")
+                .build();
+        Member member = Member.builder()
+                .id(1L)
+                .username(VALID_USERNAME)
+                .password(VALID_PASSWORD)
+                .nickname(VALID_NICKNAME)
+                .build();
+        CommentLike commentLike = CommentLike.builder()
+                .member(member)
+                .comment(comment)
+                .build();
+
+        boolean actual = commentLike.isLikeOf(memberId);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/like/domain/PostLikeTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/like/domain/PostLikeTest.java
@@ -1,0 +1,45 @@
+package com.wooteco.sokdak.like.domain;
+
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_NICKNAME;
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_PASSWORD;
+import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_USERNAME;
+import static com.wooteco.sokdak.util.fixture.PostFixture.VALID_POST_CONTENT;
+import static com.wooteco.sokdak.util.fixture.PostFixture.VALID_POST_TITLE;
+import static com.wooteco.sokdak.util.fixture.PostFixture.VALID_POST_WRITER_NICKNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wooteco.sokdak.member.domain.Member;
+import com.wooteco.sokdak.post.domain.Post;
+import java.util.ArrayList;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class PostLikeTest {
+
+    @DisplayName("특정 회원이 누른 게시글 좋아요인지 반환한다.")
+    @ParameterizedTest
+    @CsvSource({"1, true", "2, false"})
+    void isLikeOf(Long memberId, boolean expected) {
+        Post post = Post.builder()
+                .title(VALID_POST_TITLE)
+                .content(VALID_POST_CONTENT)
+                .postLikes(new ArrayList<>())
+                .writerNickname(VALID_POST_WRITER_NICKNAME)
+                .build();
+        Member member = Member.builder()
+                .id(1L)
+                .username(VALID_USERNAME)
+                .password(VALID_PASSWORD)
+                .nickname(VALID_NICKNAME)
+                .build();
+        PostLike postLike = PostLike.builder()
+                .post(post)
+                .member(member)
+                .build();
+
+        boolean actual = postLike.isLikeOf(memberId);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
@@ -94,17 +94,16 @@ class LikeServiceTest extends ServiceTest {
         likeService.flipPostLike(post.getId(), AUTH_INFO, likeFlipRequest);
         entityManager.flush();
         entityManager.clear();
-        likeService.flipPostLike(post.getId(), AUTH_INFO, likeFlipRequest);
 
-        LikeFlipResponse putLikeResponse2 = likeService.flipPostLike(post.getId(), AUTH_INFO, likeFlipRequest);
+        LikeFlipResponse putLikeResponse = likeService.flipPostLike(post.getId(), AUTH_INFO, likeFlipRequest);
 
         entityManager.flush();
         entityManager.clear();
         Post foundPost = postRepository.findById(post.getId())
                 .orElseThrow(PostNotFoundException::new);
         assertAll(
-                () -> assertThat(putLikeResponse2.isLike()).isFalse(),
-                () -> assertThat(putLikeResponse2.getLikeCount()).isZero(),
+                () -> assertThat(putLikeResponse.isLike()).isFalse(),
+                () -> assertThat(putLikeResponse.getLikeCount()).isZero(),
                 () -> assertThat(foundPost.hasLikeOfMember(member.getId())).isFalse()
         );
     }
@@ -130,6 +129,8 @@ class LikeServiceTest extends ServiceTest {
     void flipCommentLike_delete() {
         LikeFlipRequest likeFlipRequest = new LikeFlipRequest(FREE_BOARD_ID);
         likeService.flipCommentLike(comment.getId(), AUTH_INFO, likeFlipRequest);
+        entityManager.flush();
+        entityManager.clear();
 
         LikeFlipResponse likeFlipResponse = likeService.flipCommentLike(comment.getId(), AUTH_INFO, likeFlipRequest);
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
@@ -12,11 +12,13 @@ import com.wooteco.sokdak.auth.exception.AuthorizationException;
 import com.wooteco.sokdak.comment.domain.Comment;
 import com.wooteco.sokdak.comment.dto.CommentResponse;
 import com.wooteco.sokdak.comment.dto.ReplyResponse;
+import com.wooteco.sokdak.comment.exception.CommentNotFoundException;
 import com.wooteco.sokdak.comment.repository.CommentRepository;
 import com.wooteco.sokdak.comment.service.CommentService;
 import com.wooteco.sokdak.like.dto.LikeFlipRequest;
 import com.wooteco.sokdak.like.dto.LikeFlipResponse;
 import com.wooteco.sokdak.post.domain.Post;
+import com.wooteco.sokdak.post.exception.PostNotFoundException;
 import com.wooteco.sokdak.post.repository.PostRepository;
 import com.wooteco.sokdak.util.ServiceTest;
 import java.util.List;
@@ -74,9 +76,14 @@ class LikeServiceTest extends ServiceTest {
         LikeFlipResponse putLikeResponse = likeService.flipPostLike(post.getId(), AUTH_INFO, new LikeFlipRequest(
                 FREE_BOARD_ID));
 
+        entityManager.flush();
+        entityManager.clear();
+        Post foundPost = postRepository.findById(post.getId())
+                .orElseThrow(PostNotFoundException::new);
         assertAll(
                 () -> assertThat(putLikeResponse.isLike()).isTrue(),
-                () -> assertThat(putLikeResponse.getLikeCount()).isEqualTo(1)
+                () -> assertThat(putLikeResponse.getLikeCount()).isEqualTo(1),
+                () -> assertThat(foundPost.hasLikeOfMember(member.getId())).isTrue()
         );
     }
 
@@ -85,12 +92,20 @@ class LikeServiceTest extends ServiceTest {
     void flipPostLike_delete() {
         LikeFlipRequest likeFlipRequest = new LikeFlipRequest(FREE_BOARD_ID);
         likeService.flipPostLike(post.getId(), AUTH_INFO, likeFlipRequest);
+        entityManager.flush();
+        entityManager.clear();
+        likeService.flipPostLike(post.getId(), AUTH_INFO, likeFlipRequest);
 
         LikeFlipResponse putLikeResponse2 = likeService.flipPostLike(post.getId(), AUTH_INFO, likeFlipRequest);
 
+        entityManager.flush();
+        entityManager.clear();
+        Post foundPost = postRepository.findById(post.getId())
+                .orElseThrow(PostNotFoundException::new);
         assertAll(
                 () -> assertThat(putLikeResponse2.isLike()).isFalse(),
-                () -> assertThat(putLikeResponse2.getLikeCount()).isZero()
+                () -> assertThat(putLikeResponse2.getLikeCount()).isZero(),
+                () -> assertThat(foundPost.hasLikeOfMember(member.getId())).isFalse()
         );
     }
 
@@ -99,9 +114,14 @@ class LikeServiceTest extends ServiceTest {
     void flipCommentLike_create() {
         LikeFlipResponse likeFlipResponse = likeService.flipCommentLike(comment.getId(), AUTH_INFO, new LikeFlipRequest(FREE_BOARD_ID));
 
+        entityManager.flush();
+        entityManager.clear();
+        Comment foundComment = commentRepository.findById(comment.getId())
+                .orElseThrow(CommentNotFoundException::new);
         assertAll(
                 () -> assertThat(likeFlipResponse.isLike()).isTrue(),
-                () -> assertThat(likeFlipResponse.getLikeCount()).isEqualTo(1)
+                () -> assertThat(likeFlipResponse.getLikeCount()).isEqualTo(1),
+                () -> assertThat(foundComment.hasLikeOfMember(member.getId())).isTrue()
         );
     }
 
@@ -113,9 +133,14 @@ class LikeServiceTest extends ServiceTest {
 
         LikeFlipResponse likeFlipResponse = likeService.flipCommentLike(comment.getId(), AUTH_INFO, likeFlipRequest);
 
+        entityManager.flush();
+        entityManager.clear();
+        Comment foundComment = commentRepository.findById(comment.getId())
+                .orElseThrow(CommentNotFoundException::new);
         assertAll(
                 () -> assertThat(likeFlipResponse.isLike()).isFalse(),
-                () -> assertThat(likeFlipResponse.getLikeCount()).isZero()
+                () -> assertThat(likeFlipResponse.getLikeCount()).isZero(),
+                () -> assertThat(foundComment.hasLikeOfMember(member.getId())).isFalse()
         );
     }
 
@@ -147,9 +172,14 @@ class LikeServiceTest extends ServiceTest {
     void flipCommentLike_ReplyCreate() {
         LikeFlipResponse likeFlipResponse = likeService.flipCommentLike(reply.getId(), AUTH_INFO, new LikeFlipRequest(FREE_BOARD_ID));
 
+        entityManager.flush();
+        entityManager.clear();
+        Comment foundReply = commentRepository.findById(reply.getId())
+                .orElseThrow(CommentNotFoundException::new);
         assertAll(
                 () -> assertThat(likeFlipResponse.isLike()).isTrue(),
-                () -> assertThat(likeFlipResponse.getLikeCount()).isEqualTo(1)
+                () -> assertThat(likeFlipResponse.getLikeCount()).isEqualTo(1),
+                () -> assertThat(foundReply.hasLikeOfMember(member.getId())).isTrue()
         );
     }
 
@@ -161,9 +191,12 @@ class LikeServiceTest extends ServiceTest {
 
         LikeFlipResponse likeFlipResponse = likeService.flipCommentLike(reply.getId(), AUTH_INFO, likeFlipRequest);
 
+        entityManager.flush();
+        entityManager.clear();
         assertAll(
                 () -> assertThat(likeFlipResponse.isLike()).isFalse(),
-                () -> assertThat(likeFlipResponse.getLikeCount()).isZero()
+                () -> assertThat(likeFlipResponse.getLikeCount()).isZero(),
+                () -> assertThat(reply.hasLikeOfMember(member.getId())).isFalse()
         );
     }
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
@@ -20,6 +20,8 @@ import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.repository.PostRepository;
 import com.wooteco.sokdak.util.ServiceTest;
 import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,9 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 class LikeServiceTest extends ServiceTest {
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     @Autowired
     private LikeService likeService;
@@ -60,6 +65,7 @@ class LikeServiceTest extends ServiceTest {
         commentRepository.save(comment);
         reply = Comment.child(member, post, "닉네임2", "대댓글", comment);
         commentRepository.save(reply);
+        entityManager.clear();
     }
 
     @DisplayName("게시글 좋아요 등록")

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
@@ -14,9 +14,11 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.wooteco.sokdak.board.domain.Board;
 import com.wooteco.sokdak.board.domain.PostBoard;
+import com.wooteco.sokdak.like.domain.PostLike;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.report.domain.PostReport;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +47,7 @@ class PostTest {
         post = Post.builder()
                 .title(VALID_POST_TITLE)
                 .content(VALID_POST_CONTENT)
+                .postLikes(new ArrayList<>())
                 .writerNickname(VALID_POST_WRITER_NICKNAME)
                 .member(member)
                 .build();
@@ -200,6 +203,32 @@ class PostTest {
         post.addReport(postReport);
 
         assertThat(post.hasReportByMember(member)).isEqualTo(expected);
+    }
+
+    @DisplayName("게시글에 특정 멤버가 좋아요를 눌렀는지 반환한다.")
+    @ParameterizedTest
+    @CsvSource({"1, true", "2, false"})
+    void hasLikeOfMember(Long memberId, boolean expected) {
+        PostLike.builder()
+                .post(post)
+                .member(member)
+                .build();
+        boolean actual = post.hasLikeOfMember(memberId);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @DisplayName("게시글에 특정 멤버의 좋아요를 삭제한다.")
+    @Test
+    void deleteLikeOfMember() {
+        PostLike.builder()
+                .post(post)
+                .member(member)
+                .build();
+
+        post.deleteLikeOfMember(member.getId());
+
+        assertThat(post.hasLikeOfMember(member.getId())).isFalse();
     }
 
     static Stream<Arguments> hasReportByMemberArguments() {

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/LikeFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/LikeFixture.java
@@ -1,0 +1,10 @@
+package com.wooteco.sokdak.util.fixture;
+
+import static com.wooteco.sokdak.util.fixture.BoardFixture.FREE_BOARD_ID;
+
+import com.wooteco.sokdak.like.dto.LikeFlipRequest;
+
+public class LikeFixture {
+
+    public static final LikeFlipRequest LIKE_FLIP_REQUEST = new LikeFlipRequest(FREE_BOARD_ID);
+}


### PR DESCRIPTION
### 구현기능
좋아요 기능에서의 불필요한 쿼리 삭제

### 세부 구현기능
Post는 PostLike와,  Comment는 CommentLike와 연관 관계를 맺고 있는데, Post와 Comment에게 메시지를 통해 값을 조회하지 않고 query를 실행하여 값을 조회했던 로직 -> query 실행이 아닌, Post와 Comment의 메서드로 처리하도록 수정


