### PR TITLE
refactor: post와 postReport를 일대다 단방향 관계로 리팩터링

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/PostReportElement.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/dto/PostReportElement.java
@@ -29,7 +29,7 @@ public class PostReportElement {
     public static PostReportElement of(PostReport postReport) {
         return PostReportElement.builder()
                 .id(postReport.getId())
-                .postId(postReport.getPost().getId())
+                .postId(postReport.getPostId())
                 .reporterId(postReport.getReporter().getId())
                 .reportMessage(postReport.getReportMessage())
                 .createdAt(postReport.getCreatedAt())

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
@@ -99,8 +99,8 @@ public class AdminService {
 
         Post post = postRepository.findById(id)
                 .orElseThrow(PostNotFoundException::new);
+        postReportRepository.deleteAllByPostId(post.getId());
         post.deleteAllReports();
-        postReportRepository.deleteAllPostReportByPost(post);
     }
 
     public PostReportsResponse findAllPostReports(AuthInfo authInfo) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/admin/service/AdminService.java
@@ -99,8 +99,7 @@ public class AdminService {
 
         Post post = postRepository.findById(id)
                 .orElseThrow(PostNotFoundException::new);
-        postReportRepository.deleteAllByPostId(post.getId());
-        post.deleteAllReports();
+        postReportService.deleteAllPostReport(post);
     }
 
     public PostReportsResponse findAllPostReports(AuthInfo authInfo) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/Post.java
@@ -70,7 +70,8 @@ public class Post {
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private List<PostBoard> postBoards = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany
+    @JoinColumn(name = "postId")
     private List<PostReport> postReports = new ArrayList<>();
 
     @CreatedDate

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/report/domain/PostReport.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/report/domain/PostReport.java
@@ -26,9 +26,7 @@ public class PostReport {
     @Column(name = "post_report_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
-    private Post post;
+    private Long postId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -44,19 +42,18 @@ public class PostReport {
     }
 
     @Builder
-    private PostReport(Post post, Member reporter, String reportMessage) {
-        this.post = post;
+    private PostReport(Long postId, Member reporter, String reportMessage) {
+        this.postId = postId;
         this.reporter = reporter;
         this.reportMessage = new ReportMessage(reportMessage);
-        this.post.addReport(this);
     }
 
     public Long getId() {
         return id;
     }
 
-    public Post getPost() {
-        return post;
+    public Long getPostId() {
+        return postId;
     }
 
     public Member getReporter() {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/report/repository/PostReportRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/report/repository/PostReportRepository.java
@@ -3,11 +3,21 @@ package com.wooteco.sokdak.report.repository;
 import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.post.domain.Post;
 import com.wooteco.sokdak.report.domain.PostReport;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface PostReportRepository extends JpaRepository<PostReport, Long> {
 
-    void deleteAllPostReportByPost(Post post);
+    void deleteAllPostReportByPostId(Long postId);
 
-    boolean existsPostReportByPostAndReporter(Post post, Member member);
+    @Query(value = "DELETE FROM PostReport pr WHERE pr.postId = :postId")
+    @Modifying
+    void deleteAllByPostId(Long postId);
+
+    boolean existsPostReportByPostIdAndReporter(Long postId, Member member);
+
+    List<PostReport> findByPostId(Long postId);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/report/service/PostReportService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/report/service/PostReportService.java
@@ -50,11 +50,13 @@ public class PostReportService {
     }
 
     private PostReport createPostReport(Post post, Member member, String message) {
-        return PostReport.builder()
-                .post(post)
+        PostReport postReport = PostReport.builder()
+                .postId(post.getId())
                 .reporter(member)
                 .reportMessage(message)
                 .build();
+        post.addReport(postReport);
+        return postReport;
     }
 
     private void checkMemberAlreadyReport(Post post, Member member) {

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/report/service/PostReportService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/report/service/PostReportService.java
@@ -70,4 +70,10 @@ public class PostReportService {
             notificationService.notifyPostReport(post);
         }
     }
+
+    @Transactional
+    public void deleteAllPostReport(Post post) {
+        postReportRepository.deleteAllByPostId(post.getId());
+        post.deleteAllReports();
+    }
 }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/domain/PostTest.java
@@ -134,11 +134,12 @@ class PostTest {
         List<Member> members = getMembersForReport();
         int blockCondition = 5;
         for (int i = 0; i < blockCondition; ++i) {
-            PostReport.builder()
-                    .post(post)
+            PostReport postReport = PostReport.builder()
+                    .postId(post.getId())
                     .reporter(members.get(i))
                     .reportMessage("신고")
                     .build();
+            post.addReport(postReport);
         }
 
         assertAll(
@@ -176,7 +177,7 @@ class PostTest {
         int unblockCondition = 4;
         for (int i = 0; i < unblockCondition; ++i) {
             PostReport.builder()
-                    .post(post)
+                    .postId(post.getId())
                     .reporter(members.get(i))
                     .reportMessage("신고")
                     .build();
@@ -204,7 +205,7 @@ class PostTest {
     @MethodSource("hasReportByMemberArguments")
     void hasReportByMember(Member reporter, Member member, boolean expected) {
         PostReport postReport = PostReport.builder()
-                .post(post)
+                .postId(post.getId())
                 .reporter(reporter)
                 .reportMessage("report")
                 .build();

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/report/domain/PostReportTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/report/domain/PostReportTest.java
@@ -46,10 +46,11 @@ class PostReportTest {
     @Test
     void constructor() {
         PostReport postReport = PostReport.builder()
-                .post(post)
+                .postId(post.getId())
                 .reporter(member)
                 .reportMessage("신고")
                 .build();
+        post.addReport(postReport);
 
         assertThat(post.getPostReports()).contains(postReport);
     }
@@ -59,7 +60,7 @@ class PostReportTest {
     @MethodSource("isOwnerArguments")
     void isOwner(Member reporter, Member member, boolean expected) {
         PostReport postReport = PostReport.builder()
-                .post(post)
+                .postId(post.getId())
                 .reporter(reporter)
                 .reportMessage("message")
                 .build();

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/report/repository/PostReportRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/report/repository/PostReportRepositoryTest.java
@@ -45,19 +45,19 @@ class PostReportRepositoryTest extends RepositoryTest {
     void existsPostReportByPostIdAndMemberId_True() {
         PostReport postReport = PostReport.builder()
                 .reporter(member1)
-                .post(post)
+                .postId(post.getId())
                 .reportMessage("report")
                 .build();
         postReportRepository.save(postReport);
 
-        assertThat(postReportRepository.existsPostReportByPostAndReporter(post, member1))
+        assertThat(postReportRepository.existsPostReportByPostIdAndReporter(post.getId(), member1))
                 .isTrue();
     }
 
     @Test
     @DisplayName("특정 postId와 memberId를 가지는 데이터가 없으면 false를 반환한다.")
     void existsPostReportByPostIdAndMemberId_False() {
-        assertThat(postReportRepository.existsPostReportByPostAndReporter(post, member1))
+        assertThat(postReportRepository.existsPostReportByPostIdAndReporter(post.getId(), member1))
                 .isFalse();
     }
 
@@ -73,10 +73,11 @@ class PostReportRepositoryTest extends RepositoryTest {
                     .build();
             memberRepository.save(member);
             PostReport postReport = PostReport.builder()
-                    .post(post)
+                    .postId(post.getId())
                     .reporter(member)
                     .reportMessage("report")
                     .build();
+            post.addReport(postReport);
             postReportRepository.save(postReport);
         }
 


### PR DESCRIPTION
### 구현기능
postReport에서 post 다대일 연관관계 간접참조로 리팩터링
post와 postReport를 일대다 단방향으로 변경
도메인 로직 상 생명주기가 달라 post가 먼저 생성되고 postReport가 추가되어 일대다 단방향의 단점인 update쿼리 문제가 발생하지 않음

### 관련 이슈
postReportService의 deleteAllPostReport 메서느 내부 구현 순서를 바꾸면 안됨. post가 연관관계의 주인이라 postReport 컬렉션이 변경되면 변경감지가 일어나 postReportRepository.deleteAllByPostId가 의도대로 동작하지 않음
