### PR TITLE
refactor: oneToMany에 대해 stream을 돌아 n+1 발생문제 해결

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/Comment.java
@@ -2,7 +2,6 @@ package com.wooteco.sokdak.comment.domain;
 
 import com.wooteco.sokdak.auth.exception.AuthorizationException;
 import com.wooteco.sokdak.like.domain.CommentLike;
-import com.wooteco.sokdak.like.exception.CommentLikeNotFoundException;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.report.domain.CommentReport;
@@ -189,21 +188,13 @@ public class Comment {
         return children.isEmpty();
     }
 
-    public boolean hasLikeOfMember(Long memberId) {
-        return commentLikes.stream()
-                .anyMatch(commentLike -> commentLike.isLikeOf(memberId));
-    }
-
     public void addCommentLike(CommentLike commentLike) {
         commentLikes.add(commentLike);
     }
 
-    public void deleteLikeOfMember(Long memberId) {
-        CommentLike commentLike = commentLikes.stream()
-                .filter(it -> it.isLikeOf(memberId))
-                .findAny()
-                .orElseThrow(CommentLikeNotFoundException::new);
+    public void deleteLike(CommentLike commentLike) {
         commentLikes.remove(commentLike);
+        commentLike.delete();
     }
 
     public Long getBoardId() {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/service/CommentService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/service/CommentService.java
@@ -151,7 +151,7 @@ public class CommentService {
         if (comment.isSoftRemoved()) {
             return CommentResponse.softRemovedOf(comment, convertToReplyResponses(comment, id));
         }
-        boolean liked = commentLikeRepository.existsByMemberIdAndCommentId(id, comment.getId());
+        boolean liked = commentLikeRepository.existsByMemberIdAndComment(id, comment);
         return CommentResponse.of(comment, id, convertToReplyResponses(comment, id), liked);
     }
 
@@ -159,7 +159,7 @@ public class CommentService {
         final List<Comment> replies = commentRepository.findRepliesByParent(parent);
         List<ReplyResponse> replyResponses = new ArrayList<>();
         for (Comment reply : replies) {
-            boolean liked = commentLikeRepository.existsByMemberIdAndCommentId(accessMemberId, reply.getId());
+            boolean liked = commentLikeRepository.existsByMemberIdAndComment(accessMemberId, reply);
             replyResponses.add(ReplyResponse.of(reply, accessMemberId, liked));
         }
         return replyResponses;

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/domain/CommentLike.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/domain/CommentLike.java
@@ -42,4 +42,8 @@ public class CommentLike {
     public boolean isLikeOf(Long memberId) {
         return member.hasId(memberId);
     }
+
+    public void delete() {
+        this.comment = null;
+    }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/domain/PostLike.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/domain/PostLike.java
@@ -42,4 +42,8 @@ public class PostLike {
     public boolean isLikeOf(Long memberId) {
         return member.hasId(memberId);
     }
+
+    public void delete() {
+        this.post = null;
+    }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/repository/CommentLikeRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/repository/CommentLikeRepository.java
@@ -1,16 +1,15 @@
 package com.wooteco.sokdak.like.repository;
 
+import com.wooteco.sokdak.comment.domain.Comment;
 import com.wooteco.sokdak.like.domain.CommentLike;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
 
-    Optional<CommentLike> findByMemberIdAndCommentId(Long memberId, Long commentId);
-
-    int countByCommentId(Long commentId);
-
-    boolean existsByMemberIdAndCommentId(Long memberId, Long commentId);
-
     void deleteAllByCommentId(Long id);
+
+    boolean existsByMemberIdAndComment(Long memberId, Comment comment);
+
+    Optional<CommentLike> findByMemberIdAndComment(Long memberId, Comment comment);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/like/repository/PostLikeRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/like/repository/PostLikeRepository.java
@@ -1,10 +1,18 @@
 package com.wooteco.sokdak.like.repository;
 
 import com.wooteco.sokdak.like.domain.PostLike;
+import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.post.domain.Post;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     void deleteAllByPost(Post post);
+
+    boolean existsByPostAndMemberId(Post post, Long memberId);
+
+    Optional<PostLike> findByPostAndMemberId(Post post, Long memberId);
+
+    Optional<PostLike> findByPostAndMember(Post post, Member member);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -5,7 +5,6 @@ import com.wooteco.sokdak.board.domain.PostBoard;
 import com.wooteco.sokdak.comment.domain.Comment;
 import com.wooteco.sokdak.hashtag.domain.PostHashtag;
 import com.wooteco.sokdak.like.domain.PostLike;
-import com.wooteco.sokdak.like.exception.PostLikeNotFoundException;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.report.domain.PostReport;
 import java.time.LocalDateTime;
@@ -154,11 +153,6 @@ public class Post {
         return content.getValue();
     }
 
-    public boolean hasLikeOfMember(Long memberId) {
-        return postLikes.stream()
-                .anyMatch(postLike -> postLike.isLikeOf(memberId));
-    }
-
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }
@@ -217,12 +211,9 @@ public class Post {
         postLikes.add(postLike);
     }
 
-    public void deleteLikeOfMember(Long memberId) {
-        PostLike postLike = postLikes.stream()
-                .filter(it -> it.isLikeOf(memberId))
-                .findAny()
-                .orElseThrow(PostLikeNotFoundException::new);
+    public void deleteLike(PostLike postLike) {
         postLikes.remove(postLike);
+        postLike.delete();
     }
 
     public Long getBoardId() {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -101,7 +101,7 @@ public class PostService {
     public PostDetailResponse findPost(Long postId, AuthInfo authInfo) {
         Post foundPost = findPostObject(postId);
         Board writableBoard = foundPost.getWritableBoard();
-        boolean liked = foundPost.hasLikeOfMember(authInfo.getId());
+        boolean liked = postLikeRepository.existsByPostAndMemberId(foundPost, authInfo.getId());
         Hashtags hashtags = hashtagService.findHashtagsByPost(foundPost);
 
         return PostDetailResponse.of(foundPost, writableBoard, liked,

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/domain/CommentTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/domain/CommentTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.wooteco.sokdak.auth.exception.AuthorizationException;
-import com.wooteco.sokdak.like.domain.CommentLike;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.domain.Nickname;
 import com.wooteco.sokdak.member.domain.Username;
@@ -172,19 +171,5 @@ class CommentTest {
                 Arguments.of(reporter, reporter, true),
                 Arguments.of(reporter, member, false)
         );
-    }
-
-    @DisplayName("특정 멤버가 누른 좋아요가 있는지 반환한다.")
-    @ParameterizedTest
-    @CsvSource({"1, true", "2, false"})
-    void hasLikeOfMember(Long memberId, boolean expected) {
-        CommentLike.builder()
-                .member(member)
-                .comment(comment)
-                .build();
-
-        boolean actual = comment.hasLikeOfMember(memberId);
-
-        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/like/service/LikeServiceTest.java
@@ -20,6 +20,8 @@ import com.wooteco.sokdak.comment.exception.CommentNotFoundException;
 import com.wooteco.sokdak.comment.repository.CommentRepository;
 import com.wooteco.sokdak.comment.service.CommentService;
 import com.wooteco.sokdak.like.dto.LikeFlipResponse;
+import com.wooteco.sokdak.like.repository.CommentLikeRepository;
+import com.wooteco.sokdak.like.repository.PostLikeRepository;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.post.exception.PostNotFoundException;
 import com.wooteco.sokdak.post.repository.PostRepository;
@@ -56,6 +58,12 @@ class LikeServiceTest extends ServiceTest {
 
     @Autowired
     private PostBoardRepository postBoardRepository;
+
+    @Autowired
+    private PostLikeRepository postLikeRepository;
+
+    @Autowired
+    private CommentLikeRepository commentLikeRepository;
 
     private Post post;
     private Post applicantPost;
@@ -108,10 +116,11 @@ class LikeServiceTest extends ServiceTest {
 
         Post foundPost = postRepository.findById(post.getId())
                 .orElseThrow(PostNotFoundException::new);
+        boolean liked = postLikeRepository.existsByPostAndMemberId(foundPost, AUTH_INFO.getId());
         assertAll(
                 () -> assertThat(putLikeResponse.isLike()).isTrue(),
                 () -> assertThat(putLikeResponse.getLikeCount()).isEqualTo(1),
-                () -> assertThat(foundPost.hasLikeOfMember(member.getId())).isTrue()
+                () -> assertThat(liked).isTrue()
         );
     }
 
@@ -124,10 +133,11 @@ class LikeServiceTest extends ServiceTest {
 
         Post foundPost = postRepository.findById(post.getId())
                 .orElseThrow(PostNotFoundException::new);
+        boolean liked = postLikeRepository.existsByPostAndMemberId(foundPost, AUTH_INFO.getId());
         assertAll(
                 () -> assertThat(putLikeResponse.isLike()).isFalse(),
                 () -> assertThat(putLikeResponse.getLikeCount()).isZero(),
-                () -> assertThat(foundPost.hasLikeOfMember(member.getId())).isFalse()
+                () -> assertThat(liked).isFalse()
         );
     }
 
@@ -136,14 +146,13 @@ class LikeServiceTest extends ServiceTest {
     void flipCommentLike_create() {
         LikeFlipResponse likeFlipResponse = likeService.flipCommentLike(comment.getId(), AUTH_INFO);
 
-        entityManager.flush();
-        entityManager.clear();
         Comment foundComment = commentRepository.findById(comment.getId())
                 .orElseThrow(CommentNotFoundException::new);
+        boolean liked = commentLikeRepository.existsByMemberIdAndComment(AUTH_INFO.getId(), foundComment);
         assertAll(
                 () -> assertThat(likeFlipResponse.isLike()).isTrue(),
                 () -> assertThat(likeFlipResponse.getLikeCount()).isEqualTo(1),
-                () -> assertThat(foundComment.hasLikeOfMember(member.getId())).isTrue()
+                () -> assertThat(liked).isTrue()
         );
     }
 
@@ -151,19 +160,16 @@ class LikeServiceTest extends ServiceTest {
     @Test
     void flipCommentLike_delete() {
         likeService.flipCommentLike(comment.getId(), AUTH_INFO);
-        entityManager.flush();
-        entityManager.clear();
 
         LikeFlipResponse likeFlipResponse = likeService.flipCommentLike(comment.getId(), AUTH_INFO);
 
-        entityManager.flush();
-        entityManager.clear();
         Comment foundComment = commentRepository.findById(comment.getId())
                 .orElseThrow(CommentNotFoundException::new);
+        boolean liked = commentLikeRepository.existsByMemberIdAndComment(AUTH_INFO.getId(), foundComment);
         assertAll(
                 () -> assertThat(likeFlipResponse.isLike()).isFalse(),
                 () -> assertThat(likeFlipResponse.getLikeCount()).isZero(),
-                () -> assertThat(foundComment.hasLikeOfMember(member.getId())).isFalse()
+                () -> assertThat(liked).isFalse()
         );
     }
 
@@ -204,14 +210,13 @@ class LikeServiceTest extends ServiceTest {
     void flipCommentLike_ReplyCreate() {
         LikeFlipResponse likeFlipResponse = likeService.flipCommentLike(reply.getId(), AUTH_INFO);
 
-        entityManager.flush();
-        entityManager.clear();
         Comment foundReply = commentRepository.findById(reply.getId())
                 .orElseThrow(CommentNotFoundException::new);
+        boolean liked = commentLikeRepository.existsByMemberIdAndComment(AUTH_INFO.getId(), foundReply);
         assertAll(
                 () -> assertThat(likeFlipResponse.isLike()).isTrue(),
                 () -> assertThat(likeFlipResponse.getLikeCount()).isEqualTo(1),
-                () -> assertThat(foundReply.hasLikeOfMember(member.getId())).isTrue()
+                () -> assertThat(liked).isTrue()
         );
     }
 
@@ -222,12 +227,11 @@ class LikeServiceTest extends ServiceTest {
 
         LikeFlipResponse likeFlipResponse = likeService.flipCommentLike(reply.getId(), AUTH_INFO);
 
-        entityManager.flush();
-        entityManager.clear();
+        boolean liked = commentLikeRepository.existsByMemberIdAndComment(member.getId(), reply);
         assertAll(
                 () -> assertThat(likeFlipResponse.isLike()).isFalse(),
                 () -> assertThat(likeFlipResponse.getLikeCount()).isZero(),
-                () -> assertThat(reply.hasLikeOfMember(member.getId())).isFalse()
+                () -> assertThat(liked).isFalse()
         );
     }
 

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.when;
 import com.wooteco.sokdak.auth.domain.encryptor.EncryptorI;
 import com.wooteco.sokdak.board.domain.Board;
 import com.wooteco.sokdak.board.domain.PostBoard;
-import com.wooteco.sokdak.like.domain.PostLike;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.domain.Nickname;
 import com.wooteco.sokdak.member.domain.Password;
@@ -212,32 +211,6 @@ class PostTest {
         post.addReport(postReport);
 
         assertThat(post.hasReportByMember(member)).isEqualTo(expected);
-    }
-
-    @DisplayName("게시글에 특정 멤버가 좋아요를 눌렀는지 반환한다.")
-    @ParameterizedTest
-    @CsvSource({"1, true", "2, false"})
-    void hasLikeOfMember(Long memberId, boolean expected) {
-        PostLike.builder()
-                .post(post)
-                .member(member)
-                .build();
-        boolean actual = post.hasLikeOfMember(memberId);
-
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    @DisplayName("게시글에 특정 멤버의 좋아요를 삭제한다.")
-    @Test
-    void deleteLikeOfMember() {
-        PostLike.builder()
-                .post(post)
-                .member(member)
-                .build();
-
-        post.deleteLikeOfMember(member.getId());
-
-        assertThat(post.hasLikeOfMember(member.getId())).isFalse();
     }
 
     @DisplayName("핫게시판을 제외한 게시글이 속한 boardId를 가져온다.")


### PR DESCRIPTION
### 구현기능
oneToMany에 대해 stream을 돌아 n+1 발생문제 해결

### 세부 구현기능
해당 멤버가 좋아요를 눌렀는지 확인하는 과정에서 stream을 돌아 n+1문제 발생하는 부분을 해결했습니다.
