### PR TITLE
fix: 상세페이지에서 사이드바의 스크롤 이벤트가 뷰포트 초과되는 문제 해결

### DIFF
--- a/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.styles.ts
@@ -12,8 +12,8 @@ export const Container = styled.div<{ position: number; height: number }>`
   width: max-content;
   left: 0;
   box-sizing: border-box;
-  position: absolute;
-  bottom: ${props => (props.height - props.position >= 0 ? `calc(${props.height}px - ${props.position}px);` : '0')};
+  transform: ${props =>
+    props.height - props.position >= 0 ? `translateY(${props.position}px)` : `translateY(${props.height}px)`};
   transition: all 0.2s ease;
   gap: 30px;
 `;

--- a/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.styles.ts
@@ -9,7 +9,7 @@ export const SidebarContainer = styled.div`
 export const Container = styled.div<{ position: number }>`
   display: flex;
   flex-direction: column;
-  width: max-content;
+  width: 100%;
   left: 0;
   box-sizing: border-box;
   transform: ${({ position }) => `translateY(${position}px)`};

--- a/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.styles.ts
@@ -1,13 +1,19 @@
 import styled from '@emotion/styled';
 
-export const Container = styled.div<{ position: number }>`
+export const SidebarContainer = styled.div`
+  width: 30%;
+  height: calc(100% - 8rem);
+  position: absolute;
+  right: 0;
+`;
+export const Container = styled.div<{ position: number; height: number }>`
   display: flex;
   flex-direction: column;
-  width: 30%;
-  right: 0;
+  width: max-content;
+  left: 0;
   box-sizing: border-box;
   position: absolute;
-  transform: ${({ position }) => `translateY(${position}px);`};
+  bottom: ${props => (props.height - props.position >= 0 ? `calc(${props.height}px - ${props.position}px);` : '0')};
   transition: all 0.2s ease;
   gap: 30px;
 `;

--- a/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.styles.ts
+++ b/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.styles.ts
@@ -6,14 +6,13 @@ export const SidebarContainer = styled.div`
   position: absolute;
   right: 0;
 `;
-export const Container = styled.div<{ position: number; height: number }>`
+export const Container = styled.div<{ position: number }>`
   display: flex;
   flex-direction: column;
   width: max-content;
   left: 0;
   box-sizing: border-box;
-  transform: ${props =>
-    props.height - props.position >= 0 ? `translateY(${props.position}px)` : `translateY(${props.height}px)`};
+  transform: ${({ position }) => `translateY(${position}px)`};
   transition: all 0.2s ease;
   gap: 30px;
 `;

--- a/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.tsx
+++ b/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.tsx
@@ -27,9 +27,8 @@ const SidebarContainer = ({ children, className }: PropsWithChildren<HTMLAttribu
   return (
     <Styled.SidebarContainer ref={sideBarContainerRef}>
       <Styled.Container
-        position={position}
+        position={Math.min(sideBarContainerHeight - sideBarHeight, position)}
         className={className}
-        height={sideBarContainerHeight - sideBarHeight}
         ref={sideBarRef}
       >
         {children}

--- a/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.tsx
+++ b/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, PropsWithChildren, useEffect, useState } from 'react';
+import { HTMLAttributes, PropsWithChildren, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import useThrottle from '@/hooks/useThrottle';
 
@@ -8,6 +8,16 @@ const SidebarContainer = ({ children, className }: PropsWithChildren<HTMLAttribu
   const [position, setPosition] = useState(document.documentElement.scrollTop);
   const moveSidebar = useThrottle(() => setPosition(document.documentElement.scrollTop), 50);
 
+  const sideBarContainerRef = useRef<HTMLDivElement>(null);
+  const sideBarRef = useRef<HTMLDivElement>(null);
+  const [sideBarContainerHeight, setSideBarContainerHeight] = useState(0);
+  const [sideBarHeight, setSideBarHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    setSideBarContainerHeight(sideBarContainerRef.current?.clientHeight!);
+    setSideBarHeight(sideBarRef.current?.clientHeight!);
+  }, []);
+
   useEffect(() => {
     window.addEventListener('scroll', moveSidebar);
 
@@ -15,9 +25,16 @@ const SidebarContainer = ({ children, className }: PropsWithChildren<HTMLAttribu
   }, []);
 
   return (
-    <Styled.Container position={position} className={className}>
-      {children}
-    </Styled.Container>
+    <Styled.SidebarContainer ref={sideBarContainerRef}>
+      <Styled.Container
+        position={position}
+        className={className}
+        height={sideBarContainerHeight - sideBarHeight}
+        ref={sideBarRef}
+      >
+        {children}
+      </Styled.Container>
+    </Styled.SidebarContainer>
   );
 };
 

--- a/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.tsx
+++ b/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/index.tsx
@@ -1,36 +1,18 @@
-import { HTMLAttributes, PropsWithChildren, useEffect, useLayoutEffect, useRef, useState } from 'react';
-
-import useThrottle from '@/hooks/useThrottle';
+import { HTMLAttributes, PropsWithChildren, useRef } from 'react';
 
 import * as Styled from './index.styles';
 
-const SidebarContainer = ({ children, className }: PropsWithChildren<HTMLAttributes<HTMLDivElement>>) => {
-  const [position, setPosition] = useState(document.documentElement.scrollTop);
-  const moveSidebar = useThrottle(() => setPosition(document.documentElement.scrollTop), 50);
+import useAnimateContainer from './useAnimateContainer';
 
+const SidebarContainer = ({ children, className }: PropsWithChildren<HTMLAttributes<HTMLDivElement>>) => {
   const sideBarContainerRef = useRef<HTMLDivElement>(null);
   const sideBarRef = useRef<HTMLDivElement>(null);
-  const [sideBarContainerHeight, setSideBarContainerHeight] = useState(0);
-  const [sideBarHeight, setSideBarHeight] = useState(0);
 
-  useLayoutEffect(() => {
-    setSideBarContainerHeight(sideBarContainerRef.current?.clientHeight!);
-    setSideBarHeight(sideBarRef.current?.clientHeight!);
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener('scroll', moveSidebar);
-
-    return () => window.removeEventListener('scroll', moveSidebar);
-  }, []);
+  const { movementDegree } = useAnimateContainer({ parentContainer: sideBarContainerRef, childContainer: sideBarRef });
 
   return (
     <Styled.SidebarContainer ref={sideBarContainerRef}>
-      <Styled.Container
-        position={Math.min(sideBarContainerHeight - sideBarHeight, position)}
-        className={className}
-        ref={sideBarRef}
-      >
+      <Styled.Container position={movementDegree} className={className} ref={sideBarRef}>
         {children}
       </Styled.Container>
     </Styled.SidebarContainer>

--- a/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/useAnimateContainer.ts
+++ b/frontend/src/pages/PostPage/components/Sidebar/components/SidebarContainer/useAnimateContainer.ts
@@ -1,0 +1,32 @@
+import { RefObject, useEffect, useLayoutEffect, useState } from 'react';
+
+import useThrottle from '@/hooks/useThrottle';
+
+const useAnimateContainer = ({
+  parentContainer,
+  childContainer,
+}: {
+  parentContainer: RefObject<HTMLDivElement>;
+  childContainer: RefObject<HTMLDivElement>;
+}) => {
+  const [position, setPosition] = useState(document.documentElement.scrollTop);
+  const moveSidebar = useThrottle(() => setPosition(document.documentElement.scrollTop), 50);
+
+  const [sideBarContainerHeight, setSideBarContainerHeight] = useState(0);
+  const [sideBarHeight, setSideBarHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    setSideBarContainerHeight(parentContainer.current?.clientHeight!);
+    setSideBarHeight(childContainer.current?.clientHeight!);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('scroll', moveSidebar);
+
+    return () => window.removeEventListener('scroll', moveSidebar);
+  }, []);
+
+  return { movementDegree: Math.min(sideBarContainerHeight - sideBarHeight, position) };
+};
+
+export default useAnimateContainer;

--- a/frontend/webpack/webpack.local.js
+++ b/frontend/webpack/webpack.local.js
@@ -3,6 +3,7 @@ const path = require('path');
 const common = require('./webpack.config');
 const { DefinePlugin } = require('webpack');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+const Dotenv = require('dotenv-webpack');
 
 require('dotenv').config();
 
@@ -13,6 +14,7 @@ module.exports = merge(common, {
       'process.env.MODE': JSON.stringify(process.env.MODE),
     }),
     new ReactRefreshWebpackPlugin(),
+    new Dotenv(),
   ],
   devServer: {
     port: 3000,


### PR DESCRIPTION
### 구현기능

상세페이지에서 사이드바의 스크롤 이벤트가 무한대로 발생하는 문제 해결

### 세부 구현기능

상세페이지에서 해당 container의 크기가 계속해서 증가하여 position의 증가가 무한대로 이루어졌다.
부모 컨테이너를 만들고 이것의 height를 기준으로 한계값을 지정해주었다.

### 관련 이슈
close #706 