### PR TITLE
fix: 쿼리 카운트 AOP에서 DataSource 순환참조 문제 해결

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/aspect/performance/PerformanceAspect.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/aspect/performance/PerformanceAspect.java
@@ -2,7 +2,6 @@ package com.wooteco.sokdak.aspect.performance;
 
 import java.lang.reflect.Proxy;
 import java.sql.Connection;
-import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -15,12 +14,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class PerformanceAspect {
 
-    private final DataSource datasource;
     private final ThreadLocal<QueryCounter> queryCounter = new ThreadLocal<>();
-
-    public PerformanceAspect(DataSource datasource) {
-        this.datasource = datasource;
-    }
 
     @Pointcut("execution(* javax.sql.DataSource.getConnection(..))")
     public void performancePointcut() {


### PR DESCRIPTION
### 구현기능
쿼리 카운트 AOP에서 DataSource 순환참조 문제 해결