### PR TITLE
fix: 알파채널 이미지일 경우 압축이 되지 않는 문제 해결

### DIFF
--- a/imageserver/sokdakimageserver/build.gradle
+++ b/imageserver/sokdakimageserver/build.gradle
@@ -21,6 +21,10 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	implementation 'com.drewnoakes:metadata-extractor:2.18.0'
+	implementation 'org.imgscalr:imgscalr-lib:4.2'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/controller/ImageController.java
+++ b/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/controller/ImageController.java
@@ -1,5 +1,7 @@
-package com.wooteco.sokdak.image;
+package com.wooteco.sokdak.image.controller;
 
+import com.wooteco.sokdak.image.dto.ImageResponse;
+import com.wooteco.sokdak.image.service.ImageService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,7 +23,6 @@ public class ImageController {
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<ImageResponse> upload(@RequestPart MultipartFile image) {
         ImageResponse imageResponse = imageService.uploadImage(image);
-
         return ResponseEntity.ok(imageResponse);
     }
 }

--- a/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/domain/Extension.java
+++ b/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/domain/Extension.java
@@ -1,5 +1,6 @@
-package com.wooteco.sokdak.image;
+package com.wooteco.sokdak.image.domain;
 
+import com.wooteco.sokdak.image.exception.NotSupportedExtensionException;
 import java.util.Arrays;
 
 public enum Extension {

--- a/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/domain/Extension.java
+++ b/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/domain/Extension.java
@@ -23,10 +23,6 @@ public enum Extension {
                 .orElseThrow(NotSupportedExtensionException::new);
     }
 
-    public boolean canNotCompress() {
-        return this == GIF;
-    }
-
     public String getValue() {
         return value;
     }

--- a/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/domain/Image.java
+++ b/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/domain/Image.java
@@ -1,6 +1,7 @@
-package com.wooteco.sokdak.image;
+package com.wooteco.sokdak.image.domain;
 
-import com.wooteco.sokdak.exception.FileIOException;
+import com.wooteco.sokdak.image.util.ImageCompressor;
+import com.wooteco.sokdak.image.exception.FileIOException;
 import java.io.File;
 import java.util.UUID;
 import org.springframework.web.multipart.MultipartFile;

--- a/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/dto/ImageResponse.java
+++ b/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/dto/ImageResponse.java
@@ -1,4 +1,4 @@
-package com.wooteco.sokdak.image;
+package com.wooteco.sokdak.image.dto;
 
 public class ImageResponse {
 

--- a/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/exception/FileIOException.java
+++ b/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/exception/FileIOException.java
@@ -1,4 +1,4 @@
-package com.wooteco.sokdak.exception;
+package com.wooteco.sokdak.image.exception;
 
 import com.wooteco.sokdak.advice.InternalException;
 

--- a/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/exception/ImageReadException.java
+++ b/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/exception/ImageReadException.java
@@ -1,0 +1,10 @@
+package com.wooteco.sokdak.image.exception;
+
+public class ImageReadException extends RuntimeException {
+
+    private static final String MESSAGE = "이미지를 읽어오는데 문제가 발생했습니다.";
+
+    public ImageReadException() {
+        super(MESSAGE);
+    }
+}

--- a/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/exception/NotSupportedExtensionException.java
+++ b/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/exception/NotSupportedExtensionException.java
@@ -1,4 +1,4 @@
-package com.wooteco.sokdak.image;
+package com.wooteco.sokdak.image.exception;
 
 public class NotSupportedExtensionException extends RuntimeException {
 

--- a/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/service/ImageService.java
+++ b/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/service/ImageService.java
@@ -1,5 +1,7 @@
-package com.wooteco.sokdak.image;
+package com.wooteco.sokdak.image.service;
 
+import com.wooteco.sokdak.image.domain.Image;
+import com.wooteco.sokdak.image.dto.ImageResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;

--- a/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/util/ImageCompressor.java
+++ b/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/util/ImageCompressor.java
@@ -1,4 +1,4 @@
-package com.wooteco.sokdak.image;
+package com.wooteco.sokdak.image.util;
 
 import java.awt.image.BufferedImage;
 import java.io.File;

--- a/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/util/ImageCompressor.java
+++ b/imageserver/sokdakimageserver/src/main/java/com/wooteco/sokdak/image/util/ImageCompressor.java
@@ -1,8 +1,10 @@
 package com.wooteco.sokdak.image.util;
 
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Iterator;
 import javax.imageio.IIOImage;
@@ -16,7 +18,9 @@ public class ImageCompressor {
     public static void compress(File originalFile, File compressedFile, String extension) {
         try (final OutputStream outputStream = new FileOutputStream(compressedFile);
              final ImageOutputStream imageOutputStream = ImageIO.createImageOutputStream(outputStream)) {
-            final BufferedImage bufferedImage = ImageIO.read(originalFile);
+
+            final BufferedImage bufferedImage = extractBufferedImage(originalFile);
+
             final Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName(extension);
             final ImageWriter writer = writers.next();
 
@@ -32,5 +36,21 @@ public class ImageCompressor {
             return;
         }
         originalFile.delete();
+    }
+
+    private static BufferedImage extractBufferedImage(File originalFile) throws IOException {
+        final BufferedImage bufferedImage = ImageIO.read(originalFile);
+        if (!bufferedImage.getColorModel().hasAlpha()) {
+            return bufferedImage;
+        }
+
+        final BufferedImage newBufferedImage = new BufferedImage(bufferedImage.getWidth(), bufferedImage.getHeight(),
+                BufferedImage.TYPE_INT_RGB);
+        final Graphics2D g = newBufferedImage.createGraphics();
+        g.fillRect(0, 0, bufferedImage.getWidth(), bufferedImage.getHeight());
+        g.drawImage(bufferedImage, 0, 0, null);
+        g.dispose();
+
+        return newBufferedImage;
     }
 }

--- a/imageserver/sokdakimageserver/src/test/java/com/wooteco/sokdak/image/domain/ExtensionTest.java
+++ b/imageserver/sokdakimageserver/src/test/java/com/wooteco/sokdak/image/domain/ExtensionTest.java
@@ -1,0 +1,27 @@
+package com.wooteco.sokdak.image.domain;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wooteco.sokdak.image.exception.NotSupportedExtensionException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ExtensionTest {
+
+    @DisplayName("jpg, jpeg, png, gif 확장자는 허용되는 확장자이다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"jpg", "jpeg", "png", "gif"})
+    void from(String value) {
+        assertThatNoException().isThrownBy(() -> Extension.from(value));
+    }
+
+    @DisplayName("jpg, jpeg, png, gif 외의 확장자는 허용되지 않는다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"heic", "webp", "bmp", "tiff", "pdf", "svg", "ico"})
+    void from_Exception(String value) {
+        assertThatThrownBy(() -> Extension.from(value))
+                .isInstanceOf(NotSupportedExtensionException.class);
+    }
+}


### PR DESCRIPTION
### 구현기능
- 알파채널 이미지일 경우 압축이 되지 않는 문제 해결
- 이미지가 원치 않게 회전되는 경우에 대한 문제 해결
