### PR TITLE
refactor: request-uri prefix /api로 지정

### DIFF
--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/admin/acceptance/AdminAcceptanceTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 @DisplayName("관리자 인수테스트")
-public class AdminAcceptanceTest extends AcceptanceTest {
+class AdminAcceptanceTest extends AcceptanceTest {
 
     private static final int reportCount = 5;
     private static final String SERIAL_NUMBER = "test1@gmail.com";
@@ -34,9 +34,9 @@ public class AdminAcceptanceTest extends AcceptanceTest {
         String adminToken = getAdminToken();
         addNewPost();
 
-        httpDeleteWithAuthorization("admin/posts/1", adminToken);
+        httpDeleteWithAuthorization("/admin/posts/1", adminToken);
 
-        ExtractableResponse<Response> actual = httpGetWithAuthorization("posts/1", adminToken);
+        ExtractableResponse<Response> actual = httpGetWithAuthorization("/posts/1", adminToken);
         assertAll(
                 () -> assertThat(actual.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value()),
                 () -> assertThat(actual.body().asString()).contains("게시물을 찾을 수 없습니다.")
@@ -49,10 +49,10 @@ public class AdminAcceptanceTest extends AcceptanceTest {
         String adminToken = getAdminToken();
         addNewPost();
 
-        httpPostWithAuthorization("", "admin/posts/1/postreports/" + reportCount, adminToken);
-        ExtractableResponse<Response> response = httpGetWithAuthorization("admin/postreports", adminToken);
-        httpDeleteWithAuthorization("admin/posts/1/postreports", adminToken);
-        ExtractableResponse<Response> response2 = httpGetWithAuthorization("admin/postreports", adminToken);
+        httpPostWithAuthorization("", "/admin/posts/1/postreports/" + reportCount, adminToken);
+        ExtractableResponse<Response> response = httpGetWithAuthorization("/admin/postreports", adminToken);
+        httpDeleteWithAuthorization("/admin/posts/1/postreports", adminToken);
+        ExtractableResponse<Response> response2 = httpGetWithAuthorization("/admin/postreports", adminToken);
 
         assertAll(
                 () -> assertThat(getPostReports(response)).hasSize(reportCount),
@@ -74,11 +74,11 @@ public class AdminAcceptanceTest extends AcceptanceTest {
                 .build();
         int lastTicketIndex = 7;
 
-        httpPostWithAuthorization(initTicketRequest, "admin/tickets", adminToken);
-        TicketElement initTicketElement = getTicketElements(httpGetWithAuthorization("admin/tickets", adminToken))
+        httpPostWithAuthorization(initTicketRequest, "/admin/tickets", adminToken);
+        TicketElement initTicketElement = getTicketElements(httpGetWithAuthorization("/admin/tickets", adminToken))
                 .get(lastTicketIndex);
-        httpPatchWithAuthorization(usedTicketRequest, "admin/tickets", adminToken);
-        TicketElement usedTicketElement = getTicketElements(httpGetWithAuthorization("admin/tickets", adminToken))
+        httpPatchWithAuthorization(usedTicketRequest, "/admin/tickets", adminToken);
+        TicketElement usedTicketElement = getTicketElements(httpGetWithAuthorization("/admin/tickets", adminToken))
                 .get(lastTicketIndex);
 
         assertAll(

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/acceptance/AuthAcceptanceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/auth/acceptance/AuthAcceptanceTest.java
@@ -63,7 +63,7 @@ class AuthAcceptanceTest extends AcceptanceTest {
         authCodeRepository.save(authCode);
 
         ExtractableResponse<Response> response =
-                httpPost(new VerificationRequest(email, code), "members/signup/email/verification");
+                httpPost(new VerificationRequest(email, code), "/members/signup/email/verification");
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
@@ -80,7 +80,7 @@ class AuthAcceptanceTest extends AcceptanceTest {
         authCodeRepository.save(authCode);
 
         ExtractableResponse<Response> response =
-                httpPost(new VerificationRequest(email, "NONONO"), "members/signup/email/verification");
+                httpPost(new VerificationRequest(email, "NONONO"), "/members/signup/email/verification");
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
@@ -97,7 +97,7 @@ class AuthAcceptanceTest extends AcceptanceTest {
         authCodeRepository.save(authCode);
 
         ExtractableResponse<Response> response = httpPost(
-                new VerificationRequest("wrong@gmail.com", code), "members/signup/email/verification");
+                new VerificationRequest("wrong@gmail.com", code), "/members/signup/email/verification");
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
@@ -118,7 +118,7 @@ class AuthAcceptanceTest extends AcceptanceTest {
                 .instant();
 
         ExtractableResponse<Response> response =
-                httpPost(new VerificationRequest(email, code), "members/signup/email/verification");
+                httpPost(new VerificationRequest(email, code), "/members/signup/email/verification");
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/HttpMethodFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/util/fixture/HttpMethodFixture.java
@@ -10,10 +10,12 @@ import org.springframework.http.MediaType;
 
 public class HttpMethodFixture {
 
+    private static final String REQUEST_URI_PREFIX = "/api";
+
     public static ExtractableResponse<Response> httpGet(String path) {
         return RestAssured
                 .given().log().all()
-                .when().get(path)
+                .when().get(REQUEST_URI_PREFIX + path)
                 .then().log().all()
                 .extract();
     }
@@ -22,7 +24,7 @@ public class HttpMethodFixture {
         return RestAssured
                 .given().log().all()
                 .header(HttpHeaders.COOKIE, cookieValue)
-                .when().get(path)
+                .when().get(REQUEST_URI_PREFIX + path)
                 .then().log().all()
                 .extract();
     }
@@ -32,7 +34,7 @@ public class HttpMethodFixture {
                 .given().log().all()
                 .body(postRequest)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post(path)
+                .when().post(REQUEST_URI_PREFIX + path)
                 .then().log().all()
                 .extract();
     }
@@ -41,7 +43,7 @@ public class HttpMethodFixture {
         return RestAssured
                 .given().log().all()
                 .header(AUTHORIZATION, token)
-                .when().get(path)
+                .when().get(REQUEST_URI_PREFIX + path)
                 .then().log().all()
                 .extract();
     }
@@ -53,7 +55,7 @@ public class HttpMethodFixture {
                 .header(AUTHORIZATION, token)
                 .body(requestBody)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post(path)
+                .when().post(REQUEST_URI_PREFIX + path)
                 .then().log().all()
                 .extract();
     }
@@ -65,7 +67,7 @@ public class HttpMethodFixture {
                 .header(AUTHORIZATION, token)
                 .body(requestBody)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().put(path)
+                .when().put(REQUEST_URI_PREFIX + path)
                 .then().log().all()
                 .extract();
     }
@@ -74,7 +76,7 @@ public class HttpMethodFixture {
         return RestAssured
                 .given().log().all()
                 .header(AUTHORIZATION, token)
-                .when().put(path)
+                .when().put(REQUEST_URI_PREFIX + path)
                 .then().log().all()
                 .extract();
     }
@@ -86,7 +88,7 @@ public class HttpMethodFixture {
                 .header(AUTHORIZATION, token)
                 .body(requestBody)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().patch(path)
+                .when().patch(REQUEST_URI_PREFIX + path)
                 .then().log().all()
                 .extract();
     }
@@ -95,7 +97,7 @@ public class HttpMethodFixture {
         return RestAssured
                 .given().log().all()
                 .header(AUTHORIZATION, token)
-                .when().delete(path)
+                .when().delete(REQUEST_URI_PREFIX + path)
                 .then().log().all()
                 .extract();
     }

--- a/backend/sokdak/src/test/resources/application.yml
+++ b/backend/sokdak/src/test/resources/application.yml
@@ -47,6 +47,7 @@ server:
     session:
       cookie:
         http-only: false
+    context-path: /api
 
 jasypt:
   encryptor:


### PR DESCRIPTION
### 구현기능
Nginx에서 프론트에 대한 요청과 백엔드에 대한 요청을 분기하기 위해
request-uri prefix /api로 지정
