### PR TITLE
fix: findNotifications의 @Transactional readOnly 옵션 제거

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
@@ -78,6 +78,7 @@ public class NotificationService {
                 notificationRepository.existsByMemberIdAndInquiredIsFalse(authInfo.getId()));
     }
 
+    @Transactional
     public NotificationsResponse findNotifications(AuthInfo authInfo, Pageable pageable) {
         Slice<Notification> foundNotifications = notificationRepository
                 .findNotificationsByMemberId(authInfo.getId(), pageable);


### PR DESCRIPTION
### 구현기능
findNotifications의 @Transactional readOnly 옵션 제거
