### PR TITLE
refactor: notification 테스트코드 리팩토링

### DIFF
--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/fixture/NotificationFixture.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/fixture/NotificationFixture.java
@@ -1,0 +1,11 @@
+package com.wooteco.sokdak.notification.fixture;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public class NotificationFixture {
+
+    public static final Pageable ZERO_PAGE_TWO_SIZE_CREATE_AT_DESCENDING_PAGEABLE =
+            PageRequest.of(0, 2, Sort.by("createdAt").descending());
+}

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/repository/NotificationRepositoryTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/repository/NotificationRepositoryTest.java
@@ -2,6 +2,7 @@ package com.wooteco.sokdak.notification.repository;
 
 import static com.wooteco.sokdak.notification.domain.NotificationType.NEW_COMMENT;
 import static com.wooteco.sokdak.notification.domain.NotificationType.POST_REPORT;
+import static com.wooteco.sokdak.notification.fixture.NotificationFixture.ZERO_PAGE_TWO_SIZE_CREATE_AT_DESCENDING_PAGEABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -13,10 +14,7 @@ import javax.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
 
 class NotificationRepositoryTest extends RepositoryTest {
 
@@ -41,7 +39,7 @@ class NotificationRepositoryTest extends RepositoryTest {
         notificationRepository.inquireNotificationByIds(List.of(notification.getId(), notification2.getId()));
 
         List<Notification> notifications = notificationRepository
-                .findNotificationsByMemberId(MEMBER_ID, Pageable.ofSize(3))
+                .findNotificationsByMemberId(MEMBER_ID, ZERO_PAGE_TWO_SIZE_CREATE_AT_DESCENDING_PAGEABLE)
                 .getContent();
         boolean actual = notifications.stream()
                 .allMatch(Notification::isInquired);
@@ -63,19 +61,16 @@ class NotificationRepositoryTest extends RepositoryTest {
     @Test
     void findNotificationsByMemberId() {
         Long anotherPostId = 2L;
-        Notification notification = new Notification(NEW_COMMENT, MEMBER_ID, POST_ID, NULL_COMMENT_ID);
-        notificationRepository.save(notification);
         Notification notification2 = new Notification(NEW_COMMENT, MEMBER_ID, POST_ID, NULL_COMMENT_ID);
         notificationRepository.save(notification2);
         Notification notification3 = new Notification(POST_REPORT, MEMBER_ID, anotherPostId, NULL_COMMENT_ID);
         notificationRepository.save(notification3);
-        PageRequest pageRequest = PageRequest.of(0, 2, Sort.by("createdAt").descending());
 
         Slice<Notification> notifications = notificationRepository
-                .findNotificationsByMemberId(MEMBER_ID, pageRequest);
+                .findNotificationsByMemberId(MEMBER_ID, ZERO_PAGE_TWO_SIZE_CREATE_AT_DESCENDING_PAGEABLE);
 
         assertAll(
-                () -> assertThat(notifications.isLast()).isFalse(),
+                () -> assertThat(notifications.isLast()).isTrue(),
                 () -> assertThat(notifications.getContent().get(0).getNotificationType()).isEqualTo(POST_REPORT),
                 () -> assertThat(notifications.getContent().get(0).getPostId()).isEqualTo(anotherPostId),
                 () -> assertThat(notifications.getContent().get(1).getNotificationType()).isEqualTo(NEW_COMMENT),

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
@@ -4,6 +4,7 @@ import static com.wooteco.sokdak.notification.domain.NotificationType.COMMENT_RE
 import static com.wooteco.sokdak.notification.domain.NotificationType.HOT_BOARD;
 import static com.wooteco.sokdak.notification.domain.NotificationType.NEW_COMMENT;
 import static com.wooteco.sokdak.notification.domain.NotificationType.POST_REPORT;
+import static com.wooteco.sokdak.notification.fixture.NotificationFixture.ZERO_PAGE_TWO_SIZE_CREATE_AT_DESCENDING_PAGEABLE;
 import static com.wooteco.sokdak.util.fixture.MemberFixture.VALID_NICKNAME_TEXT;
 import static com.wooteco.sokdak.util.fixture.PostFixture.VALID_POST_CONTENT;
 import static com.wooteco.sokdak.util.fixture.PostFixture.VALID_POST_TITLE;
@@ -33,13 +34,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 
 class NotificationServiceTest extends ServiceTest {
-
-    private static final Pageable PAGEABLE = PageRequest.of(0, 100);
 
     @PersistenceContext
     private EntityManager em;
@@ -108,11 +104,12 @@ class NotificationServiceTest extends ServiceTest {
     @Test
     void findNotifications() {
         Notification notification2 = new Notification(POST_REPORT, member.getId(), post.getId(), null);
+        notificationRepository.save(notification2);
         Notification notification3 = new Notification(NEW_COMMENT, member.getId(), post.getId(), null);
-        notificationRepository.saveAll(List.of(notification2, notification3));
+        notificationRepository.save(notification3);
 
-        NotificationsResponse notificationsResponse = notificationService
-                .findNotifications(AUTH_INFO, PageRequest.of(0, 2, Sort.by("createdAt").descending()));
+        NotificationsResponse notificationsResponse =
+                notificationService.findNotifications(AUTH_INFO, ZERO_PAGE_TWO_SIZE_CREATE_AT_DESCENDING_PAGEABLE);
         List<NotificationResponse> notificationResponses = notificationsResponse.getNotifications();
         NewNotificationCheckResponse newNotificationCheckResponse = notificationService.checkNewNotification(AUTH_INFO);
 
@@ -141,7 +138,8 @@ class NotificationServiceTest extends ServiceTest {
 
         notificationService.deleteCommentNotification(comment.getId());
 
-        NotificationsResponse notifications = notificationService.findNotifications(AUTH_INFO, PAGEABLE);
+        NotificationsResponse notifications =
+                notificationService.findNotifications(AUTH_INFO, ZERO_PAGE_TWO_SIZE_CREATE_AT_DESCENDING_PAGEABLE);
         assertThat(notifications.getNotifications()).isEmpty();
     }
 
@@ -164,7 +162,8 @@ class NotificationServiceTest extends ServiceTest {
 
         notificationService.deletePostNotification(post.getId());
 
-        NotificationsResponse notifications = notificationService.findNotifications(AUTH_INFO, PAGEABLE);
+        NotificationsResponse notifications =
+                notificationService.findNotifications(AUTH_INFO, ZERO_PAGE_TWO_SIZE_CREATE_AT_DESCENDING_PAGEABLE);
         assertThat(notifications.getNotifications()).isEmpty();
     }
 
@@ -177,7 +176,7 @@ class NotificationServiceTest extends ServiceTest {
         notificationService.deleteNotification(AUTH_INFO, notification.getId());
 
         List<Notification> notifications = notificationRepository
-                .findNotificationsByMemberId(member.getId(), PAGEABLE)
+                .findNotificationsByMemberId(member.getId(), ZERO_PAGE_TWO_SIZE_CREATE_AT_DESCENDING_PAGEABLE)
                 .getContent();
         assertThat(notifications).isEmpty();
     }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
@@ -15,6 +15,7 @@ import com.wooteco.sokdak.auth.dto.AuthInfo;
 import com.wooteco.sokdak.comment.domain.Comment;
 import com.wooteco.sokdak.comment.repository.CommentRepository;
 import com.wooteco.sokdak.member.domain.Member;
+import com.wooteco.sokdak.member.domain.RoleType;
 import com.wooteco.sokdak.member.exception.MemberNotFoundException;
 import com.wooteco.sokdak.member.repository.MemberRepository;
 import com.wooteco.sokdak.notification.domain.Notification;
@@ -96,7 +97,7 @@ class NotificationServiceTest extends ServiceTest {
     void existsNewNotification(Long memberId, boolean expected) {
         Notification notification = new Notification(NEW_COMMENT, member.getId(), post.getId(), null);
         notificationRepository.save(notification);
-        AuthInfo authInfo = new AuthInfo(memberId, "USER", VALID_NICKNAME_TEXT);
+        AuthInfo authInfo = new AuthInfo(memberId, RoleType.USER.getName(), VALID_NICKNAME_TEXT);
 
         NewNotificationCheckResponse newNotificationCheckResponse = notificationService.checkNewNotification(authInfo);
 
@@ -120,10 +121,10 @@ class NotificationServiceTest extends ServiceTest {
                 () -> assertThat(notificationsResponse.isLastPage()).isTrue(),
                 () -> assertThat(notificationResponses).hasSize(2),
                 () -> assertThat(notificationResponses.get(0).getPostId()).isEqualTo(post.getId()),
-                () -> assertThat(notificationResponses.get(0).getType()).isEqualTo("NEW_COMMENT"),
+                () -> assertThat(notificationResponses.get(0).getType()).isEqualTo(NEW_COMMENT.name()),
                 () -> assertThat(notificationResponses.get(0).getContent()).isEqualTo(post.getTitle()),
                 () -> assertThat(notificationResponses.get(1).getPostId()).isEqualTo(post.getId()),
-                () -> assertThat(notificationResponses.get(1).getType()).isEqualTo("POST_REPORT"),
+                () -> assertThat(notificationResponses.get(1).getType()).isEqualTo(POST_REPORT.name()),
                 () -> assertThat(notificationResponses.get(1).getContent()).isEqualTo(post.getTitle()),
                 () -> assertThat(newNotificationCheckResponse.isExistence()).isFalse()
         );

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
@@ -37,6 +37,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class NotificationServiceTest extends ServiceTest {
 
+    private static final String NICKNAME = "닉네임";
+    private static final String MESSAGE = "내용";
+
     @PersistenceContext
     private EntityManager em;
 
@@ -74,14 +77,14 @@ class NotificationServiceTest extends ServiceTest {
         comment = Comment.builder()
                 .post(post)
                 .member(member2)
-                .nickname("닉네임")
-                .message("내용")
+                .nickname(NICKNAME)
+                .message(MESSAGE)
                 .build();
         comment2 = Comment.builder()
                 .post(post)
                 .member(member)
-                .nickname("닉네임")
-                .message("내용")
+                .nickname(NICKNAME)
+                .message(MESSAGE)
                 .build();
         commentRepository.save(comment);
         commentRepository.save(comment2);
@@ -149,8 +152,8 @@ class NotificationServiceTest extends ServiceTest {
         Comment comment3 = Comment.builder()
                 .post(post)
                 .member(member2)
-                .nickname("닉네임")
-                .message("내용")
+                .nickname(NICKNAME)
+                .message(MESSAGE)
                 .build();
         commentRepository.save(comment3);
         Notification notification1 = new Notification(NEW_COMMENT, member.getId(), post.getId(), null);


### PR DESCRIPTION
### 구현기능
notification 패키지의 테스트 코드를 리팩토링

### 세부 구현기능
- 픽스쳐 분리
- 하드 코딩된 enum의 name을 enum의 메서드를 사용하도록 변경
- 반복되는 Pagable 객체 상수화

