### PR TITLE
bug: 지원자로 회원가입 안되는 버그 수정

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/exception/AuthorizationException.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/exception/AuthorizationException.java
@@ -9,4 +9,8 @@ public class AuthorizationException extends ForbiddenException {
     public AuthorizationException() {
         super(MESSAGE);
     }
+
+    public AuthorizationException(String message) {
+        super(message);
+    }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/service/AuthService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/auth/service/AuthService.java
@@ -47,7 +47,7 @@ public class AuthService {
         if (isEditableBoardToApplicant(boardId)) {
             return;
         }
-        throw new AuthorizationException();
+        throw new AuthorizationException("인증된 사용자만 이용가능 합니다.");
     }
 
     private boolean isWootecoUser(AuthInfo authInfo) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/controller/MemberController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/controller/MemberController.java
@@ -8,7 +8,6 @@ import com.wooteco.sokdak.member.dto.NicknameResponse;
 import com.wooteco.sokdak.member.dto.NicknameUpdateRequest;
 import com.wooteco.sokdak.member.dto.SignupRequest;
 import com.wooteco.sokdak.member.dto.UniqueResponse;
-import com.wooteco.sokdak.member.dto.VerificationRequest;
 import com.wooteco.sokdak.member.service.EmailService;
 import com.wooteco.sokdak.member.service.MemberService;
 import com.wooteco.sokdak.support.token.Login;

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/member/controller/MemberController.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/member/controller/MemberController.java
@@ -13,6 +13,7 @@ import com.wooteco.sokdak.member.service.EmailService;
 import com.wooteco.sokdak.member.service.MemberService;
 import com.wooteco.sokdak.support.token.Login;
 import com.wooteco.sokdak.support.token.TokenManager;
+import java.util.Objects;
 import javax.validation.Valid;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -63,7 +64,7 @@ public class MemberController {
 
     @PostMapping("/signup")
     public ResponseEntity<Void> signUp(@Valid @RequestBody SignupRequest signupRequest) {
-        if (signupRequest.getEmail().isEmpty()) {
+        if (Objects.isNull(signupRequest.getEmail())) {
             memberService.signUpAsApplicant(signupRequest);
             return ResponseEntity.status(HttpStatus.CREATED).build();
         }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/member/acceptance/MemberAcceptanceTest.java
@@ -67,6 +67,18 @@ class MemberAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
 
+    @DisplayName("지원자로 회원 가입을 할 수 있다.")
+    @Test
+    void signUp_Applicant() {
+        SignupRequest signupRequest =
+                new SignupRequest(null, "username", "nickname",
+                        "123456", "Abcd123!@", "Abcd123!@");
+
+        ExtractableResponse<Response> response = httpPost(signupRequest, "/members/signup");
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
     @DisplayName("닉네임을 수정할 수 있다.")
     @Test
     void editNickname() {

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/member/controller/MemberControllerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/member/controller/MemberControllerTest.java
@@ -161,7 +161,7 @@ class MemberControllerTest extends ControllerTest {
     @DisplayName("지원자로 회원가입하면 201 반환")
     @Test
     void signUp_Applicant() {
-        SignupRequest signupRequest = new SignupRequest("", "username", "nickname", "a1b1c1",
+        SignupRequest signupRequest = new SignupRequest(null, "username", "nickname", "a1b1c1",
                 "password1!", "password1!");
 
         restDocs


### PR DESCRIPTION
### 구현기능
지원자로 회원가입 요청 시 서버에러가 남
email이 empty인지 확인했는데 null인지 확인하도록 로직 변경
