### PR TITLE
refactor: 좋아요 개수 조회 반정규화하여 count 쿼리 제거

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
@@ -66,6 +66,8 @@ public class Comment {
 
     private boolean softRemoved;
 
+    private int likeCount;
+
     @CreatedDate
     private LocalDateTime createdAt;
 
@@ -164,7 +166,7 @@ public class Comment {
     }
 
     public int getCommentLikesCount() {
-        return commentLikes.size();
+        return likeCount;
     }
 
     public boolean isSoftRemoved() {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/repository/CommentRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/repository/CommentRepository.java
@@ -5,8 +5,10 @@ import com.wooteco.sokdak.post.domain.Post;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
@@ -30,4 +32,14 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query(value = "SELECT c FROM Comment c LEFT JOIN FETCH c.commentLikes cl LEFT JOIN FETCH cl.member WHERE c.id = :id")
     Optional<Comment> findByIdForCommentLike(Long id);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE comment SET like_count = like_count + 1 WHERE comment_id = :commentId", nativeQuery = true)
+    void increaseLikeCount(Long commentId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE comment SET like_count = like_count - 1 WHERE comment_id = :commentId", nativeQuery = true)
+    void decreaseLikeCount(Long commentId);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/service/LikeService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/service/LikeService.java
@@ -53,20 +53,22 @@ public class LikeService {
                 .orElseThrow(PostNotFoundException::new);
         authService.checkAuthority(authInfo, post.getBoardId());
 
-        flipPostLike(authInfo.getId(), post);
-        int likeCount = post.getLikeCount();
+        int likeCount = flipPostLike(authInfo.getId(), post);
         boolean liked = post.hasLikeOfMember(authInfo.getId());
 
         checkSpecialAndSave(likeCount, post);
         return new LikeFlipResponse(likeCount, liked);
     }
 
-    private void flipPostLike(Long memberId, Post post) {
+    private int flipPostLike(Long memberId, Post post) {
         if (post.hasLikeOfMember(memberId)) {
             post.deleteLikeOfMember(memberId);
-            return;
+            postRepository.decreaseLikeCount(post.getId());
+            return post.getLikeCount() - 1;
         }
         addNewPostLike(memberId, post);
+        postRepository.increaseLikeCount(post.getId());
+        return post.getLikeCount() + 1;
     }
 
     private void addNewPostLike(Long memberId, Post post) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/service/LikeService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/service/LikeService.java
@@ -93,19 +93,21 @@ public class LikeService {
                 .orElseThrow(CommentNotFoundException::new);
         authService.checkAuthority(authInfo, comment.getBoardId());
 
-        flipCommentLike(authInfo.getId(), comment);
-        int likeCount = comment.getCommentLikesCount();
+        int likeCount = flipCommentLike(authInfo.getId(), comment);
         boolean liked = comment.hasLikeOfMember(authInfo.getId());
 
         return new LikeFlipResponse(likeCount, liked);
     }
 
-    private void flipCommentLike(Long memberId, Comment comment) {
+    private int flipCommentLike(Long memberId, Comment comment) {
         if (comment.hasLikeOfMember(memberId)) {
             comment.deleteLikeOfMember(memberId);
-            return;
+            commentRepository.decreaseLikeCount(comment.getId());
+            return comment.getCommentLikesCount() - 1;
         }
         addNewCommentLike(memberId, comment);
+        commentRepository.increaseLikeCount(comment.getId());
+        return comment.getCommentLikesCount() + 1;
     }
 
     private void addNewCommentLike(Long memberId, Comment comment) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -168,10 +168,6 @@ public class Post {
     }
 
     public int getLikeCount() {
-//        if (postLikes == null) {
-//            return 0;
-//        }
-//        return postLikes.size();
         return likeCount;
     }
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -53,6 +53,8 @@ public class Post {
 
     private int viewCount = 0;
 
+    private int likeCount = 0;
+
     private String writerNickname;
 
     private String imageName;
@@ -166,10 +168,11 @@ public class Post {
     }
 
     public int getLikeCount() {
-        if (postLikes == null) {
-            return 0;
-        }
-        return postLikes.size();
+//        if (postLikes == null) {
+//            return 0;
+//        }
+//        return postLikes.size();
+        return likeCount;
     }
 
     public int getCommentCount() {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/repository/PostRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/repository/PostRepository.java
@@ -35,4 +35,14 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Modifying
     @Query(value = "UPDATE post SET view_count = view_count + 1 WHERE post_id = :postId", nativeQuery = true)
     void updateViewCount(Long postId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE post SET like_count = like_count + 1 WHERE post_id = :postId", nativeQuery = true)
+    void increaseLikeCount(Long postId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE post SET like_count = like_count - 1 WHERE post_id = :postId", nativeQuery = true)
+    void decreaseLikeCount(Long postId);
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/repository/CommentRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/repository/CommentRepositoryTest.java
@@ -23,6 +23,8 @@ class CommentRepositoryTest extends RepositoryTest {
     private PostRepository postRepository;
 
     private Post post;
+    private Comment comment1;
+    private Comment comment2;
 
     @BeforeEach
     void setUp() {
@@ -32,18 +34,40 @@ class CommentRepositoryTest extends RepositoryTest {
                 .content(VALID_POST_CONTENT)
                 .build();
         postRepository.save(post);
+        comment1 = Comment.parent(member1, post, "east", "댓글");
+        comment2 = Comment.parent(member1, post, "east", "댓글2");
+        commentRepository.save(comment1);
+        commentRepository.save(comment2);
     }
 
     @DisplayName("게시물에 해당하는 모든 댓글을 가져온다.")
     @Test
     void findAllByPostId() {
-        Comment comment1 = Comment.parent(member1, post, "east", "댓글");
-        Comment comment2 = Comment.parent(member1, post, "east", "댓글2");
-        commentRepository.save(comment1);
-        commentRepository.save(comment2);
-
         List<Comment> comments = commentRepository.findCommentsByPostId(post.getId());
 
         assertThat(comments).hasSize(2);
+    }
+
+    @DisplayName("좋아요 개수를 1 증가한다.")
+    @Test
+    void increaseLikeCount() {
+        int originLikeCount = comment1.getCommentLikesCount();
+
+        commentRepository.increaseLikeCount(comment1.getId());
+
+        Comment foundComment = commentRepository.findById(comment1.getId()).orElseThrow();
+        assertThat(foundComment.getCommentLikesCount() - originLikeCount).isEqualTo(1);
+    }
+
+    @DisplayName("좋아요 개수를 1 감소한다.")
+    @Test
+    void decreaseLikeCount() {
+        commentRepository.increaseLikeCount(comment1.getId());
+        int originLikeCount = commentRepository.findById(comment1.getId()).get().getCommentLikesCount();
+
+        commentRepository.decreaseLikeCount(comment1.getId());
+
+        Comment foundComment = commentRepository.findById(comment1.getId()).orElseThrow();
+        assertThat(foundComment.getCommentLikesCount() - originLikeCount).isEqualTo(-1);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
@@ -106,8 +106,6 @@ class LikeServiceTest extends ServiceTest {
     void flipPostLike_create() {
         LikeFlipResponse putLikeResponse = likeService.flipPostLike(post.getId(), AUTH_INFO);
 
-        entityManager.flush();
-        entityManager.clear();
         Post foundPost = postRepository.findById(post.getId())
                 .orElseThrow(PostNotFoundException::new);
         assertAll(
@@ -121,13 +119,9 @@ class LikeServiceTest extends ServiceTest {
     @Test
     void flipPostLike_delete() {
         likeService.flipPostLike(post.getId(), AUTH_INFO);
-        entityManager.flush();
-        entityManager.clear();
 
         LikeFlipResponse putLikeResponse = likeService.flipPostLike(post.getId(), AUTH_INFO);
 
-        entityManager.flush();
-        entityManager.clear();
         Post foundPost = postRepository.findById(post.getId())
                 .orElseThrow(PostNotFoundException::new);
         assertAll(
@@ -327,5 +321,27 @@ class LikeServiceTest extends ServiceTest {
                 () -> assertThat(replies.get(0).getLikeCount()).isEqualTo(1),
                 () -> assertThat(replies.get(0).isLike()).isFalse()
         );
+    }
+
+    @DisplayName("게시글 좋아요시 게시글의 likeCount 가 증가한다.")
+    @Test
+    void flipLike_increaseLikeCount() {
+        int originLikeCount = post.getLikeCount();
+
+        likeService.flipPostLike(post.getId(), AUTH_INFO);
+
+        Post foundPost = postRepository.findById(post.getId()).orElseThrow();
+        assertThat(foundPost.getLikeCount() - originLikeCount).isEqualTo(1);
+    }
+
+    @DisplayName("한 사용자가 좋아요를 누른 게시글에 좋아요시 likeCount 가 감소한다.")
+    @Test
+    void flipLike_decreaseLikeCount() {
+        int originLikeCount = likeService.flipPostLike(post.getId(), AUTH_INFO).getLikeCount();
+
+        likeService.flipPostLike(post.getId(), AUTH_INFO);
+
+        Post foundPost = postRepository.findById(post.getId()).orElseThrow();
+        assertThat(foundPost.getLikeCount() - originLikeCount).isEqualTo(-1);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
@@ -325,7 +325,7 @@ class LikeServiceTest extends ServiceTest {
 
     @DisplayName("게시글 좋아요시 게시글의 likeCount 가 증가한다.")
     @Test
-    void flipLike_increaseLikeCount() {
+    void flipPostLike_increaseLikeCount() {
         int originLikeCount = post.getLikeCount();
 
         likeService.flipPostLike(post.getId(), AUTH_INFO);
@@ -336,12 +336,34 @@ class LikeServiceTest extends ServiceTest {
 
     @DisplayName("한 사용자가 좋아요를 누른 게시글에 좋아요시 likeCount 가 감소한다.")
     @Test
-    void flipLike_decreaseLikeCount() {
+    void flipPostLike_decreaseLikeCount() {
         int originLikeCount = likeService.flipPostLike(post.getId(), AUTH_INFO).getLikeCount();
 
         likeService.flipPostLike(post.getId(), AUTH_INFO);
 
         Post foundPost = postRepository.findById(post.getId()).orElseThrow();
         assertThat(foundPost.getLikeCount() - originLikeCount).isEqualTo(-1);
+    }
+
+    @DisplayName("댓글 좋아요시 댓글의 likeCount 가 증가한다.")
+    @Test
+    void flipCommentLike_increaseLikeCount() {
+        int originLikeCount = comment.getCommentLikesCount();
+
+        likeService.flipCommentLike(comment.getId(), AUTH_INFO);
+
+        Comment foundComment = commentRepository.findById(comment.getId()).orElseThrow();
+        assertThat(foundComment.getCommentLikesCount() - originLikeCount).isEqualTo(1);
+    }
+
+    @DisplayName("한 사용자가 좋아요를 누른 댓글에 좋아요시 likeCount 가 감소한다.")
+    @Test
+    void flipCommentLike_decreaseLikeCount() {
+        int originLikeCount = likeService.flipCommentLike(comment.getId(), AUTH_INFO).getLikeCount();
+
+        likeService.flipCommentLike(comment.getId(), AUTH_INFO);
+
+        Comment foundComment = commentRepository.findById(comment.getId()).orElseThrow();
+        assertThat(foundComment.getCommentLikesCount() - originLikeCount).isEqualTo(-1);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/acceptance/PostAcceptanceTest.java
@@ -376,7 +376,6 @@ class PostAcceptanceTest extends AcceptanceTest {
         assertThat(postsResponse.getTotalPostCount()).isEqualTo(1);
     }
 
-
     private String parsePostId(ExtractableResponse<Response> response) {
         return response.header("Location")
                 .split("/posts/")[1];

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/repository/PostRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/repository/PostRepositoryTest.java
@@ -128,12 +128,12 @@ class PostRepositoryTest extends RepositoryTest {
     @DisplayName("좋아요 개수를 1 감소한다.")
     @Test
     void decreaseLikeCount() {
-        int originLikeCount = post1.getLikeCount();
-
         postRepository.increaseLikeCount(post1.getId());
+        int originLikeCount = postRepository.findById(post1.getId()).get().getLikeCount();
+
+        postRepository.decreaseLikeCount(post1.getId());
 
         Post post = postRepository.findById(post1.getId()).orElseThrow();
-        assertThat(post.getLikeCount() - originLikeCount).isEqualTo(1);
-
+        assertThat(post.getLikeCount() - originLikeCount).isEqualTo(-1);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/repository/PostRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/repository/PostRepositoryTest.java
@@ -113,4 +113,27 @@ class PostRepositoryTest extends RepositoryTest {
         Page<Post> result = postRepository.findPostPagesByQuery(PageRequest.of(0, 2, DESC, "created_at"), "");
         assertThat(result.getTotalElements()).isEqualTo(5L);
     }
+
+    @DisplayName("좋아요 개수를 1 증가한다.")
+    @Test
+    void increaseLikeCount() {
+        int originLikeCount = post1.getLikeCount();
+
+        postRepository.increaseLikeCount(post1.getId());
+
+        Post post = postRepository.findById(post1.getId()).orElseThrow();
+        assertThat(post.getLikeCount() - originLikeCount).isEqualTo(1);
+    }
+
+    @DisplayName("좋아요 개수를 1 감소한다.")
+    @Test
+    void decreaseLikeCount() {
+        int originLikeCount = post1.getLikeCount();
+
+        postRepository.increaseLikeCount(post1.getId());
+
+        Post post = postRepository.findById(post1.getId()).orElseThrow();
+        assertThat(post.getLikeCount() - originLikeCount).isEqualTo(1);
+
+    }
 }


### PR DESCRIPTION
### 구현기능
좋아요 개수 조회 반정규화하여 count 쿼리 제거

### 세부 구현기능
native sql을 이용해 update문을 직접 호출하도록 변경했습니다.
