### PR TITLE
refactor: 게시글, 댓글 삭제에 따른 알림 삭제 방식을 이벤트 방식으로 수정

### DIFF
--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/CommentDeletionEvent.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/comment/domain/CommentDeletionEvent.java
@@ -1,0 +1,15 @@
+package com.wooteco.sokdak.comment.domain;
+
+public class CommentDeletionEvent {
+
+    private final Long commentId;
+
+    public CommentDeletionEvent(Long commentId) {
+        this.commentId = commentId;
+    }
+
+    public Long getCommentId() {
+        return commentId;
+    }
+}
+

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/handler/NotificationDeletionEventHandler.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/handler/NotificationDeletionEventHandler.java
@@ -1,5 +1,6 @@
 package com.wooteco.sokdak.notification.handler;
 
+import com.wooteco.sokdak.comment.domain.CommentDeletionEvent;
 import com.wooteco.sokdak.notification.repository.NotificationRepository;
 import com.wooteco.sokdak.post.domain.PostDeletionEvent;
 import javax.transaction.Transactional;
@@ -19,6 +20,11 @@ public class NotificationDeletionEventHandler {
     @EventListener
     public void handlePostDeletion(PostDeletionEvent postDeletionEvent) {
         notificationRepository.deleteAllByPostId(postDeletionEvent.getPostId());
+    }
+
+    @EventListener
+    public void handleCommentDeletion(CommentDeletionEvent commentDeletionEvent) {
+        notificationRepository.deleteAllByCommentId(commentDeletionEvent.getCommentId());
     }
 }
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/handler/NotificationDeletionEventHandler.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/handler/NotificationDeletionEventHandler.java
@@ -1,0 +1,24 @@
+package com.wooteco.sokdak.notification.handler;
+
+import com.wooteco.sokdak.notification.repository.NotificationRepository;
+import com.wooteco.sokdak.post.domain.PostDeletionEvent;
+import javax.transaction.Transactional;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Transactional
+public class NotificationDeletionEventHandler {
+
+    private final NotificationRepository notificationRepository;
+
+    public NotificationDeletionEventHandler(NotificationRepository notificationRepository) {
+        this.notificationRepository = notificationRepository;
+    }
+
+    @EventListener
+    public void handlePostDeletion(PostDeletionEvent postDeletionEvent) {
+        notificationRepository.deleteAllByPostId(postDeletionEvent.getPostId());
+    }
+}
+

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
@@ -12,16 +12,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     boolean existsByMemberIdAndInquiredIsFalse(Long memberId);
 
-    @Modifying
-    @Query(value = "DELETE FROM Notification n WHERE n.id IN :ids")
-    void deleteAllById(List<Long> ids);
-
-    @Query(value = "SELECT n.id FROM Notification n WHERE n.commentId = :commentId")
-    List<Long> findIdsByCommentId(Long commentId);
-
-    @Query(value = "SELECT n.id FROM Notification n WHERE n.postId = :postId")
-    List<Long> findIdsByPostId(Long postId);
-
     @Query(value = "SELECT n FROM Notification n WHERE n.memberId = :memberId")
     Slice<Notification> findNotificationsByMemberId(Long memberId, Pageable pageable);
 

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
@@ -32,4 +32,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Modifying
     @Query(value = "DELETE FROM Notification n WHERE n.postId = :postId")
     void deleteAllByPostId(Long postId);
+
+    @Modifying
+    @Query(value = "DELETE FROM Notification n WHERE n.commentId = :commentId")
+    void deleteAllByCommentId(Long commentId);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/repository/NotificationRepository.java
@@ -28,4 +28,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Modifying
     @Query(value = "UPDATE Notification n SET n.inquired = true WHERE n.id IN :ids")
     void inquireNotificationByIds(List<Long> ids);
+
+    @Modifying
+    @Query(value = "DELETE FROM Notification n WHERE n.postId = :postId")
+    void deleteAllByPostId(Long postId);
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
@@ -95,12 +95,4 @@ public class NotificationService {
             notificationRepository.deleteAllById(ids);
         }
     }
-
-    @Transactional
-    public void deletePostNotification(Long postId) {
-        List<Long> ids = notificationRepository.findIdsByPostId(postId);
-        if (!ids.isEmpty()) {
-            notificationRepository.deleteAllById(ids);
-        }
-    }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/notification/service/NotificationService.java
@@ -87,12 +87,4 @@ public class NotificationService {
         notification.validateOwner(authInfo.getId());
         notificationRepository.deleteById(notificationId);
     }
-
-    @Transactional
-    public void deleteCommentNotification(Long commentId) {
-        List<Long> ids = notificationRepository.findIdsByCommentId(commentId);
-        if (!ids.isEmpty()) {
-            notificationRepository.deleteAllById(ids);
-        }
-    }
 }

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/PostDeletionEvent.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/domain/PostDeletionEvent.java
@@ -1,0 +1,15 @@
+package com.wooteco.sokdak.post.domain;
+
+public class PostDeletionEvent {
+
+    private final Long postId;
+
+    public PostDeletionEvent(Long postId) {
+        this.postId = postId;
+    }
+
+    public Long getPostId() {
+        return postId;
+    }
+}
+

--- a/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
+++ b/backend/sokdak/src/main/java/com/wooteco/sokdak/post/service/PostService.java
@@ -16,8 +16,8 @@ import com.wooteco.sokdak.member.domain.Member;
 import com.wooteco.sokdak.member.exception.MemberNotFoundException;
 import com.wooteco.sokdak.member.repository.MemberRepository;
 import com.wooteco.sokdak.member.util.RandomNicknameGenerator;
-import com.wooteco.sokdak.notification.service.NotificationService;
 import com.wooteco.sokdak.post.domain.Post;
+import com.wooteco.sokdak.post.domain.PostDeletionEvent;
 import com.wooteco.sokdak.post.domain.SearchQuery;
 import com.wooteco.sokdak.post.domain.ViewCountManager;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
@@ -31,6 +31,7 @@ import com.wooteco.sokdak.post.repository.PostRepository;
 import java.util.Collections;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -50,14 +51,14 @@ public class PostService {
     private final MemberRepository memberRepository;
     private final CommentRepository commentRepository;
     private final PostLikeRepository postLikeRepository;
-    private final NotificationService notificationService;
+    private ApplicationEventPublisher applicationEventPublisher;
     private final AuthService authService;
     private final ViewCountManager viewCountManager;
 
     public PostService(HashtagService hashtagService, BoardService boardService,
                        PostRepository postRepository, PostBoardRepository postBoardRepository,
                        MemberRepository memberRepository, CommentRepository commentRepository,
-                       PostLikeRepository postLikeRepository, NotificationService notificationService,
+                       PostLikeRepository postLikeRepository, ApplicationEventPublisher applicationEventPublisher,
                        AuthService authService, ViewCountManager viewCountManager) {
         this.hashtagService = hashtagService;
         this.boardService = boardService;
@@ -66,7 +67,7 @@ public class PostService {
         this.memberRepository = memberRepository;
         this.commentRepository = commentRepository;
         this.postLikeRepository = postLikeRepository;
-        this.notificationService = notificationService;
+        this.applicationEventPublisher = applicationEventPublisher;
         this.authService = authService;
         this.viewCountManager = viewCountManager;
     }
@@ -181,7 +182,7 @@ public class PostService {
         postLikeRepository.deleteAllByPost(post);
         postLikeRepository.deleteAllByPost(post);
         hashtagService.deleteAllByPost(hashtags, post);
-        notificationService.deletePostNotification(id);
+        applicationEventPublisher.publishEvent(new PostDeletionEvent(post.getId()));
 
         postRepository.delete(post);
     }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/service/CommentServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/comment/service/CommentServiceTest.java
@@ -21,6 +21,7 @@ import com.wooteco.sokdak.board.domain.PostBoard;
 import com.wooteco.sokdak.board.repository.BoardRepository;
 import com.wooteco.sokdak.board.repository.PostBoardRepository;
 import com.wooteco.sokdak.comment.domain.Comment;
+import com.wooteco.sokdak.comment.domain.CommentDeletionEvent;
 import com.wooteco.sokdak.comment.domain.NewCommentEvent;
 import com.wooteco.sokdak.comment.domain.NewReplyEvent;
 import com.wooteco.sokdak.comment.dto.CommentResponse;
@@ -403,7 +404,11 @@ class CommentServiceTest extends ServiceTest {
 
         commentService.deleteComment(commentId, new AuthInfo(member.getId(), USER.getName(), member.getNickname()));
 
-        assertThat(commentRepository.findById(commentId)).isEmpty();
+        long commentDeletionEventCount = applicationEvents.stream(CommentDeletionEvent.class).count();
+        assertAll(
+                () -> assertThat(commentRepository.findById(commentId)).isEmpty(),
+                () -> assertThat(commentDeletionEventCount).isEqualTo(1L)
+        );
     }
 
     @DisplayName("댓글 작성자가 아닌 유저가 댓글을 삭제하면 예외 발생")

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/handler/NotificationDeletionEventHandlerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/handler/NotificationDeletionEventHandlerTest.java
@@ -1,9 +1,12 @@
 package com.wooteco.sokdak.notification.handler;
 
+import static com.wooteco.sokdak.notification.domain.NotificationType.COMMENT_REPORT;
 import static com.wooteco.sokdak.notification.domain.NotificationType.HOT_BOARD;
 import static com.wooteco.sokdak.notification.domain.NotificationType.NEW_COMMENT;
+import static com.wooteco.sokdak.notification.domain.NotificationType.NEW_REPLY;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.wooteco.sokdak.comment.domain.CommentDeletionEvent;
 import com.wooteco.sokdak.notification.domain.Notification;
 import com.wooteco.sokdak.notification.repository.NotificationRepository;
 import com.wooteco.sokdak.post.domain.PostDeletionEvent;
@@ -39,6 +42,19 @@ class NotificationDeletionEventHandlerTest extends ServiceTest {
         PostDeletionEvent postDeletionEvent = new PostDeletionEvent(postId);
 
         notificationDeletionEventHandler.handlePostDeletion(postDeletionEvent);
+
+        assertThat(notificationRepository.findAll()).isEmpty();
+    }
+
+    @DisplayName("댓글에 해당하는 알림을 모두 삭제한다.")
+    @Test
+    void handleCommentDeletion() {
+        Long commentId = 1L;
+        notificationRepository.save(new Notification(COMMENT_REPORT, 1L, 1L, commentId));
+        notificationRepository.save(new Notification(NEW_REPLY, 1L, 1L, commentId));
+        CommentDeletionEvent commentDeletionEvent = new CommentDeletionEvent(commentId);
+
+        notificationDeletionEventHandler.handleCommentDeletion(commentDeletionEvent);
 
         assertThat(notificationRepository.findAll()).isEmpty();
     }

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/handler/NotificationDeletionEventHandlerTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/handler/NotificationDeletionEventHandlerTest.java
@@ -1,0 +1,46 @@
+package com.wooteco.sokdak.notification.handler;
+
+import static com.wooteco.sokdak.notification.domain.NotificationType.HOT_BOARD;
+import static com.wooteco.sokdak.notification.domain.NotificationType.NEW_COMMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wooteco.sokdak.notification.domain.Notification;
+import com.wooteco.sokdak.notification.repository.NotificationRepository;
+import com.wooteco.sokdak.post.domain.PostDeletionEvent;
+import com.wooteco.sokdak.util.DatabaseCleaner;
+import com.wooteco.sokdak.util.ServiceTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class NotificationDeletionEventHandlerTest extends ServiceTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private NotificationDeletionEventHandler notificationDeletionEventHandler;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void cleanUp() {
+        databaseCleaner.clear();
+    }
+
+    @DisplayName("게시글에 해당하는 알림을 모두 삭제한다.")
+    @Test
+    void handlePostDeletion() {
+        Long postId = 1L;
+        notificationRepository.save(new Notification(HOT_BOARD, 1L, postId, null));
+        notificationRepository.save(new Notification(NEW_COMMENT, 1L, postId, null));
+        PostDeletionEvent postDeletionEvent = new PostDeletionEvent(postId);
+
+        notificationDeletionEventHandler.handlePostDeletion(postDeletionEvent);
+
+        assertThat(notificationRepository.findAll()).isEmpty();
+    }
+}
+

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
@@ -147,30 +147,6 @@ class NotificationServiceTest extends ServiceTest {
         assertThat(notifications.getNotifications()).isEmpty();
     }
 
-    @DisplayName("게시글에 해당하는 알림들을 삭제한다.")
-    @Test
-    void deletePostNotification() {
-        Comment comment3 = Comment.builder()
-                .post(post)
-                .member(member2)
-                .nickname(NICKNAME)
-                .message(MESSAGE)
-                .build();
-        commentRepository.save(comment3);
-        Notification notification1 = new Notification(NEW_COMMENT, member.getId(), post.getId(), null);
-        Notification notification2 = new Notification(NEW_COMMENT, member.getId(), post.getId(), null);
-        notificationRepository.save(notification1);
-        notificationRepository.save(notification2);
-
-        em.clear();
-
-        notificationService.deletePostNotification(post.getId());
-
-        NotificationsResponse notifications =
-                notificationService.findNotifications(AUTH_INFO, ZERO_PAGE_TWO_SIZE_CREATE_AT_DESCENDING_PAGEABLE);
-        assertThat(notifications.getNotifications()).isEmpty();
-    }
-
     @DisplayName("알림을 삭제한다.")
     @Test
     void deleteNotification() {

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/notification/service/NotificationServiceTest.java
@@ -1,6 +1,5 @@
 package com.wooteco.sokdak.notification.service;
 
-import static com.wooteco.sokdak.notification.domain.NotificationType.COMMENT_REPORT;
 import static com.wooteco.sokdak.notification.domain.NotificationType.HOT_BOARD;
 import static com.wooteco.sokdak.notification.domain.NotificationType.NEW_COMMENT;
 import static com.wooteco.sokdak.notification.domain.NotificationType.POST_REPORT;
@@ -128,23 +127,6 @@ class NotificationServiceTest extends ServiceTest {
                 () -> assertThat(notificationResponses.get(1).getContent()).isEqualTo(post.getTitle()),
                 () -> assertThat(newNotificationCheckResponse.isExistence()).isFalse()
         );
-    }
-
-    @DisplayName("댓글에 해당하는 알림들을 삭제한다.")
-    @Test
-    void deleteCommentNotification() {
-        Notification notification1 = new Notification(COMMENT_REPORT, member.getId(), post.getId(), comment.getId());
-        Notification notification2 = new Notification(COMMENT_REPORT, member.getId(), post.getId(), comment.getId());
-
-        notificationRepository.saveAll(List.of(notification1, notification2));
-
-        em.clear();
-
-        notificationService.deleteCommentNotification(comment.getId());
-
-        NotificationsResponse notifications =
-                notificationService.findNotifications(AUTH_INFO, ZERO_PAGE_TWO_SIZE_CREATE_AT_DESCENDING_PAGEABLE);
-        assertThat(notifications.getNotifications()).isEmpty();
     }
 
     @DisplayName("알림을 삭제한다.")

--- a/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
+++ b/backend/sokdak/src/test/java/com/wooteco/sokdak/post/service/PostServiceTest.java
@@ -22,6 +22,7 @@ import com.wooteco.sokdak.hashtag.domain.PostHashtag;
 import com.wooteco.sokdak.hashtag.repository.HashtagRepository;
 import com.wooteco.sokdak.hashtag.repository.PostHashtagRepository;
 import com.wooteco.sokdak.post.domain.Post;
+import com.wooteco.sokdak.post.domain.PostDeletionEvent;
 import com.wooteco.sokdak.post.dto.NewPostRequest;
 import com.wooteco.sokdak.post.dto.PagePostsResponse;
 import com.wooteco.sokdak.post.dto.PostDetailResponse;
@@ -170,7 +171,7 @@ class PostServiceTest extends ServiceTest {
         return Stream.of(
                 Arguments.of(EMPTY_COOKIE_VALUE, 1),
                 Arguments.of(today + ":2/3", 1),
-                Arguments.of(today+":1/2/3", 0)
+                Arguments.of(today + ":1/2/3", 0)
         );
     }
 
@@ -251,7 +252,8 @@ class PostServiceTest extends ServiceTest {
         postBoard.addBoard(board);
         postBoardRepository.save(postBoard);
 
-        PostDetailResponse response = postService.findPost(savedPostId, new AuthInfo(2L, USER.getName(), "nickname"), EMPTY_COOKIE_VALUE);
+        PostDetailResponse response = postService.findPost(savedPostId, new AuthInfo(2L, USER.getName(), "nickname"),
+                EMPTY_COOKIE_VALUE);
 
         assertAll(
                 () -> assertThat(response.getTitle()).isEqualTo(post.getTitle()),
@@ -273,7 +275,8 @@ class PostServiceTest extends ServiceTest {
         postBoard.addBoard(board);
         postBoardRepository.save(postBoard);
 
-        PostDetailResponse response = postService.findPost(savedPostId, new AuthInfo(null, USER.getName(), "nickname"), EMPTY_COOKIE_VALUE);
+        PostDetailResponse response = postService.findPost(savedPostId, new AuthInfo(null, USER.getName(), "nickname"),
+                EMPTY_COOKIE_VALUE);
 
         assertAll(
                 () -> assertThat(response.getTitle()).isEqualTo(post.getTitle()),
@@ -300,7 +303,8 @@ class PostServiceTest extends ServiceTest {
         postBoardRepository.save(postBoard);
         postBoardRepository.save(postHotBoard);
 
-        PostDetailResponse response = postService.findPost(savedPostId, new AuthInfo(null, USER.getName(), "nickname"), EMPTY_COOKIE_VALUE);
+        PostDetailResponse response = postService.findPost(savedPostId, new AuthInfo(null, USER.getName(), "nickname"),
+                EMPTY_COOKIE_VALUE);
 
         assertAll(
                 () -> assertThat(response.getTitle()).isEqualTo(post.getTitle()),
@@ -368,7 +372,11 @@ class PostServiceTest extends ServiceTest {
         postService.deletePost(postId, AUTH_INFO);
 
         Optional<Post> foundPost = postRepository.findById(postId);
-        assertThat(foundPost).isEmpty();
+        long postDeletionEventCount = applicationEvents.stream(PostDeletionEvent.class).count();
+        assertAll(
+                () -> assertThat(foundPost).isEmpty(),
+                () -> assertThat(postDeletionEventCount).isEqualTo(1L)
+        );
     }
 
     @DisplayName("댓글이 있는 게시글 삭제")


### PR DESCRIPTION
### 구현기능
게시글, 댓글 삭제에 따른 알림 삭제 방식을 이벤트 방식으로 수정

### 세부 구현기능
비동기 방식이 아닌, 동기 방식으로 이벤트 처리

### 관련 이슈
#758 
https://github.com/woowacourse-teams/2022-sokdak/pull/764 이전 PR 다시 올립니다~!