### PR TITLE
feat: 파일 형식 제한

### DIFF
--- a/frontend/src/components/PostForm/components/ImageUpload/index.tsx
+++ b/frontend/src/components/PostForm/components/ImageUpload/index.tsx
@@ -22,6 +22,11 @@ const ImageUpload = ({ setImage, uploadImage }: ImageUploadProps) => {
 
     if (!file) return;
 
+    if (!/(.*?)\.(jpg|jpeg|gif|png)$/.test(file.name)) {
+      showSnackbar(SNACKBAR_MESSAGE.UNSUPPORTED_EXTENSION);
+      return;
+    }
+
     if (file.size > 2e7) {
       showSnackbar(SNACKBAR_MESSAGE.LARGE_IMAGE);
       return;

--- a/frontend/src/constants/snackbar.ts
+++ b/frontend/src/constants/snackbar.ts
@@ -21,6 +21,7 @@ const SNACKBAR_MESSAGE = {
   ALREADY_LOGIN: '이미 로그인하였습니다.',
   LARGE_IMAGE: '이미지 크기가 너무 큽니다.',
   FAIL_INSTALL: '이미 설치했거나, 다운로드가 불가능한 환경입니다.',
+  UNSUPPORTED_EXTENSION: '지원되지 않는 파일 형식입니다.',
 };
 
 export default SNACKBAR_MESSAGE;


### PR DESCRIPTION
### 구현기능

<img width="500" alt="스크린샷 2022-10-14 오후 9 27 22" src="https://user-images.githubusercontent.com/52737532/195846784-16a3e3a4-58df-46cc-af34-5b70550c1fd8.png">

사진 업로드 시 옵션을 눌러 모든 파일로 변경해버리면 
제한을 걸었어도 사진이 아닌 다른 확장자 파일도 선택이 가능합니다. 

이런 이유로 스크립트 코드를 추가해 한번 더 제한을 주었습니다.  

### 세부 구현기능

- [x] `jpg, jpeg, png, gif` 제외 다른 확장자 파일 업로드 제한 

### 관련 이슈

close #615 
