### PR TITLE
feat: 글 상세 페이지 데스크탑 사이즈 구현 

### DIFF
--- a/frontend/src/components/CheckBox/index.styles.ts
+++ b/frontend/src/components/CheckBox/index.styles.ts
@@ -22,7 +22,7 @@ export const HiddenCheckBox = styled.input`
 
   :checked + ${CheckBox}::after {
     content: '✔';
-    font-size: 11px;
+    font-size: 0.68rem;
     color: ${props => props.theme.colors.sub};
     position: absolute;
     top: 50%;
@@ -33,6 +33,10 @@ export const HiddenCheckBox = styled.input`
 
 export const Label = styled.span`
   display: block;
-  font-size: 12px;
+  font-size: 0.75rem;
   color: ${props => props.theme.colors.gray_200};
+
+  @media (min-width: 875px) {
+    font-size: 0.8rem;
+  }
 `;

--- a/frontend/src/components/LikeButton/index.styles.ts
+++ b/frontend/src/components/LikeButton/index.styles.ts
@@ -10,6 +10,10 @@ export const Button = styled.button<{ isLiked: boolean }>`
   border: 1px solid ${props => (props.isLiked ? props.theme.colors.pink_300 : props.theme.colors.gray_300)};
   gap: 4px;
   background-color: inherit;
-  font-size: 13px;
+  font-size: 0.7rem;
   color: ${props => (props.isLiked ? props.theme.colors.pink_300 : props.theme.colors.gray_300)};
+
+  @media (min-width: 875px) {
+    font-size: 0.8rem;
+  }
 `;

--- a/frontend/src/dummy.ts
+++ b/frontend/src/dummy.ts
@@ -832,3 +832,11 @@ export const notificationList: NoticeTable[] = [
     postId: 7,
   },
 ];
+
+export const AD = [
+  { name: '5기 모집 시작!', url: 'https://woowacourse.github.io/about.html' },
+  { name: '면담은 터놓고 🙊', url: 'https://ternoko.site' },
+  { name: '면담은 티타임 ☕️', url: 'https://teatime.pe.kr/' },
+  { name: '회고는 회고덕 🐤', url: 'https://ducks.kr/' },
+  { name: '레벨인터뷰는 레벨로그 ✏️', url: 'https://levellog.app/' },
+];

--- a/frontend/src/hooks/useThrottle.ts
+++ b/frontend/src/hooks/useThrottle.ts
@@ -1,18 +1,18 @@
-import { useState } from 'react';
+import { useRef } from 'react';
 
 const useThrottle = (callback: (...input: unknown[]) => unknown, delay: number) => {
-  const [timerID, setTimerID] = useState<NodeJS.Timer | null>(null);
+  const timerID = useRef<NodeJS.Timeout | null>();
 
   return function () {
-    if (timerID) {
+    if (timerID.current) {
       return;
     }
+
     callback();
-    setTimerID(
-      setTimeout(() => {
-        setTimerID(null);
-      }, delay),
-    );
+
+    timerID.current = setTimeout(() => {
+      timerID.current = null;
+    }, delay);
   };
 };
 

--- a/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.styles.ts
@@ -1,4 +1,4 @@
-import { keyframes } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
 const leaveComment = keyframes`
@@ -11,11 +11,17 @@ const leaveComment = keyframes`
 `;
 
 export const Container = styled.div`
-  width: calc(100%-1em);
-  padding: 1em 0.5em;
+  width: 100%;
+  padding: 1.8em 15px;
   border-top: 0.5px solid ${props => props.theme.colors.gray_150};
   background-color: white;
   animation: ${leaveComment} 0.7s;
+  font-size: 10px;
+  box-sizing: border-box;
+
+  @media (min-width: 875px) {
+    font-size: 13px;
+  }
 `;
 
 export const EmptyComment = styled.div`
@@ -24,9 +30,13 @@ export const EmptyComment = styled.div`
   border-bottom: 0.5px solid ${props => props.theme.colors.gray_150};
   margin-bottom: -0.5px;
   cursor: default;
-  padding: 3.5em 0.5em;
+  padding: 3.5rem 0.5rem;
   color: ${props => props.theme.colors.gray_200};
-  font-size: 12px;
+  font-size: 0.75rem;
+
+  @media (min-width: 875px) {
+    font-size: 0.975rem;
+  }
 `;
 
 export const CommentHeader = styled.div`
@@ -34,30 +44,34 @@ export const CommentHeader = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1em;
+  margin-bottom: 1rem;
 `;
 
 export const ButtonContainer = styled.div``;
 
-export const ReplyButton = styled.button`
+const buttonStyle = css`
   background-color: transparent;
+  font-size: 1em;
+`;
+
+export const ReplyButton = styled.button`
+  ${buttonStyle};
   color: ${props => props.theme.colors.gray_200};
-  font-size: 0.6rem;
 `;
 
 export const DeleteButton = styled.button`
-  background-color: transparent;
+  ${buttonStyle};
   color: ${props => props.theme.colors.red_200};
-  font-size: 0.6rem;
 `;
 
 export const ReportButton = styled.button`
-  background-color: transparent;
+  ${buttonStyle};
 `;
 
 export const Nickname = styled.p`
   font-weight: bold;
   display: flex;
+  font-size: 1.3em;
 `;
 
 export const PostWriter = styled.span`
@@ -69,7 +83,7 @@ export const PostWriter = styled.span`
 `;
 
 export const Content = styled.p`
-  font-size: 12px;
+  font-size: 1.2em;
   line-height: 1.3;
   white-space: pre-wrap;
 `;
@@ -77,7 +91,7 @@ export const Content = styled.p`
 export const Date = styled.p`
   color: ${props => props.theme.colors.gray_200};
   margin: 10px 0;
-  font-size: 10px;
+  font-size: 1em;
 `;
 
 export const Footer = styled.div`
@@ -89,10 +103,10 @@ export const Footer = styled.div`
 export const LikeContainer = styled.button<{ isLiked: boolean }>`
   display: flex;
   color: ${props => props.theme.colors.pink_300};
-  font-size: 0.7rem;
+  font-size: 1em;
   justify-content: flex-end;
   align-items: center;
-  gap: 0.5em;
+  gap: 0.5rem;
   background-color: transparent;
   color: ${props => (props.isLiked ? props.theme.colors.pink_300 : props.theme.colors.gray_300)};
 `;

--- a/frontend/src/pages/PostPage/components/CommentBox/index.tsx
+++ b/frontend/src/pages/PostPage/components/CommentBox/index.tsx
@@ -81,6 +81,12 @@ const CommentBox = ({
     likeComment({ id });
   };
 
+  useEffect(() => {
+    if (openedFormId !== id) {
+      setIsReplyFormOpen(false);
+    }
+  }, [openedFormId]);
+
   if (!content) {
     return <Styled.EmptyComment>작성자에 의해 삭제된 댓글 입니다.</Styled.EmptyComment>;
   }
@@ -88,12 +94,6 @@ const CommentBox = ({
   if (blocked) {
     return <Styled.EmptyComment>신고에 의해 블라인드 처리되었습니다.</Styled.EmptyComment>;
   }
-
-  useEffect(() => {
-    if (openedFormId !== id) {
-      setIsReplyFormOpen(false);
-    }
-  }, [openedFormId]);
 
   return (
     <>

--- a/frontend/src/pages/PostPage/components/CommentInput/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/CommentInput/index.styles.ts
@@ -29,12 +29,11 @@ export const Label = styled.label`
 `;
 
 export const SubmitButton = styled.button`
-  height: 3rem;
+  height: 2.5rem;
   padding: 0.8em 1.2rem;
   float: right;
-  font-size: 1rem;
+  font-size: 0.9rem;
   background-color: ${props => props.theme.colors.sub};
   color: white;
-  font-family: 'BMHANNAAir', 'Noto Sans KR';
-  border-radius: 8px;
+  border-radius: 3px;
 `;

--- a/frontend/src/pages/PostPage/components/PostHeader/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/PostHeader/index.styles.ts
@@ -15,10 +15,14 @@ export const TitleContainer = styled.div`
 `;
 
 export const Title = styled.p`
-  font-size: 24px;
+  font-size: 1.3rem;
+  line-height: 1.6em;
   font-family: 'BMHANNAPro', 'Noto Sans KR';
   word-break: keep-all;
-  line-height: 30px;
+
+  @media (min-width: 875px) {
+    font-size: 2rem;
+  }
 `;
 
 export const PostController = styled.div`
@@ -28,11 +32,15 @@ export const PostController = styled.div`
 `;
 
 const controllerButton = (props: { theme: Theme }) => css`
-  font-size: 10px;
+  font-size: 0.7rem;
   background-color: transparent;
   color: ${props.theme.colors.gray_200};
   width: fit-content;
   padding: 5px;
+
+  @media (min-width: 875px) {
+    font-size: 0.8rem;
+  }
 `;
 
 export const UpdateButton = styled.button`
@@ -46,6 +54,7 @@ export const DeleteButton = styled.button`
 `;
 
 export const ReportButton = styled.button`
+  ${controllerButton};
   background-color: inherit;
 `;
 
@@ -59,13 +68,21 @@ export const PostInfo = styled.div`
 export const Author = styled.span`
   font-size: 14px;
   font-family: 'BMHANNAPro', 'Noto Sans KR';
+
+  @media (min-width: 875px) {
+    font-size: 1.1rem;
+  }
 `;
 
 export const Date = styled.span`
-  min-width: 80px;
+  width: fit-content;
   text-align: right;
-  font-size: 10px;
+  font-size: 0.6rem;
   color: ${props => props.theme.colors.gray_200};
+
+  @media (min-width: 875px) {
+    font-size: 0.8rem;
+  }
 `;
 
 export const LikeButtonContainer = styled.div`

--- a/frontend/src/pages/PostPage/components/ReplyForm/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/ReplyForm/index.styles.ts
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const Form = styled.form`
@@ -6,10 +7,11 @@ export const Form = styled.form`
   background-color: ${props => props.theme.colors.gray_5};
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
   box-sizing: border-box;
   margin-bottom: -0.5px;
   z-index: 5;
+  font-size: 0.75rem;
 `;
 
 export const Input = styled.textarea`
@@ -20,7 +22,7 @@ export const Input = styled.textarea`
   box-sizing: border-box;
 
   ::placeholder {
-    font-size: 12px;
+    font-size: 0.9em;
   }
 `;
 
@@ -37,25 +39,30 @@ export const ButtonContainer = styled.div`
   display: flex;
 `;
 
-export const CancelButton = styled.button`
-  width: 60px;
-  height: 24px;
-  background-color: transparent;
-  color: ${props => props.theme.colors.sub};
+const buttonStyle = css`
+  width: 3.75rem;
+  height: 1.5rem;
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 11px;
+  font-size: 0.68rem;
+  border-radius: 3px;
+
+  @media (min-width: 875px) {
+    font-size: 0.8rem;
+    width: 4.75rem;
+    height: 1.8rem;
+  }
+`;
+
+export const CancelButton = styled.button`
+  ${buttonStyle};
+  background-color: transparent;
+  color: ${props => props.theme.colors.sub};
 `;
 
 export const SubmitButton = styled.button`
-  width: 60px;
-  height: 24px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 11px;
+  ${buttonStyle};
   background-color: ${props => props.theme.colors.sub};
   color: white;
-  border-radius: 3px;
 `;

--- a/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.styles.ts
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div<{ position: number }>`
+  display: flex;
+  flex-direction: column;
+  width: 30%;
+  right: 0;
+  box-sizing: border-box;
+  position: absolute;
+  transform: ${({ position }) => `translateY(${position}px);`};
+  transition: all 0.2s ease;
+  gap: 30px;
+`;

--- a/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.tsx
+++ b/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.tsx
@@ -1,0 +1,24 @@
+import { HTMLAttributes, PropsWithChildren, useEffect, useState } from 'react';
+
+import useThrottle from '@/hooks/useThrottle';
+
+import * as Styled from './index.styles';
+
+const SidebarContainer = ({ children, className }: PropsWithChildren<HTMLAttributes<HTMLDivElement>>) => {
+  const [position, setPosition] = useState(document.documentElement.scrollTop);
+  const moveSidebar = useThrottle(() => setPosition(document.documentElement.scrollTop), 50);
+
+  useEffect(() => {
+    window.addEventListener('scroll', moveSidebar);
+
+    return () => window.removeEventListener('scroll', moveSidebar);
+  }, []);
+
+  return (
+    <Styled.Container position={position} className={className}>
+      {children}
+    </Styled.Container>
+  );
+};
+
+export default SidebarContainer;

--- a/frontend/src/pages/PostPage/components/Sidebar/index.stories.tsx
+++ b/frontend/src/pages/PostPage/components/Sidebar/index.stories.tsx
@@ -1,0 +1,27 @@
+import { withRouter } from 'storybook-addon-react-router-v6';
+
+import Sidebar from '.';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Pages/PostPage/Sidebar',
+  component: Sidebar,
+  decorators: [withRouter],
+} as ComponentMeta<typeof Sidebar>;
+
+const Template: ComponentStory<typeof Sidebar> = args => <Sidebar {...args} />;
+
+export const SidebarTemplate: ComponentStory<typeof Sidebar> = Template.bind({});
+SidebarTemplate.args = {
+  title: '실시간 인기글',
+  items: [
+    {
+      name: '위니, 앨버랑 노는중 ~',
+      url: '',
+    },
+    {
+      name: '너무 재밌당 ~~',
+      url: '',
+    },
+  ],
+};

--- a/frontend/src/pages/PostPage/components/Sidebar/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/Sidebar/index.styles.ts
@@ -1,0 +1,53 @@
+import { Link } from 'react-router-dom';
+
+import { css, Theme } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const Container = styled.div<{ position: number }>`
+  display: flex;
+  width: 100%;
+  height: 300px;
+  border: 1px solid ${props => props.theme.colors.gray_400};
+  padding: 30px;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: absolute;
+  transform: ${({ position }) => `translateY(${position}px);`};
+  transition: all 0.2s ease;
+  background-color: white;
+`;
+
+export const Title = styled.h1`
+  font-size: 24px;
+  font-family: 'BMHANNAPro', 'Noto Sans KR';
+  margin-bottom: 20px;
+`;
+
+export const Items = styled.ul`
+  list-style-type: disc;
+  list-style-position: inside;
+  margin-top: 10px;
+`;
+
+export const Item = styled.li`
+  margin: 15px 0;
+`;
+
+const linkStyle = (props: { theme: Theme }) => css`
+  cursor: pointer;
+  color: ${props.theme.colors.gray_200};
+  margin-top: 2px;
+
+  :hover {
+    color: ${props.theme.colors.sub};
+    border-bottom: 1px solid ${props.theme.colors.sub};
+  }
+`;
+
+export const InternalLink = styled(Link)`
+  ${linkStyle}
+`;
+
+export const ExternalLink = styled.a`
+  ${linkStyle}
+`;

--- a/frontend/src/pages/PostPage/components/Sidebar/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/Sidebar/index.styles.ts
@@ -3,17 +3,14 @@ import { Link } from 'react-router-dom';
 import { css, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const Container = styled.div<{ position: number }>`
+export const Container = styled.div`
   display: flex;
+  flex-direction: column;
   width: 100%;
   height: 300px;
   border: 1px solid ${props => props.theme.colors.gray_400};
   padding: 30px;
-  flex-direction: column;
   box-sizing: border-box;
-  position: absolute;
-  transform: ${({ position }) => `translateY(${position}px);`};
-  transition: all 0.2s ease;
   background-color: white;
 `;
 

--- a/frontend/src/pages/PostPage/components/Sidebar/index.tsx
+++ b/frontend/src/pages/PostPage/components/Sidebar/index.tsx
@@ -1,6 +1,4 @@
-import { HTMLAttributes, useEffect, useState } from 'react';
-
-import useThrottle from '@/hooks/useThrottle';
+import { HTMLAttributes } from 'react';
 
 import * as Styled from './index.styles';
 
@@ -16,17 +14,8 @@ interface Item {
 }
 
 const Sidebar = ({ title, items, className, domain = 'internal' }: SidebarProps) => {
-  const [position, setPosition] = useState(document.documentElement.scrollTop);
-  const moveSidebar = useThrottle(() => setPosition(document.documentElement.scrollTop), 50);
-
-  useEffect(() => {
-    window.addEventListener('scroll', moveSidebar);
-
-    return () => window.removeEventListener('scroll', moveSidebar);
-  }, []);
-
   return (
-    <Styled.Container position={position} className={className}>
+    <Styled.Container className={className}>
       <Styled.Title>{title}</Styled.Title>
       <Styled.Items>
         {items.map(({ name, url }) => (

--- a/frontend/src/pages/PostPage/components/Sidebar/index.tsx
+++ b/frontend/src/pages/PostPage/components/Sidebar/index.tsx
@@ -1,0 +1,48 @@
+import { HTMLAttributes, useEffect, useState } from 'react';
+
+import useThrottle from '@/hooks/useThrottle';
+
+import * as Styled from './index.styles';
+
+interface SidebarProps extends HTMLAttributes<HTMLDivElement> {
+  title: string;
+  items: Item[];
+  domain?: 'internal' | 'external';
+}
+
+interface Item {
+  name: string;
+  url: string;
+}
+
+const Sidebar = ({ title, items, className, domain = 'internal' }: SidebarProps) => {
+  const [position, setPosition] = useState(document.documentElement.scrollTop);
+  const moveSidebar = useThrottle(() => setPosition(document.documentElement.scrollTop), 50);
+
+  useEffect(() => {
+    window.addEventListener('scroll', moveSidebar);
+
+    return () => window.removeEventListener('scroll', moveSidebar);
+  }, []);
+
+  return (
+    <Styled.Container position={position} className={className}>
+      <Styled.Title>{title}</Styled.Title>
+      <Styled.Items>
+        {items.map(({ name, url }) => (
+          <Styled.Item key={name}>
+            {domain === 'internal' ? (
+              <Styled.InternalLink to={url}>{name}</Styled.InternalLink>
+            ) : (
+              <Styled.ExternalLink href={url} target="_blank">
+                {name}
+              </Styled.ExternalLink>
+            )}
+          </Styled.Item>
+        ))}
+      </Styled.Items>
+    </Styled.Container>
+  );
+};
+
+export default Sidebar;

--- a/frontend/src/pages/PostPage/index.styles.ts
+++ b/frontend/src/pages/PostPage/index.styles.ts
@@ -1,7 +1,5 @@
 import { Link } from 'react-router-dom';
 
-import Sidebar from './components/Sidebar';
-
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -115,6 +113,7 @@ export const Container = styled.div`
   width: 100%;
   display: flex;
   justify-content: space-between;
+  position: relative;
 
   @media (min-width: 875px) {
     padding: 4rem 1rem;
@@ -130,14 +129,4 @@ export const PostContainer = styled.div`
   @media (min-width: 875px) {
     width: 55%;
   }
-`;
-
-export const SideContainer = styled.aside`
-  width: 35%;
-  height: 100%;
-  position: relative;
-`;
-
-export const ADSidebar = styled(Sidebar)`
-  top: 360px;
 `;

--- a/frontend/src/pages/PostPage/index.styles.ts
+++ b/frontend/src/pages/PostPage/index.styles.ts
@@ -25,21 +25,52 @@ export const Image = styled.img`
   object-fit: scale-down;
 `;
 
-export const BlockContainer = styled.div`
-  ${containerStyle};
+export const Block = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
   height: calc(100vh - 166px);
   overflow: hidden;
-  font-family: 'BMHANNAPro', 'Noto Sans KR';
   gap: 2em;
 `;
 
+export const ErrorMessage = styled.p`
+  font-family: 'BMHANNAAir', 'Noto Sans KR';
+  text-align: center;
+  line-height: 1.5rem;
+  font-size: 1rem;
+
+  @media (min-width: 875px) {
+    font-size: 1.5rem;
+    line-height: 3rem;
+  }
+`;
+
+export const HandlingButtonContainer = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+export const MainButton = styled.button`
+  font-family: 'BMHANNAAir', 'Noto Sans KR';
+  background-color: transparent;
+  color: ${props => props.theme.colors.sub};
+  padding: 0.8rem;
+  border-radius: 3px;
+  font-size: 1rem;
+  letter-spacing: 1px;
+`;
+
 export const BackButton = styled.button`
-  font-family: 'BMHANNAPro', 'Noto Sans KR';
+  font-family: 'BMHANNAAir', 'Noto Sans KR';
   background-color: ${props => props.theme.colors.sub};
   color: white;
-  padding: 1em;
-  border-radius: 0.5em;
+  padding: 0.8rem;
+  border-radius: 3px;
+  font-size: 1rem;
+  letter-spacing: 1px;
 `;
 
 export const ListButtonContainer = styled.div`
@@ -63,21 +94,21 @@ export const ListButton = styled(Link)`
 
 export const SpinnerContainer = styled.div`
   width: 100%;
-  height: 500px;
+  height: calc(100vh - 100px);
   display: flex;
   justify-content: center;
   align-items: center;
 `;
 
-export const ErrorContainer = styled.div`
+export const NotFound = styled.div`
   width: 100%;
-  height: 500px;
-  font-family: 'BMHANNAPro', 'Noto Sans KR';
+  height: calc(100vh - 100px);
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   gap: 3em;
+  margin: auto;
 `;
 
 export const Container = styled.div`

--- a/frontend/src/pages/PostPage/index.styles.ts
+++ b/frontend/src/pages/PostPage/index.styles.ts
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom';
 
+import Sidebar from './components/Sidebar';
+
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -84,7 +86,7 @@ export const Container = styled.div`
   justify-content: space-between;
 
   @media (min-width: 875px) {
-    padding-top: 3rem;
+    padding: 4rem 1rem;
   }
 `;
 
@@ -100,6 +102,11 @@ export const PostContainer = styled.div`
 `;
 
 export const SideContainer = styled.aside`
-  width: 30%;
-  background-color: red;
+  width: 35%;
+  height: 100%;
+  position: relative;
+`;
+
+export const ADSidebar = styled(Sidebar)`
+  top: 360px;
 `;

--- a/frontend/src/pages/PostPage/index.styles.ts
+++ b/frontend/src/pages/PostPage/index.styles.ts
@@ -8,11 +8,11 @@ export const containerStyle = css`
   display: flex;
   flex-direction: column;
   align-items: center;
-`;
 
-export const Container = styled.div`
-  ${containerStyle}
-  padding:1rem 0;
+  @media (min-width: 875px) {
+    padding-top: 3rem;
+    max-width: 790px;
+  }
 `;
 
 export const Image = styled.img`
@@ -24,7 +24,7 @@ export const Image = styled.img`
 `;
 
 export const BlockContainer = styled.div`
-  ${containerStyle}
+  ${containerStyle};
   justify-content: center;
   height: calc(100vh - 166px);
   overflow: hidden;
@@ -76,4 +76,30 @@ export const ErrorContainer = styled.div`
   justify-content: center;
   align-items: center;
   gap: 3em;
+`;
+
+export const Container = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+
+  @media (min-width: 875px) {
+    padding-top: 3rem;
+  }
+`;
+
+export const PostContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  @media (min-width: 875px) {
+    width: 55%;
+  }
+`;
+
+export const SideContainer = styled.aside`
+  width: 30%;
+  background-color: red;
 `;

--- a/frontend/src/pages/PostPage/index.tsx
+++ b/frontend/src/pages/PostPage/index.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import CommentList from './components/CommentList';
 import PostContent from './components/PostContent';
 import PostHeader from './components/PostHeader';
+import Sidebar from './components/Sidebar';
 import Layout from '@/components/@styled/Layout';
 import ConfirmModal from '@/components/ConfirmModal';
 import Spinner from '@/components/Spinner';
@@ -11,11 +12,17 @@ import Spinner from '@/components/Spinner';
 import useLike from '@/hooks/queries/likes/useLike';
 import useDeletePost from '@/hooks/queries/post/useDeletePost';
 import usePost from '@/hooks/queries/post/usePost';
+import usePosts from '@/hooks/queries/post/usePosts';
 import useResponsive from '@/hooks/useResponsive';
 
 import * as Styled from './index.styles';
 
 import PATH from '@/constants/path';
+
+import { AD } from '@/dummy';
+
+const HOT_BORAD_ID = 1;
+const POST_COUNT = 5;
 
 const PostPage = () => {
   const navigate = useNavigate();
@@ -36,7 +43,15 @@ const PostPage = () => {
       navigate(-1);
     },
   });
-  const isTabletSizeOver = useResponsive(875);
+
+  const isDesktop = useResponsive(875);
+  const { data: hotPosts } = usePosts({
+    storeCode: [HOT_BORAD_ID, POST_COUNT],
+    options: {
+      enabled: isDesktop,
+      staleTime: 1000 * 20,
+    },
+  });
 
   const handleLikeButton = () => {
     putLike({ id: id! });
@@ -90,7 +105,15 @@ const PostPage = () => {
           <CommentList id={id!} />
         </Styled.PostContainer>
 
-        {isTabletSizeOver && <Styled.SideContainer></Styled.SideContainer>}
+        {isDesktop && hotPosts && (
+          <Styled.SideContainer>
+            <Sidebar
+              title="실시간 인기글"
+              items={hotPosts.pages.map(item => ({ name: item.title, url: `${PATH.POST}/${item.id}` }))!}
+            />
+            <Styled.ADSidebar title="AD" items={AD} domain="external" />
+          </Styled.SideContainer>
+        )}
 
         {isConfirmModalOpen && (
           <ConfirmModal

--- a/frontend/src/pages/PostPage/index.tsx
+++ b/frontend/src/pages/PostPage/index.tsx
@@ -11,6 +11,7 @@ import Spinner from '@/components/Spinner';
 import useLike from '@/hooks/queries/likes/useLike';
 import useDeletePost from '@/hooks/queries/post/useDeletePost';
 import usePost from '@/hooks/queries/post/usePost';
+import useResponsive from '@/hooks/useResponsive';
 
 import * as Styled from './index.styles';
 
@@ -35,6 +36,7 @@ const PostPage = () => {
       navigate(-1);
     },
   });
+  const isTabletSizeOver = useResponsive(875);
 
   const handleLikeButton = () => {
     putLike({ id: id! });
@@ -81,20 +83,24 @@ const PostPage = () => {
   return (
     <Layout>
       <Styled.Container>
-        <PostHeader post={data!} onClickDeleteButton={handleConfirmModal} onClickLikeButton={handleLikeButton} />
-        {hasImage && <Styled.Image src={process.env.IMAGE_API_URL + data.imageName} alt={data.imageName} />}
-        <PostContent content={data?.content!} hashtags={data?.hashtags!} hasImage={hasImage} />
-        <CommentList id={id!} />
-      </Styled.Container>
+        <Styled.PostContainer>
+          <PostHeader post={data!} onClickDeleteButton={handleConfirmModal} onClickLikeButton={handleLikeButton} />
+          {hasImage && <Styled.Image src={process.env.IMAGE_API_URL + data.imageName} alt={data.imageName} />}
+          <PostContent content={data?.content!} hashtags={data?.hashtags!} hasImage={hasImage} />
+          <CommentList id={id!} />
+        </Styled.PostContainer>
 
-      {isConfirmModalOpen && (
-        <ConfirmModal
-          title="삭제"
-          notice="해당 글을 삭제하시겠습니까?"
-          handleCancel={handleConfirmModal}
-          handleConfirm={() => deletePost(id!)}
-        />
-      )}
+        {isTabletSizeOver && <Styled.SideContainer></Styled.SideContainer>}
+
+        {isConfirmModalOpen && (
+          <ConfirmModal
+            title="삭제"
+            notice="해당 글을 삭제하시겠습니까?"
+            handleCancel={handleConfirmModal}
+            handleConfirm={() => deletePost(id!)}
+          />
+        )}
+      </Styled.Container>
     </Layout>
   );
 };

--- a/frontend/src/pages/PostPage/index.tsx
+++ b/frontend/src/pages/PostPage/index.tsx
@@ -5,6 +5,7 @@ import CommentList from './components/CommentList';
 import PostContent from './components/PostContent';
 import PostHeader from './components/PostHeader';
 import Sidebar from './components/Sidebar';
+import SidebarContainer from './components/Sidebar/components/SidebarContainer';
 import Layout from '@/components/@styled/Layout';
 import ConfirmModal from '@/components/ConfirmModal';
 import Spinner from '@/components/Spinner';
@@ -105,13 +106,13 @@ const PostPage = () => {
         </Styled.PostContainer>
 
         {isDesktop && hotPosts && (
-          <Styled.SideContainer>
+          <SidebarContainer>
             <Sidebar
               title="실시간 인기글"
               items={hotPosts.pages.map(item => ({ name: item.title, url: `${PATH.POST}/${item.id}` }))!}
             />
-            <Styled.ADSidebar title="AD" items={AD} domain="external" />
-          </Styled.SideContainer>
+            <Sidebar title="AD" items={AD} domain="external" />
+          </SidebarContainer>
         )}
 
         {isConfirmModalOpen && (

--- a/frontend/src/pages/PostPage/index.tsx
+++ b/frontend/src/pages/PostPage/index.tsx
@@ -59,39 +59,38 @@ const PostPage = () => {
 
   if (isLoading) {
     return (
-      <Layout>
-        <Styled.SpinnerContainer>
-          <Spinner />
-        </Styled.SpinnerContainer>
-      </Layout>
+      <Styled.SpinnerContainer>
+        <Spinner />
+      </Styled.SpinnerContainer>
     );
   }
 
-  if (isError) {
+  if (isError || !data) {
     return (
-      <Layout>
-        <Styled.ErrorContainer>
-          <Spinner />
-          존재하지 않거나 삭제된 글입니다. <Styled.ListButton to={PATH.HOME}>메인 페이지로</Styled.ListButton>
-        </Styled.ErrorContainer>
-      </Layout>
+      <Styled.NotFound>
+        <Spinner />
+        <Styled.ErrorMessage>존재하지 않거나 삭제된 글입니다. </Styled.ErrorMessage>
+        <Styled.HandlingButtonContainer>
+          <Styled.MainButton onClick={() => navigate(PATH.HOME)}>메인으로</Styled.MainButton>
+          <Styled.BackButton onClick={() => navigate(-1)}>이전 페이지</Styled.BackButton>
+        </Styled.HandlingButtonContainer>
+      </Styled.NotFound>
     );
   }
-  if (data?.blocked) {
+
+  if (data.blocked) {
     return (
-      <Layout>
-        <Styled.BlockContainer>
-          <p>다량의 신고로 인해</p>
-          <p> 블라인드 처리 된 게시물 입니다.</p>
-          <Styled.BackButton
-            onClick={() => {
-              navigate(-1);
-            }}
-          >
-            이전 페이지로 돌아가기
-          </Styled.BackButton>
-        </Styled.BlockContainer>
-      </Layout>
+      <Styled.Block>
+        <Styled.ErrorMessage>
+          다량의 신고로 인해
+          <br />
+          블라인드 처리 된 게시물 입니다.
+        </Styled.ErrorMessage>
+        <Styled.HandlingButtonContainer>
+          <Styled.MainButton onClick={() => navigate(PATH.HOME)}>메인으로</Styled.MainButton>
+          <Styled.BackButton onClick={() => navigate(-1)}>이전 페이지</Styled.BackButton>
+        </Styled.HandlingButtonContainer>
+      </Styled.Block>
     );
   }
 
@@ -99,9 +98,9 @@ const PostPage = () => {
     <Layout>
       <Styled.Container>
         <Styled.PostContainer>
-          <PostHeader post={data!} onClickDeleteButton={handleConfirmModal} onClickLikeButton={handleLikeButton} />
+          <PostHeader post={data} onClickDeleteButton={handleConfirmModal} onClickLikeButton={handleLikeButton} />
           {hasImage && <Styled.Image src={process.env.IMAGE_API_URL + data.imageName} alt={data.imageName} />}
-          <PostContent content={data?.content!} hashtags={data?.hashtags!} hasImage={hasImage} />
+          <PostContent content={data.content} hashtags={data.hashtags} hasImage={hasImage} />
           <CommentList id={id!} />
         </Styled.PostContainer>
 


### PR DESCRIPTION
### 구현기능

<img width="800" alt="스크린샷 2022-10-14 오후 8 11 16" src="https://user-images.githubusercontent.com/52737532/195833403-efd7f127-4f93-4021-a312-e55789370063.png">

글 상세 페이지를 데스크탑 사이즈로 구현합니다. 

### 세부 구현기능

- [x] 태블릿 사이즈(875px)를 초과할 경우 사이드바를 렌더링한다. 
- [x] 태블릿 사이즈(875px)를 초과할 경우 UI의 전체적인 크기를 키운다. 
- [x] 에러 핸들링 페이지를 반응형으로 구현한다. 
- [ ] 좋아요 사이드바를 제작한다. 

### 관련 이슈

close #631 

#### 광고 side

- 현재 정적 dummy 데이터를 넣어두었습니다.! 

#### em, rem

`em`과 `rem`를 사용했을 때, 반응형 구현이 좀 더 쉬운 이유는 `@media`로 break point에서 `html` 태그의 폰트 사이즈만 변경해주면 하위 요소의 `rem`이 전부 변경되기 때문에 편리하기 때문이라고 하네요 ! 그래서 html의 font-size를 계산하기 쉽게 10px로 지정해준다고 하네용. 

근데 이번에는 제 작업 전에 이미 rem이 사용되었고, 제가 임의로 html의 font-size를 변경한다면 rem을 사용한 부분이 모두 깨질 것이기 때문에 em과 rem을 혼용하여 사용했습니다! 

#### 좋아요 사이드바

구현할까 고민하다가, 이보다 급한 작업을 먼저하는 것이 낫다고 생각이 들어 
현재는 구현하지 않았습니다!! 추후 구현하도록 하겠습니다 :) 헤헤 🤪

#### addEventListener vs systhetic event (useThrottle)

useEffect를 사용해 addEventListener로 넘겨준 콜백함수에서는 state는 변경사항이 반영되지 않더군요.. ㅎㅎ
만약 state가 반영되게 하려면 useEffect의 dep 배열에 콜백함수를 넣어주거나, useEffect 안에서 addEventListener를 쓰지 않으면 됩니다 ㅎ

그렇지만 전자 방법과 후자방법은 state가 변경될 때마다 event handler가 연결되므로 좋지 않은 방법이라고 생각했습니다 ㅠㅠ
이런 이유로 useThrottle을 state와 setState를 사용하는 방식이 아닌 ref를 사용하도록 변경해주었습니다 ! 
systhetic event는 react에서 어떤 추가적인 조치를 취하는 것 같았어요. 이 부분은 좀 더 알아보도록 하겠습니당! (같이 알아보시죠)

#### react-query

options.enabled 속성을 통해 데스크탑 사이즈일 경우에만 query를 실행하도록 설정했습니다. 